### PR TITLE
[Merged by Bors] - TY-2342, TY-2345 ffi Document, NewsResource

### DIFF
--- a/discovery_engine/lib/src/ffi/types/document/document.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document.dart
@@ -1,0 +1,90 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer, Uint64Pointer;
+import 'dart:typed_data' show Float32List;
+
+import 'package:equatable/equatable.dart' show EquatableMixin;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId, StackId;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustDocument;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
+    show EmbeddingFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
+    show DocumentIdFfi, StackIdFfi;
+
+//FIXME dart Document model and rust Document are not at all in sync
+//  once in sync we could use an extension block
+class Document with EquatableMixin {
+  final DocumentId id;
+  final StackId stackId;
+  final int rank;
+  final String title;
+  final String snipped;
+  final String url;
+  final String domain;
+  final Float32List smbertEmbedding;
+
+  Document({
+    required this.id,
+    required this.stackId,
+    required this.rank,
+    required this.title,
+    required this.snipped,
+    required this.url,
+    required this.domain,
+    required this.smbertEmbedding,
+  });
+
+  factory Document.readFrom(final Pointer<RustDocument> place) {
+    return Document(
+      id: DocumentIdFfi.readNative(ffi.document_place_of_id(place)),
+      stackId: StackIdFfi.readNative(ffi.document_place_of_stack_id(place)),
+      rank: ffi.document_place_of_rank(place).value,
+      title: StringFfi.readNative(ffi.document_place_of_title(place)),
+      snipped: StringFfi.readNative(ffi.document_place_of_snipped(place)),
+      url: StringFfi.readNative(ffi.document_place_of_url(place)),
+      domain: StringFfi.readNative(ffi.document_place_of_domain(place)),
+      smbertEmbedding: EmbeddingFfi.readNative(
+        ffi.document_place_of_smbert_embedding(place),
+      ),
+    );
+  }
+
+  void writeTo(final Pointer<RustDocument> place) {
+    id.writeNative(ffi.document_place_of_id(place));
+    stackId.writeNative(ffi.document_place_of_stack_id(place));
+    ffi.document_place_of_rank(place).value = rank;
+    title.writeNative(ffi.document_place_of_title(place));
+    snipped.writeNative(ffi.document_place_of_snipped(place));
+    url.writeNative(ffi.document_place_of_url(place));
+    domain.writeNative(ffi.document_place_of_domain(place));
+    smbertEmbedding.writeNative(ffi.document_place_of_smbert_embedding(place));
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        stackId,
+        rank,
+        title,
+        snipped,
+        url,
+        domain,
+        smbertEmbedding,
+      ];
+}

--- a/discovery_engine/lib/src/ffi/types/document/document.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document.dart
@@ -12,79 +12,54 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show Pointer, Uint64Pointer;
+import 'dart:ffi' show Pointer;
 import 'dart:typed_data' show Float32List;
 
 import 'package:equatable/equatable.dart' show EquatableMixin;
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart';
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustDocument;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/news_resource.dart';
 import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
     show EmbeddingFfi;
-import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
     show DocumentIdFfi, StackIdFfi;
 
-//FIXME dart Document model and rust Document are not at all in sync
-//  once in sync we could use an extension block
-class Document with EquatableMixin {
+class DocumentFfi with EquatableMixin {
   final DocumentId id;
   final StackId stackId;
-  final int rank;
-  final String title;
-  final String snipped;
-  final String url;
-  final String domain;
   final Float32List smbertEmbedding;
+  final NewsResource resource;
 
-  Document({
+  DocumentFfi({
     required this.id,
     required this.stackId,
-    required this.rank,
-    required this.title,
-    required this.snipped,
-    required this.url,
-    required this.domain,
     required this.smbertEmbedding,
+    required this.resource,
   });
 
-  factory Document.readFrom(final Pointer<RustDocument> place) {
-    return Document(
+  factory DocumentFfi.readNative(final Pointer<RustDocument> place) {
+    return DocumentFfi(
       id: DocumentIdFfi.readNative(ffi.document_place_of_id(place)),
       stackId: StackIdFfi.readNative(ffi.document_place_of_stack_id(place)),
-      rank: ffi.document_place_of_rank(place).value,
-      title: StringFfi.readNative(ffi.document_place_of_title(place)),
-      snipped: StringFfi.readNative(ffi.document_place_of_snipped(place)),
-      url: StringFfi.readNative(ffi.document_place_of_url(place)),
-      domain: StringFfi.readNative(ffi.document_place_of_domain(place)),
       smbertEmbedding: EmbeddingFfi.readNative(
         ffi.document_place_of_smbert_embedding(place),
       ),
+      resource:
+          NewsResourceFfi.readNative(ffi.document_place_of_resource(place)),
     );
   }
 
-  void writeTo(final Pointer<RustDocument> place) {
+  void writeNative(final Pointer<RustDocument> place) {
     id.writeNative(ffi.document_place_of_id(place));
     stackId.writeNative(ffi.document_place_of_stack_id(place));
-    ffi.document_place_of_rank(place).value = rank;
-    title.writeNative(ffi.document_place_of_title(place));
-    snipped.writeNative(ffi.document_place_of_snipped(place));
-    url.writeNative(ffi.document_place_of_url(place));
-    domain.writeNative(ffi.document_place_of_domain(place));
     smbertEmbedding.writeNative(ffi.document_place_of_smbert_embedding(place));
+    resource.writeNative(ffi.document_place_of_resource(place));
   }
 
   @override
-  List<Object?> get props => [
-        id,
-        stackId,
-        rank,
-        title,
-        snipped,
-        url,
-        domain,
-        smbertEmbedding,
-      ];
+  List<Object?> get props => [id, stackId, smbertEmbedding, resource];
 }

--- a/discovery_engine/lib/src/ffi/types/document/document_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document_vec.dart
@@ -1,0 +1,70 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustDocument, RustDocumentVec;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart';
+
+extension DocumentSliceFfi on List<Document> {
+  /// Allocates a slice of documents containing all document of this list.
+  ///
+  /// We expect the length of this list to be passed in.
+  ///
+  //Note: The len arguments makes sure the len you use with the slice and
+  //      the len you create it with are the same, alternatively returning
+  //      a `Pair` or custom type could be done.
+  Pointer<RustDocument> createSlice(final int len) {
+    if (len != length) {
+      throw ArgumentError.value(len, 'len', 'len must match length');
+    }
+    final slice = ffi.alloc_uninitialized_document_slice(len);
+    var nextElement = slice;
+    for (final document in this) {
+      document.writeTo(nextElement);
+      nextElement = ffi.next_document(nextElement);
+    }
+    return slice;
+  }
+
+  static List<Document> readSlice(
+    final Pointer<RustDocument> slice,
+    final int len,
+  ) {
+    final out = <Document>[];
+    for (var c = 0, next = slice;
+        c < len;
+        c++, next = ffi.next_document(next)) {
+      out.add(Document.readFrom(next));
+    }
+    return out;
+  }
+
+  /// Consumes a `Box<Vec<Document>>` returned form rust.
+  ///
+  /// The additional indirection is necessary due to dart
+  /// not handling custom non-boxed, non-primitive return
+  /// types well.
+  static List<Document> consumeBoxedVector(
+    Pointer<RustDocumentVec> boxedVec,
+  ) {
+    final len = ffi.get_document_vec_len(boxedVec);
+    final slice = ffi.get_document_vec_buffer(boxedVec);
+    final res = readSlice(slice, len);
+    ffi.drop_document_vec(boxedVec);
+    return res;
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/document/news_resource.dart
+++ b/discovery_engine/lib/src/ffi/types/document/news_resource.dart
@@ -1,0 +1,74 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer, Uint64Pointer;
+
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
+    show NewsResource;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustNewsResource;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/date_time.dart'
+    show NaiveDateTimeFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uri.dart' show UriFfi;
+
+extension NewsResourceFfi on NewsResource {
+  void writeNative(Pointer<RustNewsResource> place) {
+    title.writeNative(ffi.news_resource_place_of_title(place));
+    snippet.writeNative(ffi.news_resource_place_of_snippet(place));
+    url.writeNative(ffi.news_resource_place_of_url(place));
+    sourceUrl.writeNative(ffi.news_resource_place_of_source_url(place));
+    UriFfi.writeNativeOption(
+      thumbnail,
+      ffi.news_resource_place_of_thumbnail(place),
+    );
+    datePublished.writeNative(ffi.news_resource_place_of_date_published(place));
+    ffi.news_resource_place_of_rank(place).value = rank;
+    PrimitivesFfi.writeNativeOptionF32(
+      score,
+      ffi.news_resource_place_of_score(place),
+    );
+    country.writeNative(ffi.news_resource_place_of_country(place));
+    language.writeNative(ffi.news_resource_place_of_language(place));
+    topic.writeNative(ffi.news_resource_place_of_topic(place));
+  }
+
+  static NewsResource readNative(Pointer<RustNewsResource> resource) {
+    return NewsResource(
+      title: StringFfi.readNative(ffi.news_resource_place_of_title(resource)),
+      snippet:
+          StringFfi.readNative(ffi.news_resource_place_of_snippet(resource)),
+      url: UriFfi.readNative(ffi.news_resource_place_of_url(resource)),
+      sourceUrl:
+          UriFfi.readNative(ffi.news_resource_place_of_source_url(resource)),
+      thumbnail: UriFfi.readNativeOption(
+        ffi.news_resource_place_of_thumbnail(resource),
+      ),
+      datePublished: NaiveDateTimeFfi.readNative(
+        ffi.news_resource_place_of_date_published(resource),
+      ),
+      rank: ffi.news_resource_place_of_rank(resource).value,
+      score: PrimitivesFfi.readNativeOptionF32(
+        ffi.news_resource_place_of_score(resource),
+      ),
+      country:
+          StringFfi.readNative(ffi.news_resource_place_of_country(resource)),
+      language:
+          StringFfi.readNative(ffi.news_resource_place_of_language(resource)),
+      topic: StringFfi.readNative(ffi.news_resource_place_of_topic(resource)),
+    );
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/primitives.dart
+++ b/discovery_engine/lib/src/ffi/types/primitives.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show FloatPointer, Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustOptionF32;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+
+class PrimitivesFfi {
+  static void writeNativeOptionF32(
+    double? value,
+    Pointer<RustOptionF32> place,
+  ) {
+    if (value == null) {
+      ffi.init_none_f32_at(place);
+    } else {
+      ffi.init_some_f32_at(place, value);
+    }
+  }
+
+  static double? readNativeOptionF32(Pointer<RustOptionF32> option) {
+    final ptr = ffi.get_option_f32_some(option);
+    if (ptr.address == 0) {
+      return null;
+    } else {
+      return ptr.value;
+    }
+  }
+}

--- a/discovery_engine/test/ffi/types/document/document_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data' show Float32List;
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId, StackId;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart'
+    show Document;
+
+void main() {
+  test('reading and written a document', () {
+    final document = Document(
+      id: DocumentId(),
+      stackId: StackId(),
+      rank: 12,
+      title: 'Dodo Mania',
+      snipped: 'Cloning bought back the dodo.',
+      url: 'htts://foo.example/bar',
+      domain: 'foo.example',
+      smbertEmbedding: Float32List.fromList([.9, .1]),
+    );
+    final place = ffi.alloc_uninitialized_document();
+    document.writeTo(place);
+    final res = Document.readFrom(place);
+    ffi.drop_document(place);
+    expect(res, equals(document));
+  });
+}

--- a/discovery_engine/test/ffi/types/document/document_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_test.dart
@@ -15,27 +15,37 @@
 import 'dart:typed_data' show Float32List;
 
 import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
+    show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart'
-    show Document;
+    show DocumentFfi;
 
 void main() {
   test('reading and written a document', () {
-    final document = Document(
+    final document = DocumentFfi(
       id: DocumentId(),
       stackId: StackId(),
-      rank: 12,
-      title: 'Dodo Mania',
-      snipped: 'Cloning bought back the dodo.',
-      url: 'htts://foo.example/bar',
-      domain: 'foo.example',
       smbertEmbedding: Float32List.fromList([.9, .1]),
+      resource: NewsResource(
+        title: 'fun',
+        snippet: 'fun is fun',
+        url: Uri.parse('https://www.foobar.example/dodo'),
+        sourceUrl: Uri.parse('yyy://www.example/'),
+        thumbnail: null,
+        datePublished: DateTime.now(),
+        rank: 12,
+        score: 32.5,
+        country: 'Germany',
+        language: 'German',
+        topic: 'FunFun',
+      ),
     );
     final place = ffi.alloc_uninitialized_document();
-    document.writeTo(place);
-    final res = Document.readFrom(place);
+    document.writeNative(place);
+    final res = DocumentFfi.readNative(place);
     ffi.drop_document(place);
     expect(res, equals(document));
   });

--- a/discovery_engine/test/ffi/types/document/document_vec_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_vec_test.dart
@@ -15,6 +15,7 @@
 import 'dart:typed_data' show Float32List;
 
 import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart';
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
@@ -24,32 +25,48 @@ import 'package:xayn_discovery_engine/src/ffi/types/document/document_vec.dart'
 
 void main() {
   test('reading and writing a list of documents', () {
-    final documents = <Document>[
-      Document(
+    final documents = <DocumentFfi>[
+      DocumentFfi(
         id: DocumentId(),
         stackId: StackId(),
-        rank: 12,
-        title: 'Dodo Mania',
-        snipped: 'Cloning bought back the dodo.',
-        url: 'htts://foo.example/bar',
-        domain: 'foo.example',
         smbertEmbedding: Float32List.fromList([.9, .1]),
+        resource: NewsResource(
+          title: 'fun',
+          snippet: 'fun is fun',
+          url: Uri.parse('https://www.foobar.example/dodo'),
+          sourceUrl: Uri.parse('yyy://www.example'),
+          thumbnail: null,
+          datePublished: DateTime.now(),
+          rank: 12,
+          score: 32.625,
+          country: 'Germany',
+          language: 'German',
+          topic: 'FunFun',
+        ),
       ),
-      Document(
+      DocumentFfi(
         id: DocumentId(),
         stackId: StackId(),
-        rank: 1,
-        title: 'Foobar',
-        snipped: 'bar foo',
-        url: 'htts://dodo.example/bird',
-        domain: 'dodo.example',
-        smbertEmbedding: Float32List.fromList([.1]),
-      )
+        smbertEmbedding: Float32List.fromList([9, 1]),
+        resource: NewsResource(
+          title: 'bun',
+          snippet: 'foo bar',
+          url: Uri.parse('https://www.barfoot.example/dodo'),
+          sourceUrl: Uri.parse('yyy://fuu.example'),
+          thumbnail: Uri.parse('https://dodo.example/'),
+          datePublished: DateTime.now(),
+          rank: 12,
+          score: 2.125,
+          country: 'Germany',
+          language: 'German',
+          topic: 'FunFun',
+        ),
+      ),
     ];
     final len = documents.length;
-    final slice = documents.createSlice(len);
-    final res = DocumentSliceFfi.readSlice(slice, len);
-    ffi.drop_document_slice(slice, len);
+    final ptr = documents.createSlice();
+    final res = DocumentSliceFfi.readSlice(ptr, len);
+    ffi.drop_document_slice(ptr, len);
     expect(res, equals(documents));
   });
 }

--- a/discovery_engine/test/ffi/types/document/document_vec_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_vec_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data' show Float32List;
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId, StackId;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/document/document_vec.dart'
+    show DocumentSliceFfi;
+
+void main() {
+  test('reading and writing a list of documents', () {
+    final documents = <Document>[
+      Document(
+        id: DocumentId(),
+        stackId: StackId(),
+        rank: 12,
+        title: 'Dodo Mania',
+        snipped: 'Cloning bought back the dodo.',
+        url: 'htts://foo.example/bar',
+        domain: 'foo.example',
+        smbertEmbedding: Float32List.fromList([.9, .1]),
+      ),
+      Document(
+        id: DocumentId(),
+        stackId: StackId(),
+        rank: 1,
+        title: 'Foobar',
+        snipped: 'bar foo',
+        url: 'htts://dodo.example/bird',
+        domain: 'dodo.example',
+        smbertEmbedding: Float32List.fromList([.1]),
+      )
+    ];
+    final len = documents.length;
+    final slice = documents.createSlice(len);
+    final res = DocumentSliceFfi.readSlice(slice, len);
+    ffi.drop_document_slice(slice, len);
+    expect(res, equals(documents));
+  });
+}

--- a/discovery_engine/test/ffi/types/document/news_resource_test.dart
+++ b/discovery_engine/test/ffi/types/document/news_resource_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
+    show NewsResource;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/news_resource.dart'
+    show NewsResourceFfi;
+
+void main() {
+  test('reading and written a document', () {
+    final resource = NewsResource(
+      title: 'fun',
+      snippet: 'fun is fun',
+      url: Uri.parse('https://www.foobar.example/dodo'),
+      sourceUrl: Uri.parse('yyy://www.example/'),
+      thumbnail: null,
+      datePublished: DateTime.now(),
+      rank: 12,
+      score: 32.25,
+      country: 'Germany',
+      language: 'German',
+      topic: 'FunFun',
+    );
+    final place = ffi.alloc_uninitialized_news_resource();
+    resource.writeNative(place);
+    final res = NewsResourceFfi.readNative(place);
+    ffi.drop_news_resource(place);
+    expect(res, equals(resource));
+  });
+}

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -31,6 +31,7 @@ include = ["xayn-discovery-engine-core"]
 "Embedding" = "RustEmbedding"
 "NaiveDateTime" = "RustNaiveDateTime"
 "NewsResource" = "RustNewsResource"
+"Option_f32" = "RustOptionF32"
 "Option_Url" = "RustOptionUrl"
 "String" = "RustString"
 "TimeSpent" = "RustTimeSpent"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -12,6 +12,7 @@ typedef struct RustDocument RustDocument;
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;
 typedef struct RustNaiveDateTime RustNaiveDateTime;
+typedef struct RustNewsResource RustNewsResource;
 typedef struct RustTimeSpent RustTimeSpent;
 typedef struct RustUrl RustUrl;
 typedef struct RustUserReacted RustUserReacted;
@@ -29,6 +30,7 @@ include = ["xayn-discovery-engine-core"]
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
 "NaiveDateTime" = "RustNaiveDateTime"
+"NewsResource" = "RustNewsResource"
 "Option_Url" = "RustOptionUrl"
 "String" = "RustString"
 "TimeSpent" = "RustTimeSpent"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -8,6 +8,7 @@ no_includes = true
 
 after_includes = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
+typedef struct RustDocument RustDocument;
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;
 typedef struct RustNaiveDateTime RustNaiveDateTime;
@@ -23,6 +24,8 @@ include = ["xayn-discovery-engine-core"]
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
+"Document" = "RustDocument"
+"Vec_Document" = "RustDocumentVec"
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
 "NaiveDateTime" = "RustNaiveDateTime"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -20,6 +20,7 @@ pub mod document;
 pub mod duration;
 pub mod embedding;
 pub mod option;
+pub mod primitives;
 pub mod slice;
 pub mod string;
 pub mod url;

--- a/discovery_engine_core/bindings/src/types/document.rs
+++ b/discovery_engine_core/bindings/src/types/document.rs
@@ -14,10 +14,15 @@
 
 //! FFI functions for handling types from the document module.
 
-mod time_spent;
+#[allow(clippy::module_inception)]
+mod document;
+mod document_vec;
 mod user_reacted;
 mod user_reaction;
+mod time_spent;
 
-pub use time_spent::*;
+pub use document::*;
+pub use document_vec::*;
 pub use user_reacted::*;
 pub use user_reaction::*;
+pub use time_spent::*;

--- a/discovery_engine_core/bindings/src/types/document.rs
+++ b/discovery_engine_core/bindings/src/types/document.rs
@@ -17,12 +17,14 @@
 #[allow(clippy::module_inception)]
 mod document;
 mod document_vec;
+mod news_resource;
+mod time_spent;
 mod user_reacted;
 mod user_reaction;
-mod time_spent;
 
 pub use document::*;
 pub use document_vec::*;
+pub use news_resource::*;
+pub use time_spent::*;
 pub use user_reacted::*;
 pub use user_reaction::*;
-pub use time_spent::*;

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -1,0 +1,126 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling documents.
+
+use core::document::{Document, Embedding};
+use std::ptr::addr_of_mut;
+
+use uuid::Uuid;
+
+/// Returns a pointer to the `id` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_id(place: *mut Document) -> *mut Uuid {
+    unsafe { addr_of_mut!((*place).id.0) }
+}
+
+/// Returns a pointer to the `stack_id` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_stack_id(place: *mut Document) -> *mut Uuid {
+    unsafe { addr_of_mut!((*place).stack_id.0) }
+}
+
+/// Returns a pointer to the `rank` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_rank(place: *mut Document) -> *mut usize {
+    unsafe { addr_of_mut!((*place).rank) }
+}
+
+/// Returns a pointer to the `title` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_title(place: *mut Document) -> *mut String {
+    unsafe { addr_of_mut!((*place).title) }
+}
+
+/// Returns a pointer to the `snipped` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_snipped(place: *mut Document) -> *mut String {
+    unsafe { addr_of_mut!((*place).snippet) }
+}
+
+/// Returns a pointer to the `url` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_url(place: *mut Document) -> *mut String {
+    unsafe { addr_of_mut!((*place).url) }
+}
+
+/// Returns a pointer to the `domain` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_domain(place: *mut Document) -> *mut String {
+    unsafe { addr_of_mut!((*place).domain) }
+}
+
+/// Returns a pointer to the `smbert_embedding` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_smbert_embedding(
+    place: *mut Document,
+) -> *mut Embedding {
+    unsafe { addr_of_mut!((*place).smbert_embedding) }
+}
+
+/// Alloc an uninitialized `Box<Document>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_document() -> *mut Document {
+    crate::types::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<Document>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Document>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_document(document: *mut Document) {
+    unsafe { crate::types::boxed::drop(document) };
+}

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -61,12 +61,9 @@ pub unsafe extern "C" fn document_place_of_smbert_embedding(
 /// The pointer must point to a valid [`Document`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn document_place_of_resource(
-    place: *mut Document,
-) -> *mut NewsResource {
+pub unsafe extern "C" fn document_place_of_resource(place: *mut Document) -> *mut NewsResource {
     unsafe { addr_of_mut!((*place).resource) }
 }
-
 
 /// Alloc an uninitialized `Box<Document>`, mainly used for testing.
 #[no_mangle]

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 /// it might be uninitialized.
 #[no_mangle]
 pub unsafe extern "C" fn document_place_of_id(place: *mut Document) -> *mut Uuid {
-    unsafe { addr_of_mut!((*place).id.0) }
+    unsafe { addr_of_mut!((*place).id) }.cast::<Uuid>()
 }
 
 /// Returns a pointer to the `stack_id` field of a document.
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn document_place_of_id(place: *mut Document) -> *mut Uuid
 /// it might be uninitialized.
 #[no_mangle]
 pub unsafe extern "C" fn document_place_of_stack_id(place: *mut Document) -> *mut Uuid {
-    unsafe { addr_of_mut!((*place).stack_id.0) }
+    unsafe { addr_of_mut!((*place).stack_id) }.cast::<Uuid>()
 }
 
 /// Returns a pointer to the `smbert_embedding` field of a document.

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -14,10 +14,11 @@
 
 //! FFI functions for handling documents.
 
-use core::document::{Document, Embedding, NewsResource};
 use std::ptr::addr_of_mut;
 
 use uuid::Uuid;
+
+use core::document::{Document, Embedding, NewsResource};
 
 /// Returns a pointer to the `id` field of a document.
 ///

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -14,7 +14,7 @@
 
 //! FFI functions for handling documents.
 
-use core::document::{Document, Embedding};
+use core::document::{Document, Embedding, NewsResource};
 use std::ptr::addr_of_mut;
 
 use uuid::Uuid;
@@ -41,61 +41,6 @@ pub unsafe extern "C" fn document_place_of_stack_id(place: *mut Document) -> *mu
     unsafe { addr_of_mut!((*place).stack_id.0) }
 }
 
-/// Returns a pointer to the `rank` field of a document.
-///
-/// # Safety
-///
-/// The pointer must point to a valid [`Document`] memory object,
-/// it might be uninitialized.
-#[no_mangle]
-pub unsafe extern "C" fn document_place_of_rank(place: *mut Document) -> *mut usize {
-    unsafe { addr_of_mut!((*place).rank) }
-}
-
-/// Returns a pointer to the `title` field of a document.
-///
-/// # Safety
-///
-/// The pointer must point to a valid [`Document`] memory object,
-/// it might be uninitialized.
-#[no_mangle]
-pub unsafe extern "C" fn document_place_of_title(place: *mut Document) -> *mut String {
-    unsafe { addr_of_mut!((*place).title) }
-}
-
-/// Returns a pointer to the `snipped` field of a document.
-///
-/// # Safety
-///
-/// The pointer must point to a valid [`Document`] memory object,
-/// it might be uninitialized.
-#[no_mangle]
-pub unsafe extern "C" fn document_place_of_snipped(place: *mut Document) -> *mut String {
-    unsafe { addr_of_mut!((*place).snippet) }
-}
-
-/// Returns a pointer to the `url` field of a document.
-///
-/// # Safety
-///
-/// The pointer must point to a valid [`Document`] memory object,
-/// it might be uninitialized.
-#[no_mangle]
-pub unsafe extern "C" fn document_place_of_url(place: *mut Document) -> *mut String {
-    unsafe { addr_of_mut!((*place).url) }
-}
-
-/// Returns a pointer to the `domain` field of a document.
-///
-/// # Safety
-///
-/// The pointer must point to a valid [`Document`] memory object,
-/// it might be uninitialized.
-#[no_mangle]
-pub unsafe extern "C" fn document_place_of_domain(place: *mut Document) -> *mut String {
-    unsafe { addr_of_mut!((*place).domain) }
-}
-
 /// Returns a pointer to the `smbert_embedding` field of a document.
 ///
 /// # Safety
@@ -108,6 +53,20 @@ pub unsafe extern "C" fn document_place_of_smbert_embedding(
 ) -> *mut Embedding {
     unsafe { addr_of_mut!((*place).smbert_embedding) }
 }
+
+/// Returns a pointer to the `resource` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_resource(
+    place: *mut Document,
+) -> *mut NewsResource {
+    unsafe { addr_of_mut!((*place).resource) }
+}
+
 
 /// Alloc an uninitialized `Box<Document>`, mainly used for testing.
 #[no_mangle]

--- a/discovery_engine_core/bindings/src/types/document/document_vec.rs
+++ b/discovery_engine_core/bindings/src/types/document/document_vec.rs
@@ -1,0 +1,85 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling slices and vectors of documents.
+
+use core::document::Document;
+
+use crate::types::{
+    slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts, next_element},
+    vec::{get_vec_buffer, get_vec_len},
+};
+
+/// Alloc an uninitialized `Box<[Document]>`, i.e. a `Box<[MaybeUninit<Document>]>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_document_slice(len: usize) -> *mut Document {
+    alloc_uninitialized_slice(len)
+}
+
+/// Given a pointer to a [`Document`] in a slice return the pointer to the next [`Document`].
+///
+/// This also works for a `Box<[MaybeUninit<Document>]>`, i.e. a boxed slice with
+/// uninitialized documents.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `RustDocument` memory object, it might
+/// be uninitialized. If it's the last object in an array the returned pointer
+/// must not be dereferenced.
+#[no_mangle]
+pub unsafe extern "C" fn next_document(place: *mut Document) -> *mut Document {
+    unsafe { next_element(place) }
+}
+
+/// Drop a `Box<[Document]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[Document]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_document_slice(documents: *mut Document, len: usize) {
+    drop(unsafe { boxed_slice_from_raw_parts(documents, len) });
+}
+
+/// Returns the length of a `Box<Vec<T>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<T>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_document_vec_len(documents: *mut Vec<Document>) -> usize {
+    unsafe { get_vec_len(documents) }
+}
+
+/// Returns the `*mut T` to the beginning of the buffer of a `Box<Vec<T>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<T>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_document_vec_buffer(documents: *mut Vec<Document>) -> *mut Document {
+    unsafe { get_vec_buffer(documents) }
+}
+
+/// Drop a `Box<Vec<T>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Vec<T>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_document_vec(documents: *mut Vec<Document>) {
+    unsafe {
+        crate::types::boxed::drop(documents);
+    }
+}

--- a/discovery_engine_core/bindings/src/types/document/document_vec.rs
+++ b/discovery_engine_core/bindings/src/types/document/document_vec.rs
@@ -21,7 +21,7 @@ use crate::types::{
     vec::{get_vec_buffer, get_vec_len},
 };
 
-/// Alloc an uninitialized `Box<[Document]>`, i.e. a `Box<[MaybeUninit<Document>]>`.
+/// Alloc an uninitialized `Box<[Document]>`.
 #[no_mangle]
 pub extern "C" fn alloc_uninitialized_document_slice(len: usize) -> *mut Document {
     alloc_uninitialized_slice(len)
@@ -29,12 +29,11 @@ pub extern "C" fn alloc_uninitialized_document_slice(len: usize) -> *mut Documen
 
 /// Given a pointer to a [`Document`] in a slice return the pointer to the next [`Document`].
 ///
-/// This also works for a `Box<[MaybeUninit<Document>]>`, i.e. a boxed slice with
-/// uninitialized documents.
+/// This also works for uninitialized document slices.
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid `RustDocument` memory object, it might
+/// The pointer must point to a valid `Document` memory object, it might
 /// be uninitialized. If it's the last object in an array the returned pointer
 /// must not be dereferenced.
 #[no_mangle]
@@ -52,31 +51,31 @@ pub unsafe extern "C" fn drop_document_slice(documents: *mut Document, len: usiz
     drop(unsafe { boxed_slice_from_raw_parts(documents, len) });
 }
 
-/// Returns the length of a `Box<Vec<T>>`.
+/// Returns the length of a `Box<Vec<Document>>`.
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid `Vec<T>` instance.
+/// The pointer must point to a valid `Vec<Document>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn get_document_vec_len(documents: *mut Vec<Document>) -> usize {
     unsafe { get_vec_len(documents) }
 }
 
-/// Returns the `*mut T` to the beginning of the buffer of a `Box<Vec<T>>`.
+/// Returns the `*mut Document` to the beginning of the buffer of a `Box<Vec<Document>>`.
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid `Vec<T>` instance.
+/// The pointer must point to a valid `Vec<Document>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn get_document_vec_buffer(documents: *mut Vec<Document>) -> *mut Document {
     unsafe { get_vec_buffer(documents) }
 }
 
-/// Drop a `Box<Vec<T>>`.
+/// Drop a `Box<Vec<Document>>`.
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Vec<T>>` instance.
+/// The pointer must represent a valid `Box<Vec<Document>>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_document_vec(documents: *mut Vec<Document>) {
     unsafe {

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -1,0 +1,139 @@
+use core::document::NewsResource;
+use std::ptr::addr_of_mut;
+
+/// Returns a pointer to the `title` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_title(place: *mut NewsResource) -> *mut String {
+    unsafe { addr_of_mut!((*place).title) }
+}
+
+/// Returns a pointer to the `snippet` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_snippet(place: *mut NewsResource) -> *mut String{
+    unsafe { addr_of_mut!((*place).snippet) }
+}
+
+/// Returns a pointer to the `url` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_url(place: *mut NewsResource) -> *mut Url {
+    unsafe { addr_of_mut!((*place).url) }
+}
+
+/// Returns a pointer to the `source_url` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_source_url(place: *mut NewsResource) -> *mut Url {
+    unsafe { addr_of_mut!((*place).source_url) }
+}
+
+/// Returns a pointer to the `date_publ` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_date_published(place: *mut NewsResource) -> *mut DateTime {
+    unsafe { addr_of_mut!((*place).date_published) }
+}
+
+/// Returns a pointer to the `thumbnail` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_thumbnail(place: *mut NewsResource) -> *mut Option<Url>{
+    unsafe { addr_of_mut!((*place).thumbnail) }
+}
+
+/// Returns a pointer to the `rank` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_rank(place: *mut NewsResource) -> *mut usize {
+    unsafe { addr_of_mut!((*place).rank) }
+}
+
+/// Returns a pointer to the `score` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_score(place: *mut NewsResource) -> *mut Option<f32> {
+    unsafe { addr_of_mut!((*place).score) }
+}
+
+/// Returns a pointer to the `country` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_country(place: *mut NewsResource) -> *mut String{
+    unsafe { addr_of_mut!((*place).country) }
+}
+
+/// Returns a pointer to the `language` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_language(place: *mut NewsResource) -> *mut String {
+    unsafe { addr_of_mut!((*place).language) }
+}
+
+/// Returns a pointer to the `topic` field of a news resource.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`NewsResource`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn news_resource_place_of_(place: *mut NewsResource) -> *mut String {
+    unsafe { addr_of_mut!((*place).topic) }
+}
+
+/// Alloc an uninitialized `Box<NewsResource>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_news_resource() -> *mut NewsResource {
+    crate::types::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<NewsResource>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Document>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_news_resource(document: *mut NewsResource) {
+    unsafe { crate::types::boxed::drop(document) };
+}

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -1,6 +1,7 @@
 use core::document::NewsResource;
 use std::ptr::addr_of_mut;
 
+use chrono::NaiveDateTime;
 use url::Url;
 
 /// Returns a pointer to the `title` field of a news resource.
@@ -21,7 +22,7 @@ pub unsafe extern "C" fn news_resource_place_of_title(place: *mut NewsResource) 
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_snippet(place: *mut NewsResource) -> *mut String{
+pub unsafe extern "C" fn news_resource_place_of_snippet(place: *mut NewsResource) -> *mut String {
     unsafe { addr_of_mut!((*place).snippet) }
 }
 
@@ -54,7 +55,9 @@ pub unsafe extern "C" fn news_resource_place_of_source_url(place: *mut NewsResou
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_date_published(place: *mut NewsResource) -> *mut NaiveDateTime {
+pub unsafe extern "C" fn news_resource_place_of_date_published(
+    place: *mut NewsResource,
+) -> *mut NaiveDateTime {
     unsafe { addr_of_mut!((*place).date_published) }
 }
 
@@ -65,7 +68,9 @@ pub unsafe extern "C" fn news_resource_place_of_date_published(place: *mut NewsR
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_thumbnail(place: *mut NewsResource) -> *mut Option<Url>{
+pub unsafe extern "C" fn news_resource_place_of_thumbnail(
+    place: *mut NewsResource,
+) -> *mut Option<Url> {
     unsafe { addr_of_mut!((*place).thumbnail) }
 }
 
@@ -87,7 +92,9 @@ pub unsafe extern "C" fn news_resource_place_of_rank(place: *mut NewsResource) -
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_score(place: *mut NewsResource) -> *mut Option<f32> {
+pub unsafe extern "C" fn news_resource_place_of_score(
+    place: *mut NewsResource,
+) -> *mut Option<f32> {
     unsafe { addr_of_mut!((*place).score) }
 }
 
@@ -98,7 +105,7 @@ pub unsafe extern "C" fn news_resource_place_of_score(place: *mut NewsResource) 
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_country(place: *mut NewsResource) -> *mut String{
+pub unsafe extern "C" fn news_resource_place_of_country(place: *mut NewsResource) -> *mut String {
     unsafe { addr_of_mut!((*place).country) }
 }
 

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -1,8 +1,23 @@
-use core::document::NewsResource;
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 use std::ptr::addr_of_mut;
 
 use chrono::NaiveDateTime;
 use url::Url;
+
+use core::document::NewsResource;
 
 /// Returns a pointer to the `title` field of a news resource.
 ///

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -1,6 +1,8 @@
 use core::document::NewsResource;
 use std::ptr::addr_of_mut;
 
+use url::Url;
+
 /// Returns a pointer to the `title` field of a news resource.
 ///
 /// # Safety
@@ -52,7 +54,7 @@ pub unsafe extern "C" fn news_resource_place_of_source_url(place: *mut NewsResou
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_date_published(place: *mut NewsResource) -> *mut DateTime {
+pub unsafe extern "C" fn news_resource_place_of_date_published(place: *mut NewsResource) -> *mut NaiveDateTime {
     unsafe { addr_of_mut!((*place).date_published) }
 }
 
@@ -118,7 +120,7 @@ pub unsafe extern "C" fn news_resource_place_of_language(place: *mut NewsResourc
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_(place: *mut NewsResource) -> *mut String {
+pub unsafe extern "C" fn news_resource_place_of_topic(place: *mut NewsResource) -> *mut String {
     unsafe { addr_of_mut!((*place).topic) }
 }
 

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn news_resource_place_of_source_url(place: *mut NewsResou
     unsafe { addr_of_mut!((*place).source_url) }
 }
 
-/// Returns a pointer to the `date_publ` field of a news resource.
+/// Returns a pointer to the `date_published` field of a news resource.
 ///
 /// # Safety
 ///

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -20,7 +20,7 @@ use super::option::get_option_some;
 ///
 /// # Safety
 ///
-/// - It must be valid to write a `f32` instance to given pointer,
+/// - It must be valid to write an `Option<f32>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 #[no_mangle]
 pub unsafe extern "C" fn init_some_f32_at(place: *mut Option<f32>, value: f32) {
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn init_some_f32_at(place: *mut Option<f32>, value: f32) {
 ///
 /// # Safety
 ///
-/// - It must be valid to write a `f32` instance to given pointer,
+/// - It must be valid to write an `Option<f32>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 #[no_mangle]
 pub unsafe extern "C" fn init_none_f32_at(place: *mut Option<f32>) {

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -1,0 +1,55 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Modules containing FFI glue for handling primitives (expect `str`/`slice`).
+
+use super::option::get_option_some;
+
+/// Initializes a rust `Option<f32>` to `Some(value)`.
+///
+/// # Safety
+///
+/// - It must be valid to write a `f32` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn init_some_f32_at(place: *mut Option<f32>, value: f32) {
+    unsafe {
+        place.write(Some(value));
+    }
+}
+
+/// Initializes a rust `Option<f32>` to `None`.
+///
+/// # Safety
+///
+/// - It must be valid to write a `f32` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn init_none_f32_at(place: *mut Option<f32>) {
+    unsafe {
+        place.write(None);
+    }
+}
+
+/// Returns a pointer to the value in the `Some` variant.
+///
+/// **Returns nullptr if the `Option<f32>` is `None`.**
+///
+/// # Safety
+///
+/// - The pointer must point to a sound initialized `Option<f32>`.
+#[no_mangle]
+pub unsafe extern "C" fn get_option_f32_some(option: *const Option<f32>) -> *const f32 {
+    unsafe { get_option_some(option) }
+}

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -64,7 +64,7 @@ pub type BoxedOps = Box<dyn Ops + Send + Sync>;
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash, From, Display)]
 #[repr(transparent)]
 #[cfg_attr(test, derive(Default))]
-pub struct Id(Uuid);
+pub struct Id(pub Uuid);
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -64,7 +64,7 @@ pub type BoxedOps = Box<dyn Ops + Send + Sync>;
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash, From, Display)]
 #[repr(transparent)]
 #[cfg_attr(test, derive(Default))]
-pub struct Id(pub Uuid);
+pub struct Id(Uuid);
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   async_bindgen_dart_utils:
     dependency: transitive
     description:
@@ -30,7 +30,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -173,7 +173,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -304,7 +304,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -332,7 +332,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds ffi support for `Document` and `Box<[Document]>`/`Vec<Document>` and `NewsResource`.