### PR TITLE
TY-2331 add snippet field

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -132,6 +132,9 @@ pub struct UserReacted {
     /// Stack from which the document has been taken.
     pub stack_id: StackId,
 
+    /// Text snippet of the document.
+    pub snippet: String,
+
     /// Precomputed S-mBert of the document.
     pub smbert: Embedding1,
 


### PR DESCRIPTION
Ticket:
- [TY-2331](https://xainag.atlassian.net/browse/TY-2331)
- part of [TY-2282](https://xainag.atlassian.net/browse/TY-2282)

Summary:
Adds a snippet field to the `UserReacted` struct. The snippet field will be used by the kpe within the ranker.