### PR TITLE
[Merged by Bors] - TY-2322  UUID bindings [2.2]

### DIFF
--- a/discovery_engine/lib/src/ffi/types/uuid.dart
+++ b/discovery_engine/lib/src/ffi/types/uuid.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/discovery_engine/lib/src/ffi/types/uuid.dart
+++ b/discovery_engine/lib/src/ffi/types/uuid.dart
@@ -1,0 +1,73 @@
+// Copyright 2021 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer, Uint8Pointer;
+import 'dart:typed_data' show Uint8List;
+
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId, StackId;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustUuid;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+
+extension DocumentIdFfi on DocumentId {
+  void writeNative(final Pointer<RustUuid> place) {
+    _writeUuid(place, value);
+  }
+
+  static DocumentId readNative(final Pointer<RustUuid> place) {
+    return DocumentId.fromBytes(_readUuid(place));
+  }
+}
+
+extension StackIdFfi on StackId {
+  void writeNative(final Pointer<RustUuid> place) {
+    _writeUuid(place, value);
+  }
+
+  static StackId readNative(final Pointer<RustUuid> place) {
+    return StackId.fromBytes(_readUuid(place));
+  }
+}
+
+void _writeUuid(final Pointer<RustUuid> uuidPlace, final Uint8List id) {
+  if (id.length != 16) {
+    throw ArgumentError('uuid must have exactly 16 bytes');
+  }
+  ffi.init_uuid_at(
+    uuidPlace,
+    id[0],
+    id[1],
+    id[2],
+    id[3],
+    id[4],
+    id[5],
+    id[6],
+    id[7],
+    id[8],
+    id[9],
+    id[10],
+    id[11],
+    id[12],
+    id[13],
+    id[14],
+    id[15],
+  );
+}
+
+Uint8List _readUuid(final Pointer<RustUuid> uuidPlace) {
+  final beginOfData = ffi.get_uuid_bytes(uuidPlace);
+  final view = beginOfData.asTypedList(16);
+  return Uint8List.fromList(view);
+}

--- a/discovery_engine/test/ffi/types/uuid_test.dart
+++ b/discovery_engine/test/ffi/types/uuid_test.dart
@@ -22,7 +22,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
 void main() {
   test('reading written document id yields same result', () {
     final uuid = DocumentId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
-    final place = ffi.alloc_uninit_uuid();
+    final place = ffi.alloc_uninitialized_uuid();
     uuid.writeNative(place);
     final res = DocumentIdFfi.readNative(place);
     ffi.drop_uuid(place);
@@ -31,7 +31,7 @@ void main() {
 
   test('reading written stack id yields same result', () {
     final uuid = StackId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
-    final place = ffi.alloc_uninit_uuid();
+    final place = ffi.alloc_uninitialized_uuid();
     uuid.writeNative(place);
     final res = StackIdFfi.readNative(place);
     ffi.drop_uuid(place);

--- a/discovery_engine/test/ffi/types/uuid_test.dart
+++ b/discovery_engine/test/ffi/types/uuid_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2021 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart' show Uuid;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
+    show DocumentIdFfi, StackIdFfi;
+
+void main() {
+  test('parsing written document id yields same result', () {
+    final uuid = DocumentId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
+    final place = ffi.alloc_uninit_uuid_box();
+    uuid.writeNative(place);
+    final res = DocumentIdFfi.readNative(place);
+    ffi.drop_uuid_box(place);
+    expect(res, equals(uuid));
+  });
+
+  test('parsing written stack id yields same result', () {
+    final uuid = StackId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
+    final place = ffi.alloc_uninit_uuid_box();
+    uuid.writeNative(place);
+    final res = StackIdFfi.readNative(place);
+    ffi.drop_uuid_box(place);
+    expect(res, equals(uuid));
+  });
+}

--- a/discovery_engine/test/ffi/types/uuid_test.dart
+++ b/discovery_engine/test/ffi/types/uuid_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -20,21 +20,21 @@ import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
     show DocumentIdFfi, StackIdFfi;
 
 void main() {
-  test('parsing written document id yields same result', () {
+  test('reading written document id yields same result', () {
     final uuid = DocumentId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
-    final place = ffi.alloc_uninit_uuid_box();
+    final place = ffi.alloc_uninit_uuid();
     uuid.writeNative(place);
     final res = DocumentIdFfi.readNative(place);
-    ffi.drop_uuid_box(place);
+    ffi.drop_uuid(place);
     expect(res, equals(uuid));
   });
 
-  test('parsing written stack id yields same result', () {
+  test('reading written stack id yields same result', () {
     final uuid = StackId.fromBytes(Uuid.parseAsByteList(const Uuid().v4()));
-    final place = ffi.alloc_uninit_uuid_box();
+    final place = ffi.alloc_uninit_uuid();
     uuid.writeNative(place);
     final res = StackIdFfi.readNative(place);
-    ffi.drop_uuid_box(place);
+    ffi.drop_uuid(place);
     expect(res, equals(uuid));
   });
 }

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -9,9 +9,11 @@ no_includes = true
 header = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
 typedef struct RustDuration RustDuration;
+typedef struct RustUuid RustUuid;
 """
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
 "Duration" = "RustDuration"
 "String" = "RustString"
+"Uuid" = "RustUuid"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -18,4 +18,5 @@ mod boxed;
 pub mod duration;
 pub mod slice;
 pub mod string;
+pub mod uuid;
 pub mod vec;

--- a/discovery_engine_core/bindings/src/types/uuid.rs
+++ b/discovery_engine_core/bindings/src/types/uuid.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn init_uuid_at(
 ///
 /// # Safety
 ///
-/// The pointer must point to a initialized [`Uuid`].
+/// The pointer must point to an initialized [`Uuid`].
 #[no_mangle]
 pub unsafe extern "C" fn get_uuid_bytes(uuid: *mut Uuid) -> *const u8 {
     let uuid = unsafe { &*uuid };
@@ -73,7 +73,7 @@ pub extern "C" fn alloc_uninitialized_uuid() -> *mut Uuid {
 ///
 /// # Safety
 ///
-/// The pointer must represent a initialized `Box<Uuid>`.
+/// The pointer must represent an initialized `Box<Uuid>`.
 #[no_mangle]
 pub unsafe extern "C" fn drop_uuid(uuid: *mut Uuid) {
     unsafe { super::boxed::drop(uuid) }

--- a/discovery_engine_core/bindings/src/types/uuid.rs
+++ b/discovery_engine_core/bindings/src/types/uuid.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn get_uuid_bytes(uuid: *mut Uuid) -> *const u8 {
 
 /// Alloc an uninitialized `Box<Uuid>`, mainly used for testing.
 #[no_mangle]
-pub extern "C" fn alloc_uninit_uuid() -> *mut Uuid {
+pub extern "C" fn alloc_uninitialized_uuid() -> *mut Uuid {
     super::boxed::alloc_uninitialized()
 }
 
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_reading_writing_uuid_works() {
         let uuid = Uuid::new_v4();
-        let place = alloc_uninit_uuid();
+        let place = alloc_uninitialized_uuid();
         let b = uuid.as_bytes();
         unsafe {
             init_uuid_at(

--- a/discovery_engine_core/bindings/src/types/uuid.rs
+++ b/discovery_engine_core/bindings/src/types/uuid.rs
@@ -1,0 +1,135 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling `Uuid`
+
+use std::ptr;
+
+use uuid::Uuid;
+
+/// Creates a new UUID based on this byes (~ `[u8; 16]`).
+///
+/// The bytes are passed in as separate parameters as dart
+/// can't handle C values on the stack well.
+///
+/// # Safety
+///
+/// It must be valid to write an [`Uuid`] to given pointer.
+#[no_mangle]
+pub unsafe extern "C" fn init_uuid_at(
+    uuid_place: *mut Uuid,
+    b0: u8, //retarded, but the simplest solution wrt. the limitations of dart
+    b1: u8,
+    b2: u8,
+    b3: u8,
+    b4: u8,
+    b5: u8,
+    b6: u8,
+    b7: u8,
+    b8: u8,
+    b9: u8,
+    b10: u8,
+    b11: u8,
+    b12: u8,
+    b13: u8,
+    b14: u8,
+    b15: u8,
+) {
+    let uuid = Uuid::from_bytes([
+        b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15,
+    ]);
+    unsafe { ptr::write(uuid_place, uuid) }
+}
+
+/// Returns a pointer to the beginning of the 16 byte long byte slice.
+///
+/// # Safety
+///
+/// The pointer must point to a initialized [`Uuid`].
+#[no_mangle]
+pub unsafe extern "C" fn get_uuid_bytes(uuid_place: *mut Uuid) -> *const u8 {
+    let uuid = unsafe { &*uuid_place };
+    uuid.as_bytes().as_ptr()
+}
+
+/// Alloc an uninitialized `Box<Uuid>`, mainly used for testing.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub extern "C" fn alloc_uninit_uuid_box() -> *mut Uuid {
+    use super::boxed::alloc_uninitialized_box;
+
+    alloc_uninitialized_box()
+}
+
+/// Drops a `Box<Uuid>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a initialized `Box<Uuid>`.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub unsafe extern "C" fn drop_uuid_box(boxed: *mut Uuid) {
+    use super::boxed::drop_box;
+
+    unsafe { drop_box(boxed) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::slice;
+
+    use super::*;
+
+    #[test]
+    fn test_reading_uuid_works() {
+        let place = &mut Uuid::new_v4();
+        let read = unsafe {
+            let data_ptr = get_uuid_bytes(place);
+            Uuid::from_slice(slice::from_raw_parts(data_ptr, 16)).unwrap()
+        };
+        assert_eq!(*place, read);
+    }
+
+    #[test]
+    fn test_writing_uuid_works() {
+        let uuid = Uuid::new_v4();
+        let place = &mut Uuid::nil();
+        unsafe {
+            let b = uuid.as_bytes();
+            init_uuid_at(
+                place, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11],
+                b[12], b[13], b[14], b[15],
+            );
+        }
+        assert_eq!(uuid, *place);
+    }
+
+    #[test]
+    fn test_reading_writing_uuid_works() {
+        let uuid = Uuid::new_v4();
+        let place = alloc_uninit_uuid_box();
+        let b = uuid.as_bytes();
+        unsafe {
+            init_uuid_at(
+                place, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11],
+                b[12], b[13], b[14], b[15],
+            );
+        }
+        let got = unsafe {
+            let ptr = get_uuid_bytes(place);
+            Uuid::from_slice(slice::from_raw_parts(ptr, 16)).unwrap()
+        };
+        assert_eq!(uuid, got);
+    }
+}


### PR DESCRIPTION
**References**

- [TY-2322](https://xainag.atlassian.net/browse/TY-2322)

**Preceded by**

- [TY-2341](https://xainag.atlassian.net/browse/TY-2341)
- [TY-2340](https://xainag.atlassian.net/browse/TY-2340)

**Parallel too**

- [TY-2341](https://xainag.atlassian.net/browse/TY-2322)

**Followed by**

- [TY-2342](https://xainag.atlassian.net/browse/TY-2342)
- [TY-2343](https://xainag.atlassian.net/browse/TY-2343)
- [TY-2344](https://xainag.atlassian.net/browse/TY-2344)

**summary**

adds bindings for `Uuid`