### PR TITLE
Pass working-dir to rust-cache

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: rustup toolchain install ${{ env.RUST_NIGHTLY }} --component rustfmt
 
       - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383 # v1
+        with:
+          working-directory: ${{ env.RUST_WORKSPACE }}
 
       - name: cargo fmt
         working-directory: ${{ env.RUST_WORKSPACE }}
@@ -46,6 +48,8 @@ jobs:
         run: rustup show
 
       - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383 # v1
+        with:
+          working-directory: ${{ env.RUST_WORKSPACE }}
 
       - name: cargo clippy
         working-directory: ${{ env.RUST_WORKSPACE }}
@@ -62,6 +66,8 @@ jobs:
         run: rustup show
 
       - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383 # v1
+        with:
+          working-directory: ${{ env.RUST_WORKSPACE }}
 
       - name: Run tests
         working-directory: ${{ env.RUST_WORKSPACE }}


### PR DESCRIPTION
Since our rust project is not in the root of the repository we need to pass `working-directory` to `rust-cache`.