### PR TITLE
DEVOPS-673 Configuring ci_ok for dart and rust ci

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -123,33 +123,7 @@ jobs:
   ci-ok:
     name: ci-ok
     needs:
-      - dart-test
+      - dart-doc
     runs-on: ubuntu-20.04
     steps:
-      - name: Nothing to do
-        run: echo "Helper job nothing to do"
-
-  notify-main-failure:
-    name: notify-main-failure
-    needs: ci-ok
-    # always() allows to run even if ci-ok is not successful
-    # we only want this to run on the main branch
-    if: always() && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Notify failure
-        if: needs.ci-ok.result != 'success'
-        uses: 8398a7/action-slack@b17d9de8e9ed64b041e4fac845d6fdb2be6b9b04 # v3.11.0
-        with:
-          status: custom
-          fields: workflow, repo
-          custom_payload: |
-            {
-              attachments: [{
-                title: 'Main CI failed :warning:',
-                color: 'danger',
-                text: `CI: ${process.env.AS_WORKFLOW}\nRepository: ${process.env.AS_REPO}`,
-              }]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: echo "Helper job"

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -126,4 +126,4 @@ jobs:
       - dart-doc
     runs-on: ubuntu-20.04
     steps:
-        run: echo "Helper job"
+      - run: echo "Helper job"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -101,4 +101,4 @@ jobs:
       - cargo-doc
     runs-on: ubuntu-20.04
     steps:
-        run: echo "Helper job"
+      - run: echo "Helper job"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -91,3 +91,14 @@ jobs:
       - name: cargo doc
         working-directory: ${{ env.RUST_WORKSPACE }}
         run: cargo doc --all-features --no-deps --document-private-items
+
+  ci-ok:
+    name: ci-ok
+    needs:
+      - cargo-format
+      - cargo-clippy
+      - cargo-test
+      - cargo-doc
+    runs-on: ubuntu-20.04
+    steps:
+        run: echo "Helper job"


### PR DESCRIPTION
Configuring the ci-ok job for both of the dart and rust ci. Deleting the notify job, because with bors it is not needed anymore. 