### PR TITLE
TY-2267 feed manager: restore feed

### DIFF
--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
-    show FeedClientEvent;
+    show FeedClientEvent, FeedRequested;
 import 'package:xayn_discovery_engine/src/domain/document_manager.dart'
     show DocumentManager;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
@@ -40,11 +40,14 @@ class FeedManager {
   /// Handle the given feed client event.
   ///
   /// Fails if [event] does not have a handler implemented.
+  /// If [event] is [FeedRequested], returns the feed documents.
+  /// Returns an empty list in all other cases.
   Future<List<Document>> handleFeedClientEvent(FeedClientEvent event) {
     return event.maybeWhen(
       feedRequested: () => restoreFeed(),
       nextFeedBatchRequested: () => nextFeedBatch().then((_) => []),
-      feedDocumentsClosed: (ids) => _docMgr.deactivateDocuments(ids).then((_) => []),
+      feedDocumentsClosed: (ids) =>
+          _docMgr.deactivateDocuments(ids).then((_) => []),
       orElse: throw UnimplementedError('handler not implemented for $event'),
     );
   }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -13,13 +13,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
-    show FeedClientEvent, FeedRequested;
+    show FeedClientEvent;
+import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
+    show EngineEvent;
 import 'package:xayn_discovery_engine/src/domain/document_manager.dart'
     show DocumentManager;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
-import 'package:xayn_discovery_engine/src/domain/models/document.dart'
-    show Document;
 import 'package:xayn_discovery_engine/src/domain/repository/active_document_repo.dart'
     show ActiveDocumentDataRepository;
 import 'package:xayn_discovery_engine/src/domain/repository/document_repo.dart'
@@ -40,34 +40,37 @@ class FeedManager {
   /// Handle the given feed client event.
   ///
   /// Fails if [event] does not have a handler implemented.
-  /// If [event] is [FeedRequested], returns the feed documents.
-  /// Returns an empty list in all other cases.
-  Future<List<Document>> handleFeedClientEvent(FeedClientEvent event) {
-    return event.maybeWhen(
-      feedRequested: () => restoreFeed(),
-      nextFeedBatchRequested: () => nextFeedBatch().then((_) => []),
-      feedDocumentsClosed: (ids) =>
-          _docMgr.deactivateDocuments(ids).then((_) => []),
-      orElse: throw UnimplementedError('handler not implemented for $event'),
-    );
-  }
+  Future<EngineEvent> handleFeedClientEvent(FeedClientEvent event) =>
+      event.maybeWhen(
+        feedRequested: () => restoreFeed(),
+        nextFeedBatchRequested: () => nextFeedBatch(),
+        feedDocumentsClosed: (ids) => _docMgr
+            .deactivateDocuments(ids)
+            .then((_) => const EngineEvent.clientEventSucceeded()),
+        orElse: throw UnimplementedError('handler not implemented for $event'),
+      );
 
   /// Generates the feed of active documents, ordered by their global rank.
   ///
   /// That is, documents are ordered by their timestamp, then local rank.
-  Future<List<Document>> restoreFeed() => _docRepo.fetchAll().then(
-        (docs) => docs
-          ..retainWhere((doc) => doc.isActive)
-          ..sort((doc1, doc2) {
-            final ord = doc1.timestamp.compareTo(doc2.timestamp);
-            return ord == 0
-                ? doc1.personalizedRank.compareTo(doc2.personalizedRank)
-                : ord;
-          }),
+  Future<EngineEvent> restoreFeed() => _docRepo.fetchAll().then(
+        (docs) {
+          final sortedActives = docs
+            ..retainWhere((doc) => doc.isActive)
+            ..sort((doc1, doc2) {
+              final ord = doc1.timestamp.compareTo(doc2.timestamp);
+              return ord == 0
+                  ? doc1.personalizedRank.compareTo(doc2.personalizedRank)
+                  : ord;
+            });
+
+          final feed = sortedActives.map((doc) => doc.toApiDocument()).toList();
+          return EngineEvent.feedRequestSucceeded(feed);
+        },
       );
 
   /// Obtain the next batch of feed documents and persist to repositories.
-  Future<void> nextFeedBatch() async {
+  Future<EngineEvent> nextFeedBatch() async {
     final feedDocs = _engine.getFeedDocuments(_maxDocs);
 
     await _docRepo.updateMany(feedDocs.keys);
@@ -75,5 +78,8 @@ class FeedManager {
       final id = feedDoc.key.documentId;
       await _activeRepo.update(id, feedDoc.value);
     }
+
+    final docs = feedDocs.keys.map((doc) => doc.toApiDocument()).toList();
+    return EngineEvent.nextFeedBatchRequestSucceeded(docs);
   }
 }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -40,11 +40,11 @@ class FeedManager {
   /// Handle the given feed client event.
   ///
   /// Fails if [event] does not have a handler implemented.
-  Future<List<Document>?> handleFeedClientEvent(FeedClientEvent event) async {
-    await event.maybeWhen(
+  Future<List<Document>> handleFeedClientEvent(FeedClientEvent event) {
+    return event.maybeWhen(
       feedRequested: () => restoreFeed(),
-      nextFeedBatchRequested: () => nextFeedBatch(),
-      feedDocumentsClosed: (ids) => _docMgr.deactivateDocuments(ids),
+      nextFeedBatchRequested: () => nextFeedBatch().then((_) => []),
+      feedDocumentsClosed: (ids) => _docMgr.deactivateDocuments(ids).then((_) => []),
       orElse: throw UnimplementedError('handler not implemented for $event'),
     );
   }

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -15,6 +15,7 @@
 import 'package:hive/hive.dart'
     show HiveType, HiveField, TypeAdapter, BinaryReader, BinaryWriter;
 import 'package:json_annotation/json_annotation.dart' show JsonValue;
+import 'package:xayn_discovery_engine/src/api/models/document.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/domain/models/web_resource.dart'
@@ -55,6 +56,15 @@ class Document {
     this.isActive = true,
   })  : documentId = DocumentId(),
         timestamp = DateTime.now().toUtc();
+
+  api.Document toApiDocument() => api.Document(
+        documentId: documentId,
+        webResource: webResource,
+        feedback: feedback,
+        nonPersonalizedRank: personalizedRank, // TODO remove?
+        personalizedRank: personalizedRank,
+        isActive: isActive,
+      );
 }
 
 /// [DocumentFeedback] indicates user's "sentiment" towards the document,


### PR DESCRIPTION
**Summary**

Previously,

- feed manager was added in #53 handling _docs closed_ and _next batch_.
- time stamps were added to documents in #64.

this pr adds handling of _restore feed_ to the feed manager.
the returned feed is ordered by `timestamp`, then `personalizedRank`.