### PR TITLE
[Merged by Bors] - TY-2308 impl ranker

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arrayvec"
@@ -45,7 +57,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#2023676c9f9cd8f0b703fb3c62cd75ead1447239"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#0901318ff74f4afd59c606121ab3966b4bdcaaa3"
 dependencies = [
  "async-bindgen-derive",
  "async-std",
@@ -57,7 +69,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-derive"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#2023676c9f9cd8f0b703fb3c62cd75ead1447239"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#0901318ff74f4afd59c606121ab3966b4bdcaaa3"
 dependencies = [
  "heck 0.4.0",
  "once_cell",
@@ -69,7 +81,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-gen-dart"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#2023676c9f9cd8f0b703fb3c62cd75ead1447239"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#0901318ff74f4afd59c606121ab3966b4bdcaaa3"
 dependencies = [
  "anyhow",
  "handlebars",
@@ -187,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
 name = "async-trait"
@@ -262,6 +274,21 @@ dependencies = [
  "shlex",
  "which",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -462,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +553,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,10 +601,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "educe"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -575,6 +652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fake-simd"
@@ -601,11 +691,41 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -791,8 +911,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -803,15 +925,14 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
+checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
 dependencies = [
  "futures-channel",
  "futures-core",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -832,6 +953,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "handlebars"
@@ -1048,12 +1175,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "kpe"
+version = "0.1.0"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#98680ca3dd6d097f47e2d21ca4092bde6f367a92"
+dependencies = [
+ "derive_more",
+ "displaydoc",
+ "layer",
+ "ndarray",
+ "rubert-tokenizer",
+ "thiserror",
+ "tract-onnx",
+]
+
+[[package]]
+name = "kstring"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "layer"
+version = "0.1.0"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#98680ca3dd6d097f47e2d21ca4092bde6f367a92"
+dependencies = [
+ "bincode",
+ "displaydoc",
+ "ndarray",
+ "rand 0.8.4",
+ "rand_distr",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1083,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libloading"
@@ -1104,6 +1268,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
+name = "liquid"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e930310cf4334c4936ae18737500a57739c69442b5c42bae114d619af54b82"
+dependencies = [
+ "doc-comment",
+ "kstring",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eae470f061bfc53607283906de925ab67ed57a341e827146e3b241699a1dcde"
+dependencies = [
+ "anymap2",
+ "chrono",
+ "itertools",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6510e456700da1afe07603913b0da5a2595f2482656ade07abf719aae7501f0a"
+dependencies = [
+ "proc-macro2",
+ "proc-quote",
+ "syn",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6341259f779ff663bdf1fc478bddb2ca51fda25414006dc69395eddfac07e0a4"
+dependencies = [
+ "chrono",
+ "itertools",
+ "kstring",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1340,16 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "mapr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "matches"
@@ -1151,6 +1383,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -1200,6 +1442,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -1271,6 +1519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1566,25 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "obake"
+version = "1.0.4"
+source = "git+https://github.com/doctorn/obake?rev=d6bea07e355ca4adf353c1e627f13c8c3286361b#d6bea07e355ca4adf353c1e627f13c8c3286361b"
+dependencies = [
+ "obake_macros",
+]
+
+[[package]]
+name = "obake_macros"
+version = "1.0.4"
+source = "git+https://github.com/doctorn/obake?rev=d6bea07e355ca4adf353c1e627f13c8c3286361b#d6bea07e355ca4adf353c1e627f13c8c3286361b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
 ]
 
 [[package]]
@@ -1361,6 +1639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1697,16 @@ dependencies = [
  "maplit",
  "pest",
  "sha-1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -1507,12 +1801,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "proc-quote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e84ab161de78c915302ca325a19bee6df272800e2ae1a43fe3ef430bab2a100"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "proc-quote-impl",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-quote-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -1523,9 +1900,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1699,6 +2076,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubert"
+version = "0.1.0"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#98680ca3dd6d097f47e2d21ca4092bde6f367a92"
+dependencies = [
+ "derive_more",
+ "displaydoc",
+ "float-cmp",
+ "ndarray",
+ "rubert-tokenizer",
+ "serde",
+ "thiserror",
+ "tract-onnx",
+]
+
+[[package]]
+name = "rubert-tokenizer"
+version = "0.1.0"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#98680ca3dd6d097f47e2d21ca4092bde6f367a92"
+dependencies = [
+ "displaydoc",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+ "smallstr",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode_categories",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +2116,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1751,18 +2167,18 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1771,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1789,6 +2205,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1828,10 +2255,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
-name = "socket2"
-version = "0.4.3"
+name = "smallstr"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "1e922794d168678729ffc7e07182721a14219c65814e66e91b839a272fe5ae4f"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -1882,6 +2324,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2053,6 +2506,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-core"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec224e77668b0857a0b93b21994323672e53479057cfa8fb4a6987086c9c879"
+dependencies = [
+ "anyhow",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "educe",
+ "half",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray",
+ "num-integer",
+ "num-traits",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1609c2b286a347d3040c7234e204de170920ec3709b15521defe098c0f8a5a67"
+dependencies = [
+ "anyhow",
+ "educe",
+ "half",
+ "itertools",
+ "lazy_static",
+ "maplit",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b579830105a172704676ca4da670931010577070e869724be6740ec43d4cc3eb"
+dependencies = [
+ "derive-new",
+ "educe",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f51d85987d90f5e6479dbe203cbf259eb9208ff4e1c94870ab0ca61492171bb"
+dependencies = [
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "educe",
+ "half",
+ "lazy_static",
+ "libc",
+ "liquid",
+ "log",
+ "num-traits",
+ "paste",
+ "smallvec",
+ "tract-data",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b15a11fea45a9f69c595cf386c87e4c3cd45d1323e7b5f430004a8cd11d2c4"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "log",
+ "nom 7.1.0",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9a6eb2116cdab535b5b9f1771e82acebea419f2571bd688e267451de3506ce"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "educe",
+ "log",
+ "mapr",
+ "num-integer",
+ "prost",
+ "prost-build",
+ "smallvec",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45ed1d95f1deef2a6240d296fa0eaf97dc4b15df32be7a5220ee825e0a3fc4d"
+dependencies = [
+ "educe",
+ "tract-nnef",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2688,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -2159,6 +2751,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2269,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
@@ -2340,9 +2943,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xayn-ai"
+version = "0.1.0"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#98680ca3dd6d097f47e2d21ca4092bde6f367a92"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derivative",
+ "derive_more",
+ "displaydoc",
+ "itertools",
+ "js-sys",
+ "kpe",
+ "layer",
+ "ndarray",
+ "obake",
+ "rand 0.8.4",
+ "rubert",
+ "serde",
+ "serde_repr",
+ "smallvec",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#6d9326b1fb8a298b9ea99c9f62b51a1270e0d8dd"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#4726d75f35513a80eb8df753b54099254cf0dc7d"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -2354,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#6d9326b1fb8a298b9ea99c9f62b51a1270e0d8dd"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#4726d75f35513a80eb8df753b54099254cf0dc7d"
 dependencies = [
  "bindgen",
  "cc",
@@ -2384,12 +3021,12 @@ dependencies = [
  "displaydoc",
  "float-cmp",
  "mockall",
- "ndarray",
  "rand 0.8.4",
  "rand_distr",
  "serde",
  "thiserror",
  "uuid",
+ "xayn-ai",
 ]
 
 [[package]]

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 async-trait = "0.1.52"
 bincode = "1.3.3"
 derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
-ndarray = { version = "=0.15.3", features = ["serde"] }
 rand = "0.8.4"
 rand_distr = "0.4.2"
 serde = { version = "1.0.130", features = ["derive"] }
 thiserror = "1.0.30"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
+xayn-ai = { git = "https://github.com/xaynetwork/xayn_ai", branch = "master" }
 
 [dev-dependencies]
 claim = "0.5.0"

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -17,12 +17,12 @@
 use std::{convert::TryFrom, time::Duration};
 
 use derivative::Derivative;
-use derive_more::{Deref, Display};
+use derive_more::Display;
 use displaydoc::Display as DisplayDoc;
-use ndarray::{Array, Dimension, Ix1};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+use xayn_ai::ranker::Embedding;
 
 use crate::stack::Id as StackId;
 
@@ -79,7 +79,7 @@ pub struct Document {
     pub domain: String,
 
     /// Embedding from smbert.
-    pub smbert_embedding: Embedding1,
+    pub smbert_embedding: Embedding,
 }
 
 /// Indicates user's "sentiment" towards the document,
@@ -98,23 +98,13 @@ pub enum UserReaction {
     Negative,
 }
 
-/// A d-dimensional sequence embedding.
-#[derive(Clone, Debug, Deref, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Default))]
-pub struct Embedding<D>(pub Array<f32, D>)
-where
-    D: Dimension;
-
-/// A 1-dimensional sequence embedding.
-pub type Embedding1 = Embedding<Ix1>;
-
 /// Log the time that has been spent on the document.
 pub struct TimeSpent {
     /// Id of the document.
     pub id: Id,
 
     /// Precomputed S-mBert of the document.
-    pub smbert: Embedding1,
+    pub smbert: Embedding,
 
     /// Time spent on the documents in seconds.
     pub seconds: Duration,
@@ -138,7 +128,7 @@ pub struct UserReacted {
     pub snippet: String,
 
     /// Precomputed S-mBert of the document.
-    pub smbert: Embedding1,
+    pub smbert: Embedding,
 
     /// Reaction.
     pub reaction: UserReaction,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 use crate::{
     document::{Document, TimeSpent, UserReacted},
     mab::{self, BetaSampler, Selection},
+    ranker::Ranker,
     stack::{self, BoxedOps, Data as StackData, Id as StackId, Stack},
 };
 
@@ -116,7 +117,7 @@ where
     pub fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), Error> {
         self.ranker.time_logged(time_logged)?;
 
-        rank_stacks(self.stacks.values_mut(), &self.ranker)
+        rank_stacks(self.stacks.values_mut(), &mut self.ranker)
     }
 
     /// Process the feedback about the user reacting to a document.
@@ -130,14 +131,14 @@ where
 
         self.ranker.user_reacted(reacted)?;
 
-        rank_stacks(self.stacks.values_mut(), &self.ranker)
+        rank_stacks(self.stacks.values_mut(), &mut self.ranker)
     }
 }
 
 /// The ranker could rank the documents in a different order so we update the stacks with it.
 fn rank_stacks<'a, R: Ranker>(
     stacks: impl Iterator<Item = &'a mut Stack>,
-    ranker: &R,
+    ranker: &mut R,
 ) -> Result<(), Error> {
     let errors = stacks.fold(vec![], |mut errors, stack| {
         if let Err(e) = stack.rank(ranker).map_err(Error::StackOpFailed) {
@@ -157,15 +158,3 @@ fn rank_stacks<'a, R: Ranker>(
 /// A wrapper around a dynamic error type, similar to `anyhow::Error`,
 /// but without the need to declare `anyhow` as a dependency.
 pub(crate) type GenericError = Box<dyn std::error::Error + Sync + Send + 'static>;
-
-/// Provides a method for ranking a slice of [`Document`] items.
-pub trait Ranker {
-    /// Performs the ranking of [`Document`] items.
-    fn rank(&self, items: &mut [Document]) -> Result<(), GenericError>;
-
-    /// Learn from the time a user spent on a document.
-    fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError>;
-
-    /// Learn from a user's interaction.
-    fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError>;
-}

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -115,7 +115,7 @@ where
 
     /// Process the feedback about the user spending some time on a document.
     pub fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), Error> {
-        self.ranker.time_logged(time_logged)?;
+        self.ranker.log_document_view_time(time_logged)?;
 
         rank_stacks(self.stacks.values_mut(), &mut self.ranker)
     }
@@ -129,7 +129,7 @@ where
 
         stack.update_relevance(reacted.reaction);
 
-        self.ranker.user_reacted(reacted)?;
+        self.ranker.log_user_reaction(reacted)?;
 
         rank_stacks(self.stacks.values_mut(), &mut self.ranker)
     }

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod document;
 mod engine;
 mod mab;
+mod ranker;
 pub mod stack;
 mod utils;
 

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -1,0 +1,82 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use xayn_ai::{ranker::Embedding, DocumentId, UserFeedback};
+
+use crate::{
+    document::{Document, Id, TimeSpent, UserReacted, UserReaction},
+    engine::GenericError,
+};
+
+/// Provides a method for ranking a slice of [`Document`] items.
+pub trait Ranker {
+    /// Performs the ranking of [`Document`] items.
+    fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError>;
+
+    /// Learn from the time a user spent on a document.
+    fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError>;
+
+    /// Learn from a user's interaction.
+    fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError>;
+}
+
+impl Ranker for xayn_ai::ranker::Ranker {
+    fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError> {
+        self.rank(items).map_err(Into::into)
+    }
+
+    fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError> {
+        self.log_document_view_time(
+            (&time_logged.reaction).into(),
+            &time_logged.smbert,
+            time_logged.seconds,
+        );
+        Ok(())
+    }
+
+    fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
+        self.log_user_reaction(
+            (&reaction.reaction).into(),
+            &reaction.snippet,
+            &reaction.smbert,
+        );
+        Ok(())
+    }
+}
+
+impl xayn_ai::ranker::Document for Document {
+    fn id(&self) -> DocumentId {
+        self.id.into()
+    }
+
+    fn smbert_embedding(&self) -> &Embedding {
+        &self.smbert_embedding
+    }
+}
+
+impl From<Id> for DocumentId {
+    fn from(id: Id) -> Self {
+        Self(id.0)
+    }
+}
+
+impl From<&UserReaction> for UserFeedback {
+    fn from(reaction: &UserReaction) -> Self {
+        match reaction {
+            UserReaction::Neutral => UserFeedback::NotGiven,
+            UserReaction::Positive => UserFeedback::Relevant,
+            UserReaction::Negative => UserFeedback::Irrelevant,
+        }
+    }
+}

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -38,7 +38,7 @@ impl Ranker for xayn_ai::ranker::Ranker {
 
     fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError> {
         self.log_document_view_time(
-            (&time_logged.reaction).into(),
+            time_logged.reaction.into(),
             &time_logged.smbert,
             time_logged.seconds,
         );
@@ -47,7 +47,7 @@ impl Ranker for xayn_ai::ranker::Ranker {
 
     fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
         self.log_user_reaction(
-            (&reaction.reaction).into(),
+            reaction.reaction.into(),
             &reaction.snippet,
             &reaction.smbert,
         );

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -71,8 +71,8 @@ impl From<Id> for DocumentId {
     }
 }
 
-impl From<&UserReaction> for UserFeedback {
-    fn from(reaction: &UserReaction) -> Self {
+impl From<UserReaction> for UserFeedback {
+    fn from(reaction: UserReaction) -> Self {
         match reaction {
             UserReaction::Neutral => UserFeedback::NotGiven,
             UserReaction::Positive => UserFeedback::Relevant,

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -24,11 +24,11 @@ pub trait Ranker {
     /// Performs the ranking of [`Document`] items.
     fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError>;
 
-    /// Learn from the time a user spent on a document.
-    fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError>;
+    /// Logs the time a user spent on a document.
+    fn log_document_view_time(&mut self, time_spent: &TimeSpent) -> Result<(), GenericError>;
 
-    /// Learn from a user's interaction.
-    fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError>;
+    /// Logs a user's interaction.
+    fn log_user_reaction(&mut self, reaction: &UserReacted) -> Result<(), GenericError>;
 }
 
 impl Ranker for xayn_ai::ranker::Ranker {
@@ -36,16 +36,16 @@ impl Ranker for xayn_ai::ranker::Ranker {
         self.rank(items).map_err(Into::into)
     }
 
-    fn time_logged(&mut self, time_logged: &TimeSpent) -> Result<(), GenericError> {
+    fn log_document_view_time(&mut self, time_spent: &TimeSpent) -> Result<(), GenericError> {
         self.log_document_view_time(
-            time_logged.reaction.into(),
-            &time_logged.smbert,
-            time_logged.seconds,
+            time_spent.reaction.into(),
+            &time_spent.smbert,
+            time_spent.seconds,
         );
         Ok(())
     }
 
-    fn user_reacted(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
+    fn log_user_reaction(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
         self.log_user_reaction(
             reaction.reaction.into(),
             &reaction.snippet,

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -23,8 +23,9 @@ use uuid::Uuid;
 
 use crate::{
     document::{Document, Id as DocumentId, UserReaction},
-    engine::{GenericError, Ranker},
+    engine::GenericError,
     mab::Bucket,
+    ranker::Ranker,
 };
 
 mod data;
@@ -91,7 +92,7 @@ impl Stack {
     pub(crate) fn update<R: Ranker>(
         mut self,
         new_documents: &[Document],
-        ranker: &R,
+        ranker: &mut R,
     ) -> Result<Self, Error> {
         Self::validate_documents_stack_id(new_documents, self.ops.id())?;
 
@@ -107,7 +108,7 @@ impl Stack {
     /// Rank the internal documents.
     ///
     /// This is useful when the [`Ranker`] has been updated.
-    pub(crate) fn rank<R: Ranker>(&mut self, ranker: &R) -> Result<(), Error> {
+    pub(crate) fn rank<R: Ranker>(&mut self, ranker: &mut R) -> Result<(), Error> {
         ranker
             .rank(&mut self.data.documents)
             .map_err(Error::Ranking)


### PR DESCRIPTION
Ticket:

- [TY-2308]


based on #84 

Summary:

- moved the Ranker trait into a separate file
- `Ranker::rank` now requires `&mut self` instead of `&self` because during the context calculation  the internal `RelevanceMap` in `xayn_ai::Ranker` will change
- replaced `Embedding1` with `xayn_ai::ranker::Embedding`

[TY-2308]: https://xainag.atlassian.net/browse/TY-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ