### PR TITLE
TY-2301 async engine

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1566,7 @@ dependencies = [
 name = "xayn-discovery-engine-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "claim",
  "derivative",

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -5,6 +5,7 @@ license = "AGPL-3.0-only"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.52"
 bincode = "1.3.3"
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from"] }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -103,7 +103,10 @@ where
     }
 
     /// Returns at most `max_documents` [`Document`]s for the feed.
-    pub fn get_feed_documents(&mut self, max_documents: u32) -> Result<Vec<Document>, Error> {
+    pub async fn get_feed_documents(&mut self, max_documents: u32) -> Result<Vec<Document>, Error>
+    where
+        R: Send + Sync,
+    {
         Selection::new(BetaSampler)
             .select(self.stacks.values_mut().collect(), max_documents)
             .map_err(|e| e.into())

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
 
@@ -21,6 +22,7 @@ use crate::{document::Document, engine::GenericError, stack::Id};
 ///
 /// Each stack can get and select new items using different sources
 /// or different strategies.
+#[async_trait]
 #[cfg_attr(test, automock)]
 pub trait Ops {
     /// Get the id for this set of operations.
@@ -33,7 +35,7 @@ pub trait Ops {
     ///
     /// Personalized key phrases can be optionally used to return items
     /// tailored to the user's interests.
-    fn new_items(&self, keyphrases: &[String]) -> Result<Vec<Document>, GenericError>;
+    async fn new_items(&self, keyphrases: &[String]) -> Result<Vec<Document>, GenericError>;
 
     /// Merge current and new items.
     fn merge(&self, current: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   async_bindgen_dart_utils:
     dependency: transitive
     description:
@@ -30,7 +30,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -85,6 +85,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -132,6 +139,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.3.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logger:
     dependency: transitive
     description:
@@ -145,7 +159,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -206,7 +220,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -234,7 +248,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   xayn_discovery_engine:
     dependency: "direct overridden"
     description:
@@ -250,5 +264,5 @@ packages:
     source: path
     version: "0.1.0"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.14.4 <3.0.0"
   flutter: ">=2.5.0"

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.0
 
 # to use local version of xayn_discovery_engine we need to override it here
 dependency_overrides:


### PR DESCRIPTION
**References**

- [TY-2301]
- [TY-2312]
- [TY-2313]

**Summary**
- async'ed the `stack::ops::Ops` trait and its `new_items()` function
- async'ed the `Engine::get_feed_documents()` method
- fixed dart linter warning



[TY-2301]: https://xainag.atlassian.net/browse/TY-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2312]: https://xainag.atlassian.net/browse/TY-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2313]: https://xainag.atlassian.net/browse/TY-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ