### PR TITLE
DEVOPS-672 Configuring labeler CI for any base

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,6 @@ name: PR Label Assigner
 
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, converted_to_draft, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
Changing the configuration of the labeler CI to label when the base is any branch.