### PR TITLE
[Merged by Bors] - TY-2341  duration [2.1]

### DIFF
--- a/discovery_engine/lib/src/ffi/types/duration.dart
+++ b/discovery_engine/lib/src/ffi/types/duration.dart
@@ -1,0 +1,50 @@
+// Copyright 2021 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustDuration;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+
+extension DurationFfi on Duration {
+  void writeNative(final Pointer<RustDuration> durationPlace) {
+    final nanos = (inMicroseconds % Duration.microsecondsPerSecond) * 1000;
+    ffi.init_duration_at(durationPlace, inSeconds, nanos);
+  }
+
+  /// Reads a dart [Duration] from a rust duration.
+  ///
+  /// Be aware that darts [Duration] has both less precision and  is more
+  /// limited wrt. the max duration as it stores the duration as a `int`
+  /// of microseconds.
+  ///
+  /// Sub microseconds precision will be ignored.
+  ///
+  /// In case of to large durations an exception will be throw.
+  ///
+  static Duration readNative(final Pointer<RustDuration> durationPlace) {
+    const maxDurationSeconds = 0x8637bd05af6;
+    final seconds = ffi.get_duration_seconds(durationPlace);
+    if (seconds > maxDurationSeconds) {
+      throw ArgumentError.value(
+        seconds,
+        'seconds',
+        'duration is bigger then what dart Duration supports',
+      );
+    }
+    final microseconds = ffi.get_duration_nanos(durationPlace) ~/ 1000;
+    return Duration(seconds: seconds, microseconds: microseconds);
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/duration.dart
+++ b/discovery_engine/lib/src/ffi/types/duration.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -27,15 +27,15 @@ extension DurationFfi on Duration {
   /// Reads a dart [Duration] from a rust duration.
   ///
   /// Be aware that darts [Duration] has both less precision and  is more
-  /// limited wrt. the max duration as it stores the duration as a `int`
+  /// limited wrt. the max duration as it stores the duration as an `int`
   /// of microseconds.
   ///
   /// Sub microseconds precision will be ignored.
   ///
-  /// In case of to large durations an exception will be throw.
-  ///
+  /// In case of a too large durations an exception will be throw.
   static Duration readNative(final Pointer<RustDuration> durationPlace) {
-    const maxDurationSeconds = 0x8637bd05af6;
+    const i64Max = 0x7fffffffffffffff;
+    const maxDurationSeconds = i64Max ~/ Duration.microsecondsPerSecond;
     final seconds = ffi.get_duration_seconds(durationPlace);
     if (seconds > maxDurationSeconds) {
       throw ArgumentError.value(

--- a/discovery_engine/test/ffi/types/duration_test.dart
+++ b/discovery_engine/test/ffi/types/duration_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Xayn AG
+// Copyright 2021 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -12,10 +12,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Modules containing FFI glue for various types.
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/duration.dart'
+    show DurationFfi;
 
-mod boxed;
-pub mod duration;
-pub mod slice;
-pub mod string;
-pub mod vec;
+void main() {
+  test('parsing written duration yields same result', () {
+    const duration = Duration(seconds: 4949, microseconds: 5012);
+    final place = ffi.alloc_uninitialized_duration_box();
+    duration.writeNative(place);
+    final res = DurationFfi.readNative(place);
+    ffi.drop_duration_box(place);
+    expect(res, equals(duration));
+  });
+}

--- a/discovery_engine/test/ffi/types/duration_test.dart
+++ b/discovery_engine/test/ffi/types/duration_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -18,12 +18,12 @@ import 'package:xayn_discovery_engine/src/ffi/types/duration.dart'
     show DurationFfi;
 
 void main() {
-  test('parsing written duration yields same result', () {
+  test('reading written duration yields same result', () {
     const duration = Duration(seconds: 4949, microseconds: 5012);
-    final place = ffi.alloc_uninitialized_duration_box();
+    final place = ffi.alloc_uninitialized_duration();
     duration.writeNative(place);
     final res = DurationFfi.readNative(place);
-    ffi.drop_duration_box(place);
+    ffi.drop_duration(place);
     expect(res, equals(duration));
   });
 }

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -2371,7 +2371,6 @@ dependencies = [
  "cbindgen",
  "heck 0.4.0",
  "ndarray",
- "rand 0.8.4",
  "uuid",
  "xayn-discovery-engine-core",
 ]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -12,7 +12,6 @@ uuid = "0.8.2"
 
 [dev-dependencies]
 async-bindgen-gen-dart = "0.1.0"
-rand = "0.8.4"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [build-dependencies]

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -8,10 +8,10 @@ no_includes = true
 
 header = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
-// (get added in follow up PRs), e.g. `typedef struct RustDuration RustDuration;`
+typedef struct RustDuration RustDuration;
 """
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
+"Duration" = "RustDuration"
 "String" = "RustString"
-

--- a/discovery_engine_core/bindings/src/types/duration.rs
+++ b/discovery_engine_core/bindings/src/types/duration.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-/// Initializes a `Duration` field at given place.
+/// Initializes a [`Duration`] field at given place.
 ///
 /// # Safety
 ///
@@ -34,8 +34,8 @@ pub unsafe extern "C" fn init_duration_at(place: *mut Duration, seconds: u64, na
 ///
 /// The pointer must point to a valid [`Duration`] instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_duration_seconds(place: *mut Duration) -> u64 {
-    unsafe { &*place }.as_secs()
+pub unsafe extern "C" fn get_duration_seconds(duration: *mut Duration) -> u64 {
+    unsafe { &*duration }.as_secs()
 }
 
 /// Gets the (subseconds) nanoseconds of a duration at given place.
@@ -44,17 +44,14 @@ pub unsafe extern "C" fn get_duration_seconds(place: *mut Duration) -> u64 {
 ///
 /// The pointer must point to a valid [`Duration`] instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_duration_nanos(place: *mut Duration) -> u32 {
-    unsafe { &*place }.subsec_nanos()
+pub unsafe extern "C" fn get_duration_nanos(duration: *mut Duration) -> u32 {
+    unsafe { &*duration }.subsec_nanos()
 }
 
 /// Alloc an uninitialized `Box<Duration>`, mainly used for testing.
-#[cfg(feature = "additional-ffi-methods")]
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_duration_box() -> *mut Duration {
-    use super::boxed::alloc_uninitialized_box;
-
-    alloc_uninitialized_box()
+pub extern "C" fn alloc_uninitialized_duration() -> *mut Duration {
+    super::boxed::alloc_uninitialized()
 }
 
 /// Drops a `Box<Duration>`, mainly used for testing.
@@ -62,23 +59,18 @@ pub extern "C" fn alloc_uninitialized_duration_box() -> *mut Duration {
 /// # Safety
 ///
 /// The pointer must represent a valid `Box<Duration>` instance.
-#[cfg(feature = "additional-ffi-methods")]
 #[no_mangle]
-pub unsafe extern "C" fn drop_duration_box(boxed: *mut Duration) {
-    use super::boxed::drop_box;
-
-    unsafe { drop_box(boxed) };
+pub unsafe extern "C" fn drop_duration(duration: *mut Duration) {
+   unsafe {  super::boxed::drop(duration) };
 }
 
 #[cfg(test)]
 mod tests {
-    use rand::random;
-
     use super::*;
 
     #[test]
     fn test_reading_duration() {
-        let place = &mut Duration::new(random(), random());
+        let place = &mut Duration::new(78978, 89378);
         let read = unsafe {
             let secs = get_duration_seconds(place);
             let nanos = get_duration_nanos(place);
@@ -89,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_writing_duration() {
-        let duration = Duration::new(random(), random());
+        let duration = Duration::new(78978, 89378);
         let place = &mut Duration::default();
         unsafe {
             init_duration_at(place, duration.as_secs(), duration.subsec_nanos());

--- a/discovery_engine_core/bindings/src/types/duration.rs
+++ b/discovery_engine_core/bindings/src/types/duration.rs
@@ -1,0 +1,97 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling `Duration` fields.
+
+use std::time::Duration;
+
+/// Initializes a `Duration` field at given place.
+///
+/// # Safety
+///
+/// It must be valid to write a [`Duration`] to given pointer.
+#[no_mangle]
+pub unsafe extern "C" fn init_duration_at(place: *mut Duration, seconds: u64, nanos: u32) {
+    unsafe {
+        place.write(Duration::new(seconds, nanos));
+    }
+}
+
+/// Gets the seconds of a duration at given place.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Duration`] instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_duration_seconds(place: *mut Duration) -> u64 {
+    unsafe { &*place }.as_secs()
+}
+
+/// Gets the (subseconds) nanoseconds of a duration at given place.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Duration`] instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_duration_nanos(place: *mut Duration) -> u32 {
+    unsafe { &*place }.subsec_nanos()
+}
+
+/// Alloc an uninitialized `Box<Duration>`, mainly used for testing.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_duration_box() -> *mut Duration {
+    use super::boxed::alloc_uninitialized_box;
+
+    alloc_uninitialized_box()
+}
+
+/// Drops a `Box<Duration>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Duration>` instance.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub unsafe extern "C" fn drop_duration_box(boxed: *mut Duration) {
+    use super::boxed::drop_box;
+
+    unsafe { drop_box(boxed) };
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::random;
+
+    use super::*;
+
+    #[test]
+    fn test_reading_duration() {
+        let place = &mut Duration::new(random(), random());
+        let read = unsafe {
+            let secs = get_duration_seconds(place);
+            let nanos = get_duration_nanos(place);
+            Duration::new(secs, nanos)
+        };
+        assert_eq!(read, *place);
+    }
+
+    #[test]
+    fn test_writing_duration() {
+        let duration = Duration::new(random(), random());
+        let place = &mut Duration::default();
+        unsafe {
+            init_duration_at(place, duration.as_secs(), duration.subsec_nanos());
+        }
+        assert_eq!(duration, *place);
+    }
+}

--- a/discovery_engine_core/bindings/src/types/duration.rs
+++ b/discovery_engine_core/bindings/src/types/duration.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 Xayn AG
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
 // published by the Free Software Foundation, version 3.

--- a/discovery_engine_core/bindings/src/types/duration.rs
+++ b/discovery_engine_core/bindings/src/types/duration.rs
@@ -61,7 +61,7 @@ pub extern "C" fn alloc_uninitialized_duration() -> *mut Duration {
 /// The pointer must represent a valid `Box<Duration>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_duration(duration: *mut Duration) {
-   unsafe {  super::boxed::drop(duration) };
+    unsafe { super::boxed::drop(duration) };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**References**

- [TY-2341](https://xainag.atlassian.net/browse/TY-2341)

**Preceded by**

- [TY-2320](https://xainag.atlassian.net/browse/TY-2320)

**Parallel too**

- [TY-2322](https://xainag.atlassian.net/browse/TY-2322)
- [TY-2340](https://xainag.atlassian.net/browse/TY-2340)

**Followed by**

- [TY-2342](https://xainag.atlassian.net/browse/TY-2342)
- [TY-2343](https://xainag.atlassian.net/browse/TY-2343)
- [TY-2344](https://xainag.atlassian.net/browse/TY-2344)

**summary**

adds bindings for `Duration`