### PR TITLE
[Merged by Bors] - TY-2340  embedding bindings [2.3]

### DIFF
--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -16,24 +16,24 @@ import 'dart:ffi' show Pointer, FloatPointer;
 import 'dart:typed_data' show Float32List;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
-    show RustEmbedding1;
+    show RustEmbedding;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 
-extension Embedding1Ffi on Float32List {
+extension EmbeddingFfi on Float32List {
   void writeNative(
-    final Pointer<RustEmbedding1> place,
+    final Pointer<RustEmbedding> place,
   ) {
     final len = length;
     final buffer = ffi.alloc_uninitialized_f32_slice(len);
     buffer.asTypedList(len).setAll(0, this);
-    ffi.init_embedding1_at(place, buffer, len);
+    ffi.init_embedding_at(place, buffer, len);
   }
 
   static Float32List readNative(
-    final Pointer<RustEmbedding1> place,
+    final Pointer<RustEmbedding> place,
   ) {
-    final len = ffi.get_embedding1_buffer_len(place);
-    final data = ffi.get_embedding1_buffer(place).asTypedList(len);
+    final len = ffi.get_embedding_buffer_len(place);
+    final data = ffi.get_embedding_buffer(place).asTypedList(len);
     return Float32List.fromList(data);
   }
 }

--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as

--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -1,0 +1,39 @@
+// Copyright 2021 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer, FloatPointer;
+import 'dart:typed_data' show Float32List;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustEmbedding1;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+
+extension Embedding1Ffi on Float32List {
+  void writeNative(
+    final Pointer<RustEmbedding1> place,
+  ) {
+    final len = length;
+    final buffer = ffi.alloc_uninitialized_f32_slice(len);
+    buffer.asTypedList(len).setAll(0, this);
+    ffi.init_embedding1_at(place, buffer, len);
+  }
+
+  static Float32List readNative(
+    final Pointer<RustEmbedding1> place,
+  ) {
+    final len = ffi.get_embedding1_buffer_len(place);
+    final data = ffi.get_embedding1_buffer(place).asTypedList(len);
+    return Float32List.fromList(data);
+  }
+}

--- a/discovery_engine/test/ffi/types/embedding_test.dart
+++ b/discovery_engine/test/ffi/types/embedding_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -20,22 +20,22 @@ import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
     show Embedding1Ffi;
 
 void main() {
-  test('parsing written empty embeddings works', () {
+  test('reading written empty embeddings works', () {
     final embedding = Float32List(0);
-    final place = ffi.alloc_uninitialized_embedding1_box();
+    final place = ffi.alloc_uninitialized_embedding1();
     embedding.writeNative(place);
     final res = Embedding1Ffi.readNative(place);
-    ffi.drop_embedding1_box(place);
+    ffi.drop_embedding1(place);
     expect(res, equals(embedding));
   });
 
-  test('parsing written embeddings yields same result', () {
+  test('reading written embeddings yields same result', () {
     final embedding =
         Float32List.fromList([18.4, 6.9, 13.2, 7.8945, 8.2, 0.3, 7.8, 9.479]);
-    final place = ffi.alloc_uninitialized_embedding1_box();
+    final place = ffi.alloc_uninitialized_embedding1();
     embedding.writeNative(place);
     final res = Embedding1Ffi.readNative(place);
-    ffi.drop_embedding1_box(place);
+    ffi.drop_embedding1(place);
     expect(res, equals(embedding));
   });
 }

--- a/discovery_engine/test/ffi/types/embedding_test.dart
+++ b/discovery_engine/test/ffi/types/embedding_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2021 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
+    show Embedding1Ffi;
+
+void main() {
+  test('parsing written empty embeddings works', () {
+    final embedding = Float32List(0);
+    final place = ffi.alloc_uninitialized_embedding1_box();
+    embedding.writeNative(place);
+    final res = Embedding1Ffi.readNative(place);
+    ffi.drop_embedding1_box(place);
+    expect(res, equals(embedding));
+  });
+
+  test('parsing written embeddings yields same result', () {
+    final embedding =
+        Float32List.fromList([18.4, 6.9, 13.2, 7.8945, 8.2, 0.3, 7.8, 9.479]);
+    final place = ffi.alloc_uninitialized_embedding1_box();
+    embedding.writeNative(place);
+    final res = Embedding1Ffi.readNative(place);
+    ffi.drop_embedding1_box(place);
+    expect(res, equals(embedding));
+  });
+}

--- a/discovery_engine/test/ffi/types/embedding_test.dart
+++ b/discovery_engine/test/ffi/types/embedding_test.dart
@@ -17,25 +17,25 @@ import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
-    show Embedding1Ffi;
+    show EmbeddingFfi;
 
 void main() {
   test('reading written empty embeddings works', () {
     final embedding = Float32List(0);
-    final place = ffi.alloc_uninitialized_embedding1();
+    final place = ffi.alloc_uninitialized_embedding();
     embedding.writeNative(place);
-    final res = Embedding1Ffi.readNative(place);
-    ffi.drop_embedding1(place);
+    final res = EmbeddingFfi.readNative(place);
+    ffi.drop_embedding(place);
     expect(res, equals(embedding));
   });
 
   test('reading written embeddings yields same result', () {
     final embedding =
         Float32List.fromList([18.4, 6.9, 13.2, 7.8945, 8.2, 0.3, 7.8, 9.479]);
-    final place = ffi.alloc_uninitialized_embedding1();
+    final place = ffi.alloc_uninitialized_embedding();
     embedding.writeNative(place);
-    final res = Embedding1Ffi.readNative(place);
-    ffi.drop_embedding1(place);
+    final res = EmbeddingFfi.readNative(place);
+    ffi.drop_embedding(place);
     expect(res, equals(embedding));
   });
 }

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -9,13 +9,13 @@ no_includes = true
 header = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
 typedef struct RustDuration RustDuration;
-typedef struct RustEmbedding1 RustEmbedding1;
+typedef struct RustEmbedding RustEmbedding;
 typedef struct RustUuid RustUuid;
 """
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
 "Duration" = "RustDuration"
-"Embedding1" = "RustEmbedding1"
+"Embedding" = "RustEmbedding"
 "String" = "RustString"
 "Uuid" = "RustUuid"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -9,11 +9,13 @@ no_includes = true
 header = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
 typedef struct RustDuration RustDuration;
+typedef struct RustEmbedding1 RustEmbedding1;
 typedef struct RustUuid RustUuid;
 """
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
 "Duration" = "RustDuration"
+"Embedding1" = "RustEmbedding1"
 "String" = "RustString"
 "Uuid" = "RustUuid"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -16,6 +16,7 @@
 
 mod boxed;
 pub mod duration;
+pub mod embedding;
 pub mod slice;
 pub mod string;
 pub mod uuid;

--- a/discovery_engine_core/bindings/src/types/embedding.rs
+++ b/discovery_engine_core/bindings/src/types/embedding.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 Xayn AG
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
 // published by the Free Software Foundation, version 3.

--- a/discovery_engine_core/bindings/src/types/embedding.rs
+++ b/discovery_engine_core/bindings/src/types/embedding.rs
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn get_embedding_buffer(embedding: *const Embedding) -> *c
 /// # Aborts
 ///
 /// Aborts if the embedding is not "contiguous and in standard order".
-//Note: Wether this is or isn't the case should (for our use case) be always
+//Note: Whether this is or isn't the case should (for our use case) be always
 // the same independent of input data. Hence this should be caught by
 // tests. If that isn't the case anymore it should be considered to
 // change this interface, e.g. to support reading a buffer with strides.

--- a/discovery_engine_core/bindings/src/types/embedding.rs
+++ b/discovery_engine_core/bindings/src/types/embedding.rs
@@ -1,0 +1,133 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling embeddings.
+
+use core::document::{Embedding, Embedding1};
+
+use ndarray::Array;
+
+use crate::types::slice::boxed_slice;
+
+/// Creates a rust `Embedding1` with given capacity at given memory address.
+///
+/// The `Embedding1` is created at given address, not it's content.
+///
+/// Returns a pointer to the begin of the buffer of the embedding.
+///
+/// # Safety
+///
+/// - It must be valid to write an `Embedding1` instance to given pointer.
+/// - The passed in slice must represent a `Box<[f32]>` and transfers ownership,
+///   it must be fully initialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_embedding1_at(
+    place: *mut Embedding1,
+    float_slice: *mut f32,
+    len: usize,
+) {
+    let vec = unsafe { boxed_slice::<f32>(float_slice, len).into() };
+    let embedding = Embedding(Array::from_vec(vec));
+    unsafe {
+        place.write(embedding);
+    }
+}
+
+/// Returns a pointer to the begin of the `[f32]` backing the `Embedding1`
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Embedding1`] instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_embedding1_buffer(place: *mut Embedding1) -> *mut f32 {
+    let embedding = unsafe { &mut *place };
+    embedding.0.as_mut_ptr()
+}
+
+/// Returns len of given embeddings buffer.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Embedding1`] instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_embedding1_buffer_len(place: *mut Embedding1) -> usize {
+    //WARNING: This holds for `Embedding1` but not for all possible `ndarray::Array<...>`.
+    unsafe { &*place }.len()
+}
+
+/// Alloc an uninitialized `Box<String>`, mainly used for testing.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_embedding1_box() -> *mut Embedding1 {
+    use super::boxed::alloc_uninitialized_box;
+
+    alloc_uninitialized_box()
+}
+
+/// Drops a `Box<String>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Embedding1>` instance.
+#[cfg(feature = "additional-ffi-methods")]
+#[no_mangle]
+pub unsafe extern "C" fn drop_embedding1_box(boxed: *mut Embedding1) {
+    use super::boxed::drop_box;
+
+    unsafe { drop_box(boxed) };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ptr, slice};
+
+    use ndarray::arr1;
+    use rand::{distributions::Standard, prelude::Distribution, thread_rng, Rng};
+
+    use crate::types::slice::alloc_uninitialized_f32_slice;
+
+    use super::*;
+
+    #[test]
+    fn test_reading_embedding1_works() {
+        let place = &mut random_embedding();
+        let read = unsafe {
+            let buffer_view = slice::from_raw_parts(
+                get_embedding1_buffer(place),
+                get_embedding1_buffer_len(place),
+            );
+            Embedding(Array::from_vec(buffer_view.to_owned()))
+        };
+        assert_eq!(place.0, read.0);
+    }
+
+    #[test]
+    fn test_writing_embedding1_works() {
+        let embedding = random_embedding();
+        let len = embedding.len();
+        let place: &mut Embedding1 = &mut Embedding(arr1(&[]));
+        unsafe {
+            let data_ptr = alloc_uninitialized_f32_slice(len);
+            ptr::copy(embedding.as_ptr(), data_ptr, len);
+            init_embedding1_at(place, data_ptr, len);
+        }
+        assert_eq!(embedding.0, place.0);
+    }
+
+    fn random_embedding() -> Embedding1 {
+        let rng = &mut thread_rng();
+        let len = rng.gen_range(1..1024);
+        Embedding(Array::from_vec(
+            Standard.sample_iter(rng).take(len).collect(),
+        ))
+    }
+}

--- a/discovery_engine_core/bindings/src/types/embedding.rs
+++ b/discovery_engine_core/bindings/src/types/embedding.rs
@@ -14,67 +14,66 @@
 
 //! FFI functions for handling embeddings.
 
-use core::document::{Embedding, Embedding1};
+use core::document::Embedding;
 
 use ndarray::Array;
 
 use crate::types::slice::boxed_slice_from_raw_parts;
 
-/// Creates a rust `Embedding1` with given capacity at given memory address.
+/// Creates a rust `Embedding` with given capacity at given memory address.
 ///
 /// # Safety
 ///
-/// - It must be valid to write an `Embedding1` instance to given pointer.
+/// - It must be valid to write an `Embedding` instance to given pointer.
 /// - The passed in slice must represent a `Box<[f32]>` and transfers ownership,
 ///   it must be fully initialized.
 #[no_mangle]
-pub unsafe extern "C" fn init_embedding1_at(
-    place: *mut Embedding1,
+pub unsafe extern "C" fn init_embedding_at(
+    place: *mut Embedding,
     owning_ptr: *mut f32,
     len: usize,
 ) {
     let vec = unsafe { boxed_slice_from_raw_parts::<f32>(owning_ptr, len).into() };
-    let embedding = Embedding(Array::from_vec(vec));
+    let embedding = Embedding::from(Array::from_vec(vec));
     unsafe {
         place.write(embedding);
     }
 }
 
-/// Returns a pointer to the begin of the `[f32]` backing the `Embedding1`
+/// Returns a pointer to the begin of the `[f32]` backing the `Embedding`
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid [`Embedding1`] instance.
+/// The pointer must point to a valid [`Embedding`] instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_embedding1_buffer(embedding: *mut Embedding1) -> *mut f32 {
-    let embedding = unsafe { &mut *embedding };
-    embedding.0.as_mut_ptr()
+pub unsafe extern "C" fn get_embedding_buffer(embedding: *const Embedding) -> *const f32 {
+    unsafe { &*embedding }.as_ptr()
 }
 
 /// Returns len of the given embedding.
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid [`Embedding1`] instance.
+/// The pointer must point to a valid [`Embedding`] instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_embedding1_buffer_len(embedding: *mut Embedding1) -> usize {
-    //WARNING: This holds for `Embedding1` but not for all possible `ndarray::Array<...>`.
+pub unsafe extern "C" fn get_embedding_buffer_len(embedding: *mut Embedding) -> usize {
+    //WARNING: This holds for `Embedding` but not for all possible `ndarray::Array<...>`.
     unsafe { &*embedding }.len()
 }
 
-/// Alloc an uninitialized `Box<Embedding1>`, mainly used for testing.
+/// Alloc an uninitialized `Box<Embedding>`, mainly used for testing.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_embedding1() -> *mut Embedding1 {
+pub extern "C" fn alloc_uninitialized_embedding() -> *mut Embedding {
     super::boxed::alloc_uninitialized()
 }
 
-/// Drops a `Box<Embedding1>`, mainly used for testing.
+/// Drops a `Box<Embedding>`, mainly used for testing.
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Embedding1>` instance.
+/// The pointer must represent a valid `Box<Embedding>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn drop_embedding1(embedding: *mut Embedding1) {
+pub unsafe extern "C" fn drop_embedding(embedding: *mut Embedding) {
     unsafe { super::boxed::drop(embedding) };
 }
 
@@ -89,32 +88,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_reading_embedding1_works() {
-        let place = &mut arbitrary_embeddig();
+    fn test_reading_embedding_works() {
+        let embedding = &mut arbitrary_embeddig();
         let read = unsafe {
             let buffer_view = slice::from_raw_parts(
-                get_embedding1_buffer(place),
-                get_embedding1_buffer_len(place),
+                get_embedding_buffer(embedding),
+                get_embedding_buffer_len(embedding),
             );
-            Embedding(Array::from_vec(buffer_view.to_owned()))
+            Embedding::from(Array::from_vec(buffer_view.to_owned()))
         };
-        assert_eq!(place.0, read.0);
+        assert_eq!(*read, *embedding);
     }
 
     #[test]
-    fn test_writing_embedding1_works() {
+    fn test_writing_embedding_works() {
         let embedding = arbitrary_embeddig();
         let len = embedding.len();
-        let place: &mut Embedding1 = &mut Embedding(arr1(&[]));
+        let place: &mut Embedding = &mut Embedding::from(arr1(&[]));
         unsafe {
             let data_ptr = alloc_uninitialized_f32_slice(len);
             ptr::copy(embedding.as_ptr(), data_ptr, len);
-            init_embedding1_at(place, data_ptr, len);
+            init_embedding_at(place, data_ptr, len);
         }
-        assert_eq!(embedding.0, place.0);
+        assert_eq!(*place, embedding);
     }
 
-    fn arbitrary_embeddig() -> Embedding1 {
-        Embedding(arr1(&[0.0, 1.2, 3.1, 0.4]))
+    fn arbitrary_embeddig() -> Embedding {
+        Embedding::from(arr1(&[0.0, 1.2, 3.1, 0.4]))
     }
 }

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -27,11 +27,12 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
-use xayn_ai::ranker::Embedding;
 
 use xayn_discovery_engine_providers::Article;
 
 use crate::stack::Id as StackId;
+
+pub use xayn_ai::ranker::Embedding;
 
 /// Errors that could happen when constructing a [`Document`].
 #[derive(Error, Debug, DisplayDoc)]


### PR DESCRIPTION
**References**

- [TY-2340](https://xainag.atlassian.net/browse/TY-2340)

**Preceded by**

- [TY-2320](https://xainag.atlassian.net/browse/TY-2320)

**Parallel too**

- [TY-2322](https://xainag.atlassian.net/browse/TY-2322)
- [TY-2341](https://xainag.atlassian.net/browse/TY-2341)

**Followed by**

- [TY-2342](https://xainag.atlassian.net/browse/TY-2342)
- [TY-2343](https://xainag.atlassian.net/browse/TY-2343)
- [TY-2344](https://xainag.atlassian.net/browse/TY-2344)

**summary**

adds bindings for `Embedding1`