### PR TITLE
TY 2295 Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,14 @@ jobs:
 
           # Commit only if something changed
           if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-            git commit --message "$SRC_COMMIT_MSG
+            git commit --message "This commit is a complete release.
+            The next commit need to set the dependencies references."
+
+            # change deps to the commit we just did
+            sed -i s/change_me_to_commit_ref/$(git rev-parse HEAD)/ ./discovery_engine_flutter/pubspec.yaml
+            git commit -a --message "$SRC_COMMIT_MSG
             https://github.com/xaynetwork/xayn_discovery_engine/commit/$SRC_COMMIT
             https://github.com/xaynetwork/xayn_discovery_engine/tree/$BRANCH"
+
             git push -u origin HEAD:$BRANCH
           fi

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   xayn_discovery_engine:
     git:
       url: git@github.com:xaynetwork/xayn_discovery_engine_release.git
-      ref: main
+      ref: change_me_to_commit_ref
       path: discovery_engine
 
 dev_dependencies:


### PR DESCRIPTION
With the current release workflow the flutter plugin always depends on the `main` branch.
This PR change that to the previous commit so that it always depends on the same branch and at a fixed location.