### PR TITLE
[Merged by Bors] - Fix versions and gradle

### DIFF
--- a/discovery_engine_flutter/example/android/app/build.gradle
+++ b/discovery_engine_flutter/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 30
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,7 +45,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.xayn_discovery_engine_flutter_example"
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/discovery_engine_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/discovery_engine_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     package="com.example.xayn_discovery_engine_flutter_example">
    <application
         android:label="xayn_discovery_engine_flutter_example"
-        android:name="${applicationName}"
+        android:name="xayn_discovery_engine_flutter_example"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -7,13 +7,13 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   async_bindgen_dart_utils:
     dependency: transitive
     description:
       path: async_bindgen_dart_utils
       ref: HEAD
-      resolved-ref: "2023676c9f9cd8f0b703fb3c62cd75ead1447239"
+      resolved-ref: "0901318ff74f4afd59c606121ab3966b4bdcaaa3"
       url: "https://github.com/xaynetwork/xayn_async_bindgen.git"
     source: git
     version: "0.1.0"
@@ -30,7 +30,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -159,7 +159,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -220,7 +220,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -248,7 +248,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   xayn_discovery_engine:
     dependency: "direct overridden"
     description:
@@ -264,5 +264,5 @@ packages:
     source: path
     version: "0.1.0"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.14.4 <3.0.0"
   flutter: ">=2.5.0"

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the xayn_discovery_engine_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.14.2 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.14.2 <3.0.0"
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
Change dart sdk version to match the one we are using in the dart only project.

The properties `flutter.compileSdkVersion` and `flutter.targetSdkVersionis`  are only available in flutter > 2.8; the value `30` is what is generated when we create a new flutter plugin with flutter 2.5 and is the same value the app is using.

In the manifest the full name is used instead of the place holder.