### PR TITLE
[TY-2258] Fix tests for Dart 2.15.1

### DIFF
--- a/discovery_engine/test/discovery_engine/init_test.dart
+++ b/discovery_engine/test/discovery_engine/init_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     test('when passing a bad entry point it should throw "EngineInitException"',
-        () async {
+        () {
       void wrongTypeSignature() {}
 
       expect(


### PR DESCRIPTION
[Jira ref](https://xainag.atlassian.net/browse/TY-2258)

For some reason after the Dart 2.15.1 update, the `Isolate.spawn` method accepts also non-static or non-top-level functions as entrypoint, even if the documentation [says otherwise](https://api.dart.dev/stable/2.15.1/dart-isolate/Isolate/spawn.html).