### PR TITLE
[Merged by Bors] - TY-2339 Add feedback for asset fetching

### DIFF
--- a/discovery_engine/example/lib/example.dart
+++ b/discovery_engine/example/lib/example.dart
@@ -19,8 +19,7 @@ Future<void> runExample() async {
   final config = Configuration(
     apiKey: '**********',
     apiBaseUrl: 'https://example-api.dev',
-    // assetsUrl: '<replace with a working URL to assets server>',
-    assetsUrl: 'https://ai-assets.xaynet.dev',
+    assetsUrl: '<replace with a working URL to assets server>',
     maxItemsPerFeedBatch: 50,
     applicationDirectoryPath: './',
     feedMarkets: {const FeedMarket(countryCode: 'DE', langCode: 'de')},
@@ -36,15 +35,12 @@ Future<void> runExample() async {
     print('Starting the Discovery Engine...');
     engine = await DiscoveryEngine.init(
       configuration: config,
-      onAssetsProgress: (event) {
-        if (event is FetchingAssetsStarted) {
-          print('Fetching Assets Started');
-        } else if (event is FetchingAssetsProgressed) {
-          print('Fetching Assets Progress: ${event.percentage}');
-        } else if (event is FetchingAssetsFinished) {
-          print('Fetching Assets Finished');
-        }
-      },
+      onAssetsProgress: (event) => event.whenOrNull(
+        fetchingAssetsStarted: () => print('Fetching Assets Started'),
+        fetchingAssetsProgressed: (percentage) =>
+            print('Fetching Assets Progress: $percentage'),
+        fetchingAssetsFinished: () => print('Fetching Assets Finished'),
+      ),
     );
     print('Engine initialized successfully.');
   } on EngineInitException catch (e) {

--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -36,10 +36,11 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         NextFeedBatchRequestFailed,
         NextFeedBatchAvailable,
         FeedFailureReason,
-        SystemEngineEvent,
+        AssetsStatusEngineEvent,
         FetchingAssetsStarted,
         FetchingAssetsProgressed,
         FetchingAssetsFinished,
+        SystemEngineEvent,
         ClientEventSucceeded,
         EngineExceptionRaised,
         EngineExceptionReason;

--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -37,6 +37,9 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         NextFeedBatchAvailable,
         FeedFailureReason,
         SystemEngineEvent,
+        FetchingAssetsStarted,
+        FetchingAssetsProgressed,
+        FetchingAssetsFinished,
         ClientEventSucceeded,
         EngineExceptionRaised,
         EngineExceptionReason;

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -98,6 +98,19 @@ class EngineEvent with _$EngineEvent {
   @Implements<FeedEngineEvent>()
   const factory EngineEvent.nextFeedBatchAvailable() = NextFeedBatchAvailable;
 
+  /// Event created when fetching of AI assets has started.
+  @Implements<SystemEngineEvent>()
+  const factory EngineEvent.fetchingAssetsStarted() = FetchingAssetsStarted;
+
+  /// Event created when fetching of AI assets has progressed.
+  @Implements<SystemEngineEvent>()
+  const factory EngineEvent.fetchingAssetsProgressed(double percentage) =
+      FetchingAssetsProgressed;
+
+  /// Event created when fetching of AI assets has finished.
+  @Implements<SystemEngineEvent>()
+  const factory EngineEvent.fetchingAssetsFinished() = FetchingAssetsFinished;
+
   /// Event created to inform the client that a particular "fire and forget"
   /// event, like DocumentFeedbackChanged, was successfuly processed
   /// by the engine.

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -31,6 +31,10 @@ abstract class FeedEngineEvent {}
 /// Used to group generic system events.
 abstract class SystemEngineEvent {}
 
+/// Abstract class implemented by events used to communicate status of
+/// AI assets fetching process.
+abstract class AssetsStatusEngineEvent {}
+
 enum FeedFailureReason {
   @JsonValue(0)
   notAuthorised,
@@ -99,16 +103,16 @@ class EngineEvent with _$EngineEvent {
   const factory EngineEvent.nextFeedBatchAvailable() = NextFeedBatchAvailable;
 
   /// Event created when fetching of AI assets has started.
-  @Implements<SystemEngineEvent>()
+  @Implements<AssetsStatusEngineEvent>()
   const factory EngineEvent.fetchingAssetsStarted() = FetchingAssetsStarted;
 
   /// Event created when fetching of AI assets has progressed.
-  @Implements<SystemEngineEvent>()
+  @Implements<AssetsStatusEngineEvent>()
   const factory EngineEvent.fetchingAssetsProgressed(double percentage) =
       FetchingAssetsProgressed;
 
   /// Event created when fetching of AI assets has finished.
-  @Implements<SystemEngineEvent>()
+  @Implements<AssetsStatusEngineEvent>()
   const factory EngineEvent.fetchingAssetsFinished() = FetchingAssetsFinished;
 
   /// Event created to inform the client that a particular "fire and forget"

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -307,6 +307,9 @@ extension _MapEvent on EngineEvent {
     bool? nextFeedBatchRequestSucceeded,
     bool? nextFeedBatchRequestFailed,
     bool? nextFeedBatchAvailable,
+    bool? fetchingAssetsStarted,
+    bool? fetchingAssetsProgressed,
+    bool? fetchingAssetsFinished,
     bool? clientEventSucceeded,
     bool? engineExceptionRaised,
   }) =>
@@ -318,6 +321,9 @@ extension _MapEvent on EngineEvent {
         nextFeedBatchRequestFailed:
             _maybePassThrough(nextFeedBatchRequestFailed),
         nextFeedBatchAvailable: _maybePassThrough(nextFeedBatchAvailable),
+        fetchingAssetsStarted: _maybePassThrough(fetchingAssetsStarted),
+        fetchingAssetsProgressed: _maybePassThrough(fetchingAssetsProgressed),
+        fetchingAssetsFinished: _maybePassThrough(fetchingAssetsFinished),
         clientEventSucceeded: _maybePassThrough(clientEventSucceeded),
         engineExceptionRaised: _maybePassThrough(engineExceptionRaised),
       );

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -83,7 +83,7 @@ class DiscoveryEngine {
   /// ```
   static Future<DiscoveryEngine> init({
     required Configuration configuration,
-    void Function(AssetsStatusEngineEvent event)? onAssetsProgress,
+    void Function(EngineEvent event)? onAssetsProgress,
     Object? entryPoint,
   }) async {
     try {
@@ -94,9 +94,7 @@ class DiscoveryEngine {
       if (onAssetsProgress != null) {
         subscription = manager.responses
             .where((event) => event is AssetsStatusEngineEvent)
-            .listen(
-              (event) => onAssetsProgress(event as AssetsStatusEngineEvent),
-            );
+            .listen(onAssetsProgress);
       }
 
       final initEvent = ClientEvent.init(configuration);

--- a/discovery_engine/lib/src/discovery_engine_worker.dart
+++ b/discovery_engine/lib/src/discovery_engine_worker.dart
@@ -34,7 +34,11 @@ class DiscoveryEngineWorker extends Worker<ClientEvent, EngineEvent> {
   @override
   Converter<EngineEvent, Object> get responseConverter => _responseConverter;
 
-  DiscoveryEngineWorker(Object message) : super(message);
+  DiscoveryEngineWorker(Object message) : super(message) {
+    _handler.assetsProgress.listen((event) {
+      send(event as EngineEvent);
+    });
+  }
 
   Sender? _getSenderFromMessageOrNull(Object? incomingMessage) {
     if (incomingMessage == null) return null;

--- a/discovery_engine/lib/src/domain/assets/asset_fetcher.dart
+++ b/discovery_engine/lib/src/domain/assets/asset_fetcher.dart
@@ -17,11 +17,13 @@ import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
     show Asset, Fragment;
 import 'package:xayn_discovery_engine/src/logger.dart' show logger;
 
+typedef OnFetched = void Function(String urlSuffix);
+
 /// Fetches the asset either from the `urlSuffix` or from [Fragment]s
 /// and returns a single bytes list.
 abstract class AssetFetcher {
   Future<Uint8List> fetchFragment(String urlSuffix);
-  Future<Uint8List> fetchAsset(Asset asset) async {
+  Future<Uint8List> fetchAsset(Asset asset, {OnFetched? onFetched}) async {
     final builder = BytesBuilder(copy: false);
 
     final message =
@@ -30,11 +32,13 @@ abstract class AssetFetcher {
 
     if (asset.fragments.isEmpty) {
       final bytes = await fetchFragment(asset.urlSuffix);
+      onFetched?.call(asset.urlSuffix);
       builder.add(bytes);
     }
 
     for (final fragment in asset.fragments) {
       final bytes = await fetchFragment(fragment.urlSuffix);
+      onFetched?.call(fragment.urlSuffix);
       builder.add(bytes);
     }
 

--- a/discovery_engine/lib/src/domain/assets/asset_reporter.dart
+++ b/discovery_engine/lib/src/domain/assets/asset_reporter.dart
@@ -1,0 +1,52 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:async' show StreamController;
+
+import 'package:xayn_discovery_engine/src/api/api.dart'
+    show
+        AssetsStatusEngineEvent,
+        FetchingAssetsFinished,
+        FetchingAssetsProgressed,
+        FetchingAssetsStarted;
+import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
+    show Manifest;
+
+class AssetReporter {
+  int _totalNbOfAssets = 0;
+  final Set<String> _fetchedUrls = {};
+  final _statusCtrl = StreamController<AssetsStatusEngineEvent>.broadcast();
+  Stream<AssetsStatusEngineEvent> get progress => _statusCtrl.stream;
+
+  void fetchingStarted(Manifest manifest) {
+    _totalNbOfAssets = manifest.assets.fold<int>(
+      0,
+      (sum, asset) =>
+          sum + (asset.fragments.isNotEmpty ? asset.fragments.length : 1),
+    );
+    _statusCtrl.add(const FetchingAssetsStarted());
+  }
+
+  void assetFetched(String fetchedUrl) {
+    assert(_totalNbOfAssets > 0);
+    final currentCount = (_fetchedUrls..add(fetchedUrl)).length;
+    final progress = currentCount * 100 / _totalNbOfAssets;
+    _statusCtrl.add(FetchingAssetsProgressed(progress));
+  }
+
+  Future<void> fetchingFinished() async {
+    _statusCtrl.add(const FetchingAssetsFinished());
+    await _statusCtrl.close();
+  }
+}

--- a/discovery_engine/lib/src/domain/assets/assets.dart
+++ b/discovery_engine/lib/src/domain/assets/assets.dart
@@ -16,6 +16,8 @@ export 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
     show Manifest, Asset, AssetType, Checksum, Fragment;
 export 'package:xayn_discovery_engine/src/domain/assets/asset_fetcher.dart'
     show AssetFetcher, AssetFetcherException;
+export 'package:xayn_discovery_engine/src/domain/assets/asset_reporter.dart'
+    show AssetReporter;
 export 'package:xayn_discovery_engine/src/domain/assets/data_provider.dart'
     show DataProvider, SetupData;
 export 'package:xayn_discovery_engine/src/domain/assets/manifest_reader.dart'

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -12,12 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:async' show StreamController;
-
-import 'package:xayn_discovery_engine/src/api/api.dart'
-    show AssetsStatusEngineEvent;
 import 'package:xayn_discovery_engine/src/domain/assets/asset_fetcher.dart'
     show AssetFetcher;
+import 'package:xayn_discovery_engine/src/domain/assets/asset_reporter.dart'
+    show AssetReporter;
 import 'package:xayn_discovery_engine/src/domain/assets/manifest_reader.dart'
     show ManifestReader;
 
@@ -34,11 +32,8 @@ abstract class SetupData {
 /// Reads the assets manifest and provides the [SetupData] to further use.
 abstract class DataProvider {
   AssetFetcher get assetFetcher;
+  AssetReporter get assetReporter;
   ManifestReader get manifestReader;
-
-  final Set<String> fetchedAssets = {};
-  final assetsStatusCtrl = StreamController<AssetsStatusEngineEvent>();
-  Stream<AssetsStatusEngineEvent> get assetsProgress => assetsStatusCtrl.stream;
 
   Future<SetupData> getSetupData() {
     throw UnsupportedError('Unsupported platform.');

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -12,6 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:async' show StreamController;
+
+import 'package:xayn_discovery_engine/src/api/api.dart'
+    show AssetsStatusEngineEvent;
 import 'package:xayn_discovery_engine/src/domain/assets/asset_fetcher.dart'
     show AssetFetcher;
 import 'package:xayn_discovery_engine/src/domain/assets/manifest_reader.dart'
@@ -31,6 +35,10 @@ abstract class SetupData {
 abstract class DataProvider {
   AssetFetcher get assetFetcher;
   ManifestReader get manifestReader;
+
+  final Set<String> fetchedAssets = {};
+  final assetsStatusCtrl = StreamController<AssetsStatusEngineEvent>();
+  Stream<AssetsStatusEngineEvent> get assetsProgress => assetsStatusCtrl.stream;
 
   Future<SetupData> getSetupData() {
     throw UnsupportedError('Unsupported platform.');

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -40,3 +40,14 @@ abstract class DataProvider {
     return paths.where((e) => e.isNotEmpty).join('/');
   }
 }
+
+/// Thrown when a there is an issue with downloading AI assets.
+class DataProviderException implements Exception {
+  /// Message (or string representation of the exception).
+  final String message;
+
+  DataProviderException(this.message);
+
+  @override
+  String toString() => 'DataProviderException: $message';
+}

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -40,14 +40,3 @@ abstract class DataProvider {
     return paths.where((e) => e.isNotEmpty).join('/');
   }
 }
-
-/// Thrown when a there is an issue with downloading AI assets.
-class DataProviderException implements Exception {
-  /// Message (or string representation of the exception).
-  final String message;
-
-  DataProviderException(this.message);
-
-  @override
-  String toString() => 'DataProviderException: $message';
-}

--- a/discovery_engine/lib/src/domain/assets/manifest_reader.dart
+++ b/discovery_engine/lib/src/domain/assets/manifest_reader.dart
@@ -27,14 +27,3 @@ abstract class ManifestReader {
   /// Loads the [Manifest] json file as [String] from bundled assets.
   Future<String> loadManifestAsString();
 }
-
-/// Thrown when a there is an issue reading the assets manifest file.
-class ManifestReaderException implements Exception {
-  /// Message (or string representation of the exception).
-  final String message;
-
-  ManifestReaderException(this.message);
-
-  @override
-  String toString() => 'ManifestReaderException: $message';
-}

--- a/discovery_engine/lib/src/domain/assets/manifest_reader.dart
+++ b/discovery_engine/lib/src/domain/assets/manifest_reader.dart
@@ -27,3 +27,14 @@ abstract class ManifestReader {
   /// Loads the [Manifest] json file as [String] from bundled assets.
   Future<String> loadManifestAsString();
 }
+
+/// Thrown when a there is an issue reading the assets manifest file.
+class ManifestReaderException implements Exception {
+  /// Message (or string representation of the exception).
+  final String message;
+
+  ManifestReaderException(this.message);
+
+  @override
+  String toString() => 'ManifestReaderException: $message';
+}

--- a/discovery_engine/lib/src/domain/assets/manifest_reader.dart
+++ b/discovery_engine/lib/src/domain/assets/manifest_reader.dart
@@ -17,18 +17,11 @@ import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
     show Manifest;
 
 abstract class ManifestReader {
-  int fragmentsTotal = 0;
-
   /// Loads and returns the assets [Manifest].
   Future<Manifest> read() async {
     final jsonString = await loadManifestAsString();
     final json = jsonDecode(jsonString) as Map;
     final manifest = Manifest.fromJson(json.cast<String, Object>());
-    fragmentsTotal = manifest.assets.fold<int>(
-      0,
-      (sum, asset) =>
-          sum + (asset.fragments.isNotEmpty ? asset.fragments.length : 1),
-    );
     return manifest;
   }
 

--- a/discovery_engine/lib/src/domain/assets/manifest_reader.dart
+++ b/discovery_engine/lib/src/domain/assets/manifest_reader.dart
@@ -21,8 +21,7 @@ abstract class ManifestReader {
   Future<Manifest> read() async {
     final jsonString = await loadManifestAsString();
     final json = jsonDecode(jsonString) as Map;
-    final manifest = Manifest.fromJson(json.cast<String, Object>());
-    return manifest;
+    return Manifest.fromJson(json.cast<String, Object>());
   }
 
   /// Loads the [Manifest] json file as [String] from bundled assets.

--- a/discovery_engine/lib/src/domain/assets/manifest_reader.dart
+++ b/discovery_engine/lib/src/domain/assets/manifest_reader.dart
@@ -17,11 +17,19 @@ import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
     show Manifest;
 
 abstract class ManifestReader {
+  int fragmentsTotal = 0;
+
   /// Loads and returns the assets [Manifest].
   Future<Manifest> read() async {
     final jsonString = await loadManifestAsString();
     final json = jsonDecode(jsonString) as Map;
-    return Manifest.fromJson(json.cast<String, Object>());
+    final manifest = Manifest.fromJson(json.cast<String, Object>());
+    fragmentsTotal = manifest.assets.fold<int>(
+      0,
+      (sum, asset) =>
+          sum + (asset.fragments.isNotEmpty ? asset.fragments.length : 1),
+    );
+    return manifest;
   }
 
   /// Loads the [Manifest] json file as [String] from bundled assets.

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -16,6 +16,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:hive/hive.dart' show Hive;
 import 'package:xayn_discovery_engine/src/api/api.dart'
     show
+        AssetsStatusEngineEvent,
         ClientEvent,
         DocumentClientEvent,
         EngineEvent,
@@ -25,7 +26,7 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         Init,
         SystemClientEvent;
 import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
-    show AssetFetcherException, SetupData;
+    show AssetFetcherException, DataProvider, SetupData;
 import 'package:xayn_discovery_engine/src/domain/document_manager.dart'
     show DocumentManager;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
@@ -78,6 +79,10 @@ class EventHandler {
   late final ChangedDocumentRepository _changedDocumentRepository;
   late final DocumentManager _documentManager;
   late final FeedManager _feedManager;
+  late final DataProvider _dataProvider;
+
+  Stream<AssetsStatusEngineEvent> get assetsProgress =>
+      _dataProvider.assetsProgress;
 
   /// Decides what to do with incoming [ClientEvent] by passing it
   /// to a dedicated manager and returns the appropriate response in the form
@@ -181,12 +186,12 @@ class EventHandler {
     final storageDirPath = '$appDir/$kEnginePath';
     final assetFetcher = HttpAssetFetcher(config.assetsUrl);
     final manifestReader = createManifestReader();
-    final dataProvider = createDataProvider(
+    _dataProvider = createDataProvider(
       assetFetcher,
       manifestReader,
       storageDirPath,
     );
-    return dataProvider.getSetupData();
+    return _dataProvider.getSetupData();
   }
 
   Future<void> _initDatabase(String appDir) async {

--- a/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
+++ b/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
@@ -14,28 +14,26 @@
 
 import 'dart:typed_data' show Uint8List;
 
-import 'package:xayn_discovery_engine/src/api/api.dart'
+import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
     show
-        FetchingAssetsStarted,
-        FetchingAssetsProgressed,
-        FetchingAssetsFinished;
-import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
-    show AssetType;
-import 'package:xayn_discovery_engine/src/domain/assets/asset_fetcher.dart'
-    show AssetFetcher;
-import 'package:xayn_discovery_engine/src/domain/assets/data_provider.dart'
-    show DataProvider, SetupData;
-import 'package:xayn_discovery_engine/src/domain/assets/manifest_reader.dart'
-    show ManifestReader;
+        AssetType,
+        AssetFetcher,
+        AssetReporter,
+        DataProvider,
+        ManifestReader,
+        SetupData;
 
 class WebDataProvider extends DataProvider {
   @override
   final AssetFetcher assetFetcher;
   @override
+  final AssetReporter assetReporter;
+  @override
   final ManifestReader manifestReader;
 
   WebDataProvider(
     this.assetFetcher,
+    this.assetReporter,
     this.manifestReader,
   );
 
@@ -44,24 +42,17 @@ class WebDataProvider extends DataProvider {
     final fetched = <AssetType, Uint8List>{};
     final manifest = await manifestReader.read();
 
-    // assets started fetching
-    assetsStatusCtrl.add(const FetchingAssetsStarted());
+    assetReporter.fetchingStarted(manifest);
 
     for (final asset in manifest.assets) {
       final bytes = await assetFetcher.fetchAsset(
         asset,
-        onFetched: (urlSuffix) {
-          final currentCount = (fetchedAssets..add(urlSuffix)).length;
-          final progress = currentCount * 100 / manifestReader.fragmentsTotal;
-          assetsStatusCtrl.add(FetchingAssetsProgressed(progress));
-        },
+        onFetched: assetReporter.assetFetched,
       );
       fetched.putIfAbsent(asset.id, () => bytes);
     }
 
-    // assets finished fetching
-    assetsStatusCtrl.add(const FetchingAssetsFinished());
-    await assetsStatusCtrl.close();
+    await assetReporter.fetchingFinished();
 
     return WebSetupData(
       smbertVocab: fetched[AssetType.smbertVocab]!,
@@ -100,7 +91,8 @@ class WebSetupData extends SetupData {
 
 DataProvider createDataProvider(
   final AssetFetcher assetFetcher,
+  final AssetReporter assetReporter,
   final ManifestReader manifestReader,
   final String storageDirectoryPath,
 ) =>
-    WebDataProvider(assetFetcher, manifestReader);
+    WebDataProvider(assetFetcher, assetReporter, manifestReader);

--- a/discovery_engine/test/codecs/mocks.dart
+++ b/discovery_engine/test/codecs/mocks.dart
@@ -20,25 +20,28 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         ConfigurationChanged,
         Document,
         DocumentFeedback,
-        DocumentViewMode,
         DocumentFeedbackChanged,
         DocumentId,
         DocumentTimeSpent,
+        DocumentViewMode,
         EngineEvent,
         EngineExceptionRaised,
         EngineExceptionReason,
         FeedDocumentsClosed,
         FeedFailureReason,
+        FeedMarkets,
         FeedRequestFailed,
         FeedRequestSucceeded,
         FeedRequested,
+        FetchingAssetsFinished,
+        FetchingAssetsProgressed,
+        FetchingAssetsStarted,
         Init,
         NextFeedBatchAvailable,
         NextFeedBatchRequestFailed,
         NextFeedBatchRequestSucceeded,
         NextFeedBatchRequested,
-        ResetEngine,
-        FeedMarkets;
+        ResetEngine;
 
 class BadClientEvent implements ClientEvent {
   const BadClientEvent();
@@ -176,6 +179,12 @@ class BadEngineEvent implements EngineEvent {
         nextFeedBatchRequestFailed,
     required TResult Function(NextFeedBatchAvailable value)
         nextFeedBatchAvailable,
+    required TResult Function(FetchingAssetsStarted value)
+        fetchingAssetsStarted,
+    required TResult Function(FetchingAssetsProgressed value)
+        fetchingAssetsProgressed,
+    required TResult Function(FetchingAssetsFinished value)
+        fetchingAssetsFinished,
     required TResult Function(ClientEventSucceeded value) clientEventSucceeded,
     required TResult Function(EngineExceptionRaised value)
         engineExceptionRaised,
@@ -192,6 +201,9 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(NextFeedBatchRequestFailed value)?
         nextFeedBatchRequestFailed,
     TResult Function(NextFeedBatchAvailable value)? nextFeedBatchAvailable,
+    TResult Function(FetchingAssetsStarted value)? fetchingAssetsStarted,
+    TResult Function(FetchingAssetsProgressed value)? fetchingAssetsProgressed,
+    TResult Function(FetchingAssetsFinished value)? fetchingAssetsFinished,
     TResult Function(ClientEventSucceeded value)? clientEventSucceeded,
     TResult Function(EngineExceptionRaised value)? engineExceptionRaised,
   }) {
@@ -208,6 +220,9 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(NextFeedBatchRequestFailed value)?
         nextFeedBatchRequestFailed,
     TResult Function(NextFeedBatchAvailable value)? nextFeedBatchAvailable,
+    TResult Function(FetchingAssetsStarted value)? fetchingAssetsStarted,
+    TResult Function(FetchingAssetsProgressed value)? fetchingAssetsProgressed,
+    TResult Function(FetchingAssetsFinished value)? fetchingAssetsFinished,
     TResult Function(ClientEventSucceeded value)? clientEventSucceeded,
     TResult Function(EngineExceptionRaised value)? engineExceptionRaised,
   }) {
@@ -222,6 +237,9 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(List<Document> items)? nextFeedBatchRequestSucceeded,
     TResult Function(FeedFailureReason reason)? nextFeedBatchRequestFailed,
     TResult Function()? nextFeedBatchAvailable,
+    TResult Function()? fetchingAssetsStarted,
+    TResult Function(double percentage)? fetchingAssetsProgressed,
+    TResult Function()? fetchingAssetsFinished,
     TResult Function()? clientEventSucceeded,
     TResult Function(EngineExceptionReason reason)? engineExceptionRaised,
   }) {
@@ -242,6 +260,9 @@ class BadEngineEvent implements EngineEvent {
     required TResult Function(FeedFailureReason reason)
         nextFeedBatchRequestFailed,
     required TResult Function() nextFeedBatchAvailable,
+    required TResult Function() fetchingAssetsStarted,
+    required TResult Function(double percentage) fetchingAssetsProgressed,
+    required TResult Function() fetchingAssetsFinished,
     required TResult Function() clientEventSucceeded,
     required TResult Function(EngineExceptionReason reason)
         engineExceptionRaised,
@@ -256,6 +277,9 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(List<Document> items)? nextFeedBatchRequestSucceeded,
     TResult Function(FeedFailureReason reason)? nextFeedBatchRequestFailed,
     TResult Function()? nextFeedBatchAvailable,
+    TResult Function()? fetchingAssetsStarted,
+    TResult Function(double percentage)? fetchingAssetsProgressed,
+    TResult Function()? fetchingAssetsFinished,
     TResult Function()? clientEventSucceeded,
     TResult Function(EngineExceptionReason reason)? engineExceptionRaised,
   }) {


### PR DESCRIPTION
[Jira ref](https://xainag.atlassian.net/browse/TY-2339)

### Feedback for fetching assets

This PR adds a way for a user of `DiscoveryEngine` to get informed about progress of **AI assets fetching process**. 

It adds:
- dedicated events such as `FetchingAssetsStarted`, `FetchingAssetsProgressed` and `FetchingAssetsFinished` to indicate various stages of fetching process
- a dedicated `AssetReporter` class which abstracts the responsibility of tracking how many assets there is to fetch, which of them were already fetched, hence what the progress is, and when the process is finished. `AssetReporter` exposes a `Stream` of `FetchingAssets*` events so that it could be listened to 
- a callback to the `DiscoveryEngine.init` method, which can be used to listen and react to incoming fetching updates events