### PR TITLE
[Merged by Bors] - TY-2407 ffi support for URI/URL

### DIFF
--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:convert' show utf8;
-import 'dart:ffi' show Pointer, Uint8Pointer;
+import 'dart:ffi' show Pointer, Uint8, Uint8Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustString;
@@ -21,17 +21,38 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 
 extension StringFfi on String {
   void writeNative(final Pointer<RustString> place) {
-    final utf8Bytes = utf8.encode(this);
-    final len = utf8Bytes.length;
-    ffi.init_string_at(place, len).asTypedList(len).setAll(0, utf8Bytes);
-    ffi.set_string_len(place, len);
+    final str = BoxedStr.create(this);
+    ffi.init_string_at(place, str.start, str.len);
   }
 
   static String readNative(
     final Pointer<RustString> place,
-  ) {
-    final len = ffi.get_string_len(place);
-    final data = ffi.get_string_buffer(place).asTypedList(len);
-    return utf8.decode(data);
+  ) =>
+      BoxedStr.fromRawParts(
+        ffi.get_string_buffer(place),
+        ffi.get_string_len(place),
+      ).readNative();
+}
+
+class BoxedStr {
+  final Pointer<Uint8> start;
+  final int len;
+
+  BoxedStr.fromRawParts(this.start, this.len);
+
+  /// Creates a `Box<str>` based on given dart string.
+  factory BoxedStr.create(String string) {
+    final utf8Bytes = utf8.encode(string);
+    final len = utf8Bytes.length;
+    final start = ffi.alloc_uninitialized_bytes(len);
+    start.asTypedList(len).setAll(0, utf8Bytes);
+    return BoxedStr.fromRawParts(start, len);
   }
+
+  /// Call to free allocated memory if not moved to dart.
+  void free() {
+    ffi.drop_bytes(this.start, this.len);
+  }
+
+  String readNative() => utf8.decode(start.asTypedList(len));
 }

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -22,7 +22,7 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 extension StringFfi on String {
   void writeNative(final Pointer<RustString> place) {
     final str = BoxedStr.create(this);
-    ffi.init_string_at(place, str.start, str.len);
+    ffi.init_string_at(place, str.ptr, str.len);
   }
 
   static String readNative(
@@ -35,27 +35,27 @@ extension StringFfi on String {
 }
 
 class BoxedStr {
-  final Pointer<Uint8> start;
+  final Pointer<Uint8> ptr;
   final int len;
 
-  BoxedStr.fromRawParts(this.start, this.len);
+  BoxedStr.fromRawParts(this.ptr, this.len);
 
   /// Creates a `Box<str>` based on given dart string.
   factory BoxedStr.create(String string) {
     final utf8Bytes = utf8.encode(string);
     final len = utf8Bytes.length;
-    final start = ffi.alloc_uninitialized_bytes(len);
-    start.asTypedList(len).setAll(0, utf8Bytes);
-    return BoxedStr.fromRawParts(start, len);
+    final ptr = ffi.alloc_uninitialized_bytes(len);
+    ptr.asTypedList(len).setAll(0, utf8Bytes);
+    return BoxedStr.fromRawParts(ptr, len);
   }
 
   /// Call to free allocated memory if not moved to dart.
   void free() {
-    ffi.drop_bytes(this.start, this.len);
+    ffi.drop_bytes(ptr, len);
   }
 
   String readNative() {
-    final data = start.asTypedList(len);
+    final data = ptr.asTypedList(len);
     return utf8.decode(data);
   }
 }

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -54,5 +54,8 @@ class BoxedStr {
     ffi.drop_bytes(this.start, this.len);
   }
 
-  String readNative() => utf8.decode(start.asTypedList(len));
+  String readNative() {
+    final data = start.asTypedList(len);
+    return utf8.decode(data);
+  }
 }

--- a/discovery_engine/lib/src/ffi/types/uri.dart
+++ b/discovery_engine/lib/src/ffi/types/uri.dart
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show Pointer, Uint8;
+import 'dart:ffi' show Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustUrl, RustOptionUrl;

--- a/discovery_engine/lib/src/ffi/types/uri.dart
+++ b/discovery_engine/lib/src/ffi/types/uri.dart
@@ -1,0 +1,34 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart' show RustUrl;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show BoxedStr;
+
+extension UriFfi on Uri {
+  void writeNative(Pointer<RustUrl> place) {
+    final str = BoxedStr.create(toString());
+    final ok = ffi.init_url_at(place, str.start, str.len);
+    str.free();
+    if (ok != 1) {
+      throw ArgumentError('dart Uri incompatible with rust Url');
+    }
+  }
+
+  // static Uri readNative(Pointer<RustUrl> url) {
+
+  // }
+}

--- a/discovery_engine/lib/src/ffi/types/uri.dart
+++ b/discovery_engine/lib/src/ffi/types/uri.dart
@@ -19,12 +19,10 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show BoxedStr;
 
-
 extension UriFfi on Uri {
-
   void writeNative(Pointer<RustUrl> place) {
     final str = BoxedStr.create(toString());
-    final ok = ffi.init_url_at(place, str.start, str.len);
+    final ok = ffi.init_url_at(place, str.ptr, str.len);
     str.free();
     if (ok != 1) {
       throw ArgumentError('dart Uri incompatible with rust Url');
@@ -45,7 +43,7 @@ extension UriFfi on Uri {
       ffi.inti_none_url_at(place);
     } else {
       final str = BoxedStr.create(self.toString());
-      final ok = ffi.init_some_url_at(place, str.start, str.len);
+      final ok = ffi.init_some_url_at(place, str.ptr, str.len);
       str.free();
       if (ok != 1) {
         throw ArgumentError('dart Uri incompatible with rust Url');

--- a/discovery_engine/lib/src/ffi/types/uri.dart
+++ b/discovery_engine/lib/src/ffi/types/uri.dart
@@ -14,7 +14,8 @@
 
 import 'dart:ffi' show Pointer;
 
-import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart' show RustUrl;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustUrl, RustOptionUrl;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show BoxedStr;
 
@@ -35,5 +36,22 @@ extension UriFfi on Uri {
     ).readNative();
 
     return Uri.parse(string);
+  }
+
+  static void writeNativeOption(Uri? self, Pointer<RustOptionUrl> place) {
+    if (self == null) {
+      ffi.inti_none_url_at(place);
+    } else {
+      self.writeNative(ffi.init_some_url_at(place));
+    }
+  }
+
+  static Uri? readNativeOption(Pointer<RustOptionUrl> optUrl) {
+    final url = ffi.get_option_url_some(optUrl);
+    if (url.address == 0) {
+      return null;
+    } else {
+      UriFfi.readNative(url);
+    }
   }
 }

--- a/discovery_engine/lib/src/ffi/types/uri.dart
+++ b/discovery_engine/lib/src/ffi/types/uri.dart
@@ -12,14 +12,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show Pointer;
+import 'dart:ffi' show Pointer, Uint8;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustUrl, RustOptionUrl;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show BoxedStr;
 
+
 extension UriFfi on Uri {
+
   void writeNative(Pointer<RustUrl> place) {
     final str = BoxedStr.create(toString());
     final ok = ffi.init_url_at(place, str.start, str.len);
@@ -42,7 +44,12 @@ extension UriFfi on Uri {
     if (self == null) {
       ffi.inti_none_url_at(place);
     } else {
-      self.writeNative(ffi.init_some_url_at(place));
+      final str = BoxedStr.create(self.toString());
+      final ok = ffi.init_some_url_at(place, str.start, str.len);
+      str.free();
+      if (ok != 1) {
+        throw ArgumentError('dart Uri incompatible with rust Url');
+      }
     }
   }
 
@@ -51,7 +58,7 @@ extension UriFfi on Uri {
     if (url.address == 0) {
       return null;
     } else {
-      UriFfi.readNative(url);
+      return UriFfi.readNative(url);
     }
   }
 }

--- a/discovery_engine/test/ffi/types/uri_test.dart
+++ b/discovery_engine/test/ffi/types/uri_test.dart
@@ -23,6 +23,23 @@ void main() {
     uri.writeNative(place);
     final res = UriFfi.readNative(place);
     ffi.drop_url(place);
+    expect(uri, equals(res));
+  });
+
+  test('reading written Option::Some uri works', () {
+    final uri = Uri.parse('https://foo.example/bar');
+    final place = ffi.alloc_uninitialized_option_url();
+    UriFfi.writeNativeOption(uri, place);
+    final res = UriFfi.readNativeOption(place);
+    ffi.drop_option_url(place);
     expect(res, equals(uri));
+  });
+
+  test('reading written Option::None uri works', () {
+    final place = ffi.alloc_uninitialized_option_url();
+    UriFfi.writeNativeOption(null, place);
+    final res = UriFfi.readNativeOption(place);
+    ffi.drop_option_url(place);
+    expect(res, isNull);
   });
 }

--- a/discovery_engine/test/ffi/types/uri_test.dart
+++ b/discovery_engine/test/ffi/types/uri_test.dart
@@ -12,28 +12,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show Pointer;
-
-import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart' show RustUrl;
+import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
-import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show BoxedStr;
+import 'package:xayn_discovery_engine/src/ffi/types/uri.dart' show UriFfi;
 
-extension UriFfi on Uri {
-  void writeNative(Pointer<RustUrl> place) {
-    final str = BoxedStr.create(toString());
-    final ok = ffi.init_url_at(place, str.start, str.len);
-    str.free();
-    if (ok != 1) {
-      throw ArgumentError('dart Uri incompatible with rust Url');
-    }
-  }
-
-  static Uri readNative(Pointer<RustUrl> url) {
-    final string = BoxedStr.fromRawParts(
-      ffi.get_url_buffer(url),
-      ffi.get_url_buffer_len(url),
-    ).readNative();
-
-    return Uri.parse(string);
-  }
+void main() {
+  test('reading written uri works', () {
+    final uri = Uri.parse('https://foo.example/bar');
+    final place = ffi.alloc_uninitialized_url();
+    uri.writeNative(place);
+    final res = UriFfi.readNative(place);
+    ffi.drop_url(place);
+    expect(res, equals(uri));
+  });
 }

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -2824,6 +2824,7 @@ dependencies = [
  "cbindgen",
  "heck 0.4.0",
  "ndarray",
+ "url",
  "uuid",
  "xayn-discovery-engine-core",
 ]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -8,6 +8,7 @@ license = "AGPL-3.0-only"
 async-bindgen = "0.1.0"
 core = { package = "xayn-discovery-engine-core", path = "../core" }
 ndarray = "=0.15.3"
+url = "2.2.2"
 uuid = "0.8.2"
 
 [dev-dependencies]

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -23,6 +23,7 @@ include = ["xayn-discovery-engine-core"]
 # Renamings to avoid name conflicts/confusion in dart.
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
+"Option_Url" = "RustOptionUrl"
 "String" = "RustString"
 "Url" = "RustUrl"
 "UserReacted" = "RustUserReacted"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -10,6 +10,7 @@ after_includes = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;
+typedef struct RustUrl RustUrl;
 typedef struct RustUserReacted RustUserReacted;
 typedef struct RustUuid RustUuid;
 """
@@ -23,6 +24,7 @@ include = ["xayn-discovery-engine-core"]
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
 "String" = "RustString"
+"Url" = "RustUrl"
 "UserReacted" = "RustUserReacted"
 "UserReaction" = "RustUserReaction"
 "Uuid" = "RustUuid"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -18,6 +18,7 @@ mod boxed;
 pub mod document;
 pub mod duration;
 pub mod embedding;
+pub mod option;
 pub mod slice;
 pub mod string;
 pub mod url;

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -20,5 +20,6 @@ pub mod duration;
 pub mod embedding;
 pub mod slice;
 pub mod string;
+pub mod url;
 pub mod uuid;
 pub mod vec;

--- a/discovery_engine_core/bindings/src/types/option.rs
+++ b/discovery_engine_core/bindings/src/types/option.rs
@@ -14,45 +14,11 @@
 
 //! FFI functions for handling `Option<T>`
 
-use std::{ptr, mem::MaybeUninit, hint::unreachable_unchecked};
-
-/// Writes `Some(MaybeUninit::uninit())` to given place.
-///
-/// # Safety
-///
-/// - It must be valid to write a `Option<T>` instance to given pointer,
-///   the pointer is expected to point to uninitialized memory.
-/// - Before using the option the value must be initialized using the returned pointer.
-///   (except if `T` is valid without initialization, e.g. `MaybeUninit`).
-pub(super) unsafe fn init_some_at<T>(place: *mut Option<T>) -> *mut T{
-    let place = place.cast::<Option<MaybeUninit<T>>>();
-    unsafe {
-        ptr::write(place, Some(MaybeUninit::uninit()));
-    }
-    //SAFE as ptr is `Option<MaybeUninit<T>>`
-    match unsafe { &mut *place } {
-        Some(uninit) => uninit.as_mut_ptr(),
-        None => unsafe { unreachable_unchecked() },
-    }
-}
-
-/// Writes `None` to given place.
-///
-/// # Safety
-///
-/// - It must be valid to write a `Option<T>` instance to given pointer,
-///   the pointer is expected to point to uninitialized memory.
-pub(super) unsafe fn init_none_at<T>(place: *mut Option<T>) {
-    unsafe {
-        ptr::write(place, None);
-    }
-}
+use std::ptr;
 
 /// Returns a pointer to the value in the `Some` variant.
 ///
 /// **Returns nullptr if the `Option<T>` is `None`.**
-///
-/// This function MUST NOT be used to init a partially initialized option.
 ///
 /// # Safety
 ///

--- a/discovery_engine_core/bindings/src/types/option.rs
+++ b/discovery_engine_core/bindings/src/types/option.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling `Option<T>`
+
+use std::{ptr, mem::MaybeUninit, hint::unreachable_unchecked};
+
+/// Writes `Some(MaybeUninit::uninit())` to given place.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<T>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+/// - Before using the option the value must be initialized using the returned pointer.
+///   (except if `T` is valid without initialization, e.g. `MaybeUninit`).
+pub(super) unsafe fn init_some_at<T>(place: *mut Option<T>) -> *mut T{
+    let place = place.cast::<Option<MaybeUninit<T>>>();
+    unsafe {
+        ptr::write(place, Some(MaybeUninit::uninit()));
+    }
+    //SAFE as ptr is `Option<MaybeUninit<T>>`
+    match unsafe { &mut *place } {
+        Some(uninit) => uninit.as_mut_ptr(),
+        None => unsafe { unreachable_unchecked() },
+    }
+}
+
+/// Writes `None` to given place.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<T>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+pub(super) unsafe fn init_none_at<T>(place: *mut Option<T>) {
+    unsafe {
+        ptr::write(place, None);
+    }
+}
+
+/// Returns a pointer to the value in the `Some` variant.
+///
+/// **Returns nullptr if the `Option<T>` is `None`.**
+///
+/// This function MUST NOT be used to init a partially initialized option.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound initialized `Option<T>`.
+pub(super) unsafe fn get_option_some<T>(opt_url: *const Option<T>) -> *const T {
+    match unsafe { &*opt_url } {
+        Some(val) => val,
+        None => ptr::null(),
+    }
+}

--- a/discovery_engine_core/bindings/src/types/slice.rs
+++ b/discovery_engine_core/bindings/src/types/slice.rs
@@ -58,3 +58,19 @@ pub extern "C" fn alloc_uninitialized_f32_slice(len: usize) -> *mut f32 {
 pub unsafe extern "C" fn drop_f32_slice(ptr: *mut f32, len: usize) {
     drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
 }
+
+/// Allocates an uninitialized array of bytes.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_bytes(len: usize) -> *mut u8 {
+    alloc_uninitialized_slice(len)
+}
+
+/// Drops a `Box<[u8]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[u8]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: usize) {
+    drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
+}

--- a/discovery_engine_core/bindings/src/types/string.rs
+++ b/discovery_engine_core/bindings/src/types/string.rs
@@ -20,12 +20,10 @@ use std::{ptr, slice, str};
 ///
 /// # Safety
 ///
-/// - The bytes `str_start..str_start+str_len` must be a sound rust string for the
+/// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust string for the
 ///   lifetime of `'a`.
-pub(super) unsafe fn str_from_raw_parts<'a>(str_start: *const u8, str_len: usize) -> &'a str {
-    unsafe {
-        str::from_utf8_unchecked(slice::from_raw_parts(str_start, str_len))
-    }
+pub(super) unsafe fn str_from_raw_parts<'a>(str_ptr: *const u8, str_len: usize) -> &'a str {
+    unsafe { str::from_utf8_unchecked(slice::from_raw_parts(str_ptr, str_len)) }
 }
 
 /// Creates a rust `String` from given `Box<str>`.
@@ -34,11 +32,11 @@ pub(super) unsafe fn str_from_raw_parts<'a>(str_start: *const u8, str_len: usize
 ///
 /// - It must be valid to write a `String` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
-/// - The bytes `str_start..str_start+str_len` must be a sound rust string.
+/// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust string.
 #[no_mangle]
-pub unsafe extern "C" fn init_string_at(place: *mut String, str_start: *mut u8, str_len: usize) {
+pub unsafe extern "C" fn init_string_at(place: *mut String, str_ptr: *mut u8, str_len: usize) {
     unsafe {
-        ptr::write(place, String::from_raw_parts(str_start, str_len, str_len));
+        ptr::write(place, String::from_raw_parts(str_ptr, str_len, str_len));
     }
 }
 
@@ -96,8 +94,8 @@ mod tests {
         unsafe {
             let boxed = string.to_owned().into_boxed_str();
             let str_len = boxed.len();
-            let str_start = Box::into_raw(boxed).cast::<u8>();
-            init_string_at(place, str_start, str_len);
+            let str_ptr = Box::into_raw(boxed).cast::<u8>();
+            init_string_at(place, str_ptr, str_len);
         }
         assert_eq!(string, *place);
     }

--- a/discovery_engine_core/bindings/src/types/url.rs
+++ b/discovery_engine_core/bindings/src/types/url.rs
@@ -18,10 +18,7 @@ use std::ptr;
 
 use url::Url;
 
-use super::{
-    option::get_option_some,
-    string::str_from_raw_parts,
-};
+use super::{option::get_option_some, string::str_from_raw_parts};
 
 /// Creates a rust `Url` based on given parsing given `&str` at given place.
 ///
@@ -31,10 +28,10 @@ use super::{
 ///
 /// - It must be valid to write a `Url` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
-/// - The bytes `str_start..str_start+str_len` must be a sound rust `str`.
+/// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust `str`.
 #[no_mangle]
-pub unsafe extern "C" fn init_url_at(place: *mut Url, str_start: *const u8, str_len: usize) -> u8 {
-    if let Ok(url) = unsafe { parse_url_from_parts(str_start, str_len) } {
+pub unsafe extern "C" fn init_url_at(place: *mut Url, str_ptr: *const u8, str_len: usize) -> u8 {
+    if let Ok(url) = unsafe { parse_url_from_parts(str_ptr, str_len) } {
         unsafe {
             ptr::write(place, url);
         }
@@ -52,14 +49,14 @@ pub unsafe extern "C" fn init_url_at(place: *mut Url, str_start: *const u8, str_
 ///
 /// - It must be valid to write a `Url` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
-/// - The bytes `str_start..str_start+str_len` must be a sound rust `str`.
+/// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust `str`.
 #[no_mangle]
 pub unsafe extern "C" fn init_some_url_at(
     place: *mut Option<Url>,
-    str_start: *const u8,
+    str_ptr: *const u8,
     str_len: usize,
 ) -> u8 {
-    if let Ok(url) = unsafe { parse_url_from_parts(str_start, str_len) } {
+    if let Ok(url) = unsafe { parse_url_from_parts(str_ptr, str_len) } {
         unsafe {
             ptr::write(place, Some(url));
         }
@@ -73,9 +70,9 @@ pub unsafe extern "C" fn init_some_url_at(
 ///
 /// # Safety
 ///
-/// - The bytes `str_start..str_start+str_len` must be a sound rust `str`.
-unsafe fn parse_url_from_parts(str_start: *const u8, str_len: usize) -> Result<Url, url::ParseError>{
-    Url::parse(unsafe { str_from_raw_parts(str_start, str_len) })
+/// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust `str`.
+unsafe fn parse_url_from_parts(str_ptr: *const u8, str_len: usize) -> Result<Url, url::ParseError> {
+    Url::parse(unsafe { str_from_raw_parts(str_ptr, str_len) })
 }
 
 /// Creates a `None` variant of `Option<Url>` at given place.
@@ -102,7 +99,7 @@ pub unsafe extern "C" fn get_url_buffer(url: *const Url) -> *const u8 {
     unsafe { &*url }.as_str().as_ptr()
 }
 
-/// Returns teh length of the `str` buffer in an `Url` instance.
+/// Returns the length of the `str` buffer in an `Url` instance.
 ///
 /// # Safety
 ///
@@ -134,10 +131,10 @@ pub extern "C" fn alloc_uninitialized_url() -> *mut Url {
 ///
 /// # Safety
 ///
-/// The pointer must represent an initialized `Box<Uuid>`.
+/// The pointer must represent an initialized `Box<Url>`.
 #[no_mangle]
-pub unsafe extern "C" fn drop_url(uuid: *mut Url) {
-    unsafe { super::boxed::drop(uuid) }
+pub unsafe extern "C" fn drop_url(url: *mut Url) {
+    unsafe { super::boxed::drop(url) }
 }
 
 /// Alloc an uninitialized `Box<Option<Url>>`, mainly used for testing.

--- a/discovery_engine_core/bindings/src/types/url.rs
+++ b/discovery_engine_core/bindings/src/types/url.rs
@@ -1,0 +1,109 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling `Url`
+
+use std::ptr;
+
+use url::Url;
+
+use super::string::str_from_raw_parts;
+
+/// Creates a rust `Url` based on given parsing given `&str` at given address.
+///
+/// Return `1` if it succeeds `0` otherwise.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Url` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+/// - The bytes `str_start..str_start+str_len` must be a sound rust `str`.
+#[no_mangle]
+pub unsafe extern "C" fn init_url_at(place: *mut Url, str_start: *const u8, str_len: usize) -> u8 {
+    let str = unsafe { str_from_raw_parts(str_start, str_len) };
+    if let Ok(url) = Url::parse(str) {
+        unsafe {
+            ptr::write(place, url);
+        }
+        1
+    } else {
+        0
+    }
+}
+
+/// Returns a pointer to the start of the `str` buffer in an `Url` instance.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound initialized `Url` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_url_buffer(url: *const Url) -> *const u8 {
+    unsafe { &*url }.as_str().as_ptr()
+}
+
+/// Returns teh length of the `str` buffer in an `Url` instance.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound initialized `Url` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_url_buffer_len(url: *const Url) -> usize {
+    unsafe { &*url }.as_str().len()
+}
+
+/// Alloc an uninitialized `Box<Url>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_url() -> *mut Url {
+    super::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<Url>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent an initialized `Box<Uuid>`.
+#[no_mangle]
+pub unsafe extern "C" fn drop_url(uuid: *mut Url) {
+    unsafe { super::boxed::drop(uuid) }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::mem::MaybeUninit;
+
+    use super::*;
+
+    #[test]
+    fn test_creating_url() {
+        let url = "https://foo.example/bar";
+        let place = &mut MaybeUninit::<Url>::uninit();
+        unsafe {
+            let ok = init_url_at(place.as_mut_ptr(), url.as_ptr(), url.len());
+            assert_eq!(ok, 1);
+        }
+        let place = unsafe { place.assume_init_mut() };
+        assert_eq!(*place, Url::parse(url).unwrap());
+    }
+
+    #[test]
+    fn test_crating_url_fails() {
+        let url = "not_an_url";
+        let place = &mut MaybeUninit::<Url>::uninit();
+        unsafe {
+            let ok = init_url_at(place.as_mut_ptr(), url.as_ptr(), url.len());
+            assert_eq!(ok, 0);
+        }
+    }
+}

--- a/discovery_engine_core/bindings/src/types/url.rs
+++ b/discovery_engine_core/bindings/src/types/url.rs
@@ -18,9 +18,9 @@ use std::ptr;
 
 use url::Url;
 
-use super::string::str_from_raw_parts;
+use super::{string::str_from_raw_parts, option::{init_some_at, init_none_at, get_option_some}};
 
-/// Creates a rust `Url` based on given parsing given `&str` at given address.
+/// Creates a rust `Url` based on given parsing given `&str` at given place.
 ///
 /// Return `1` if it succeeds `0` otherwise.
 ///
@@ -40,6 +40,31 @@ pub unsafe extern "C" fn init_url_at(place: *mut Url, str_start: *const u8, str_
     } else {
         0
     }
+}
+
+/// Create a rust `Option<Url>` partially initialized to `Some(MaybeUninit::uninit())`.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<Url>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+/// - The returned pointer must be used to initialize the `Url` before the
+///   place is used anywhere.
+#[no_mangle]
+pub unsafe extern "C" fn init_some_url_at(place: *mut Option<Url>) -> *mut Url {
+    unsafe { init_some_at(place) }
+}
+
+/// Creates a `None` variant of `Option<Url>` at given place.
+///
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<Url>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn inti_none_url_at(place: *mut Option<Url>) {
+    unsafe { init_none_at(place); }
 }
 
 /// Returns a pointer to the start of the `str` buffer in an `Url` instance.
@@ -62,6 +87,18 @@ pub unsafe extern "C" fn get_url_buffer_len(url: *const Url) -> usize {
     unsafe { &*url }.as_str().len()
 }
 
+/// Returns a pointer to the value in the `Some` variant.
+///
+/// **Returns nullptr if the `Option<Url>` is `None`.**
+///
+/// # Safety
+///
+/// - The pointer must point to a sound initialized `Option<Url>`.
+#[no_mangle]
+pub unsafe extern "C" fn get_option_url_some(opt_url: *const Option<Url>) -> *const Url {
+    unsafe { get_option_some(opt_url) }
+}
+
 /// Alloc an uninitialized `Box<Url>`, mainly used for testing.
 #[no_mangle]
 pub extern "C" fn alloc_uninitialized_url() -> *mut Url {
@@ -78,6 +115,21 @@ pub unsafe extern "C" fn drop_url(uuid: *mut Url) {
     unsafe { super::boxed::drop(uuid) }
 }
 
+/// Alloc an uninitialized `Box<Option<Url>>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_option_url() -> *mut Option<Url> {
+    super::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<Option<Url>>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent an initialized `Box<Option<Url>>`.
+#[no_mangle]
+pub unsafe extern "C" fn drop_option_url(uuid: *mut Option<Url>) {
+    unsafe { super::boxed::drop(uuid) }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Add ffi support for dart Uri <-> rust Url types.

Required by #105/[TY-2342](https://xainag.atlassian.net/browse/TY-2342).