### PR TITLE
[Merged by Bors] - TY-2304 create engine from config

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -67,8 +67,12 @@ pub struct Config {
     api_key: String,
     api_base_url: String,
     markets: Vec<Market>,
-    smbert_vocab: Vec<u8>,
-    smbert_model: Vec<u8>,
+    smbert_vocab: String,
+    smbert_model: String,
+    kpe_vocab: String,
+    kpe_model: String,
+    kpe_cnn: String,
+    kpe_classifier: String,
 }
 
 /// Discovery Engine.

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -54,8 +54,27 @@ pub enum Error {
     Errors(Vec<Error>),
 }
 
+#[allow(dead_code)]
+/// Feed market.
+struct Market {
+    country_code: String,
+    lang_code: String,
+}
+
+#[allow(dead_code)]
+/// Discovery Engine configuration settings.
+pub struct Config {
+    api_key: String,
+    api_base_url: String,
+    markets: Vec<Market>,
+    smbert_vocab: Vec<u8>,
+    smbert_model: Vec<u8>,
+}
+
 /// Discovery Engine.
 pub struct Engine<R> {
+    #[allow(dead_code)]
+    config: Config,
     stacks: HashMap<StackId, Stack>,
     ranker: R,
 }
@@ -64,11 +83,25 @@ impl<R> Engine<R>
 where
     R: Ranker,
 {
+    /// Creates a new `Engine` from configuration.
+    pub fn from_config(config: Config, ranker: R) -> Self {
+        Self {
+            config,
+            stacks: HashMap::new(), // FIXME check
+            ranker,
+        }
+    }
+
     /// Creates a new `Engine` from serialized state and stack operations.
     ///
     /// The `Engine` only keeps in its state data related to the current [`BoxedOps`].
     /// Data related to missing operations will be dropped.
-    pub fn new(state: &[u8], ranker: R, stacks_ops: Vec<BoxedOps>) -> Result<Self, Error> {
+    pub fn new(
+        state: &[u8],
+        config: Config, // FIXME part of state?
+        ranker: R,
+        stacks_ops: Vec<BoxedOps>,
+    ) -> Result<Self, Error> {
         if stacks_ops.is_empty() {
             return Err(Error::NoStackOps);
         }
@@ -87,7 +120,11 @@ where
             .collect::<Result<_, _>>()
             .map_err(Error::InvalidStack)?;
 
-        Ok(Engine { stacks, ranker })
+        Ok(Engine {
+            config,
+            stacks,
+            ranker,
+        })
     }
 
     /// Serializes the state of the `Engine`.


### PR DESCRIPTION
**Summary**

adds a `Config` struct and an `Engine` constructor method `from_config`, which initializes the stacks.
it takes a `Ranker` for now, but this will be constructed as well later.