### PR TITLE
[Merged by Bors] - TY-2305 updateable markets config

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -63,7 +63,7 @@ pub enum Error {
 
 #[allow(dead_code)]
 /// Feed market.
-struct Market {
+pub struct Market {
     country_code: String,
     lang_code: String,
 }
@@ -73,7 +73,7 @@ struct Market {
 pub struct Config {
     api_key: String,
     api_base_url: String,
-    markets: Vec<Market>,
+    markets: RwLock<Vec<Market>>,
     smbert_vocab: String,
     smbert_model: String,
     kpe_vocab: String,
@@ -188,6 +188,12 @@ where
         let state_data = State { engine, ranker };
 
         bincode::serialize(&state_data).map_err(|err| Error::Serialization(err.into()))
+    }
+
+    /// Updates the markets configuration.
+    pub async fn set_markets(&mut self, markets: Vec<Market>) {
+        let mut mkts = self.config.markets.write().await;
+        *mkts = markets;
     }
 
     /// Returns at most `max_documents` [`Document`]s for the feed.


### PR DESCRIPTION
previously: #95 added a configuration struct to initialize the engine

**Summary**

- puts the markets part of the configuration behind a lock
- adds a method `set_markets` to update it
- config struct now called `InitConfig` with the "endpoint-specific" parts in a new `EndpointConfig` struct