### PR TITLE
[Merged by Bors] - TY-2310 add user reaction to time spent struct

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -90,7 +90,7 @@ class DocumentManager {
       throw ArgumentError('id $id does not identify an active document');
     }
     final doc = await _documentRepo.fetchById(id);
-    if (doc == null) {
+    if (doc == null || !doc.isActive) {
       throw ArgumentError('id $id does not identify an active document');
     }
 

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -89,6 +89,11 @@ class DocumentManager {
     if (activeData == null) {
       throw ArgumentError('id $id does not identify an active document');
     }
+    final doc = await _documentRepo.fetchById(id);
+    if (doc == null) {
+      throw ArgumentError('id $id does not identify an active document');
+    }
+
     activeData.addViewTime(mode, Duration(seconds: sec));
     await _activeRepo.update(id, activeData);
 
@@ -101,6 +106,7 @@ class DocumentManager {
       id,
       smbertEmbedding: activeData.smbertEmbedding,
       seconds: sumDuration,
+      reaction: doc.feedback,
     );
   }
 }

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -31,6 +31,7 @@ abstract class Engine {
     DocumentId docId, {
     required Uint8List smbertEmbedding,
     required Duration seconds,
+    required DocumentFeedback reaction,
   });
 
   /// Process the feedback about the user reacting to a document.

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -91,6 +91,7 @@ class MockEngine implements Engine {
     DocumentId docId, {
     required Uint8List smbertEmbedding,
     required Duration seconds,
+    required DocumentFeedback reaction,
   }) {
     _incrementCount('timeLogged');
   }

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -162,6 +162,25 @@ Future<void> main() async {
       );
     });
 
+    test('add time to an inactive document with active document data',
+        () async {
+      const mode = DocumentViewMode.story;
+      await activeRepo.update(id2, data);
+      expect(
+        () => mgr.addActiveDocumentTime(id2, mode, 1),
+        throwsArgumentError,
+      );
+    });
+
+    test('add time to an absent document with active document data', () async {
+      const mode = DocumentViewMode.story;
+      await activeRepo.update(id3, data);
+      expect(
+        () => mgr.addActiveDocumentTime(id3, mode, 1),
+        throwsArgumentError,
+      );
+    });
+
     test('add positive time to document with active data', () async {
       const mode = DocumentViewMode.story;
 

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -122,6 +122,8 @@ pub struct TimeSpent {
        coi just consider one time. On the dart side we are saving all these values
        and when we call the feedbackloop we will decide which value to use or to aggregate them.
     */
+    /// Reaction.
+    pub reaction: UserReaction,
 }
 
 /// User reacted to a document.


### PR DESCRIPTION
Ticket:

- [TY-2310]

part of [TY-2282]

Summary:

Adds the `UserReaction` field to the `TimeSpent` struct. The field will be used later in the `log_document_view_time` method in xayn_ai (https://github.com/xaynetwork/xayn_ai/pull/401)

Question:
Do we need to do the same in dart?

[TY-2310]: https://xainag.atlassian.net/browse/TY-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2282]: https://xainag.atlassian.net/browse/TY-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ