### PR TITLE
[Merged by Bors] - TY-2347 More relaxed freezed objects exports

### DIFF
--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -44,10 +44,8 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         ClientEventSucceeded,
         EngineExceptionRaised,
         EngineExceptionReason;
-export 'package:xayn_discovery_engine/src/api/models/document.dart'
-    show Document;
-export 'package:xayn_discovery_engine/src/domain/models/configuration.dart'
-    show Configuration;
+export 'package:xayn_discovery_engine/src/api/models/document.dart';
+export 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
 export 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show DocumentFeedback;
 export 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'


### PR DESCRIPTION
[Jira ref](https://xainag.atlassian.net/browse/TY-2347)

This PR uses more relaxed exports for classes that use freezed package to ensure that consumers of the package that also use freezed with our models can use them without any issues, like `Error: Type '$ModelCopyWith' not found.`, etc.