### PR TITLE
[TY-2191] Update Stack algorithm

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -67,7 +67,7 @@ impl Stack {
         }
     }
 
-    /// Ranks the slice of [`Document`] items and returns a new [`Stack`]
+    /// Ranks the slice of [`Document`] items and returns an updated [`Stack`]
     pub(crate) fn _update<R: Ranker>(
         mut self,
         new_feed_items: &[Document],


### PR DESCRIPTION
[Jira ticket](https://xainag.atlassian.net/browse/TY-2191)

This PR adds a `Reranker` trait that abstracts over the AI and ranks a `Document` slice. It also adds an `update` method to the `Stack` implementation, that uses the `Reranker` to return a new, updated `Stack`.