### PR TITLE
[Merged by Bors] - TY-2379, TY-2380 Added EngineStateRepository and Hive implementation

### DIFF
--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -49,18 +49,26 @@ import 'package:xayn_discovery_engine/src/domain/repository/changed_document_rep
     show ChangedDocumentRepository;
 import 'package:xayn_discovery_engine/src/domain/repository/document_repo.dart'
     show DocumentRepository;
+import 'package:xayn_discovery_engine/src/domain/repository/engine_state_repo.dart'
+    show EngineStateRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/assets.dart'
     show createDataProvider, createManifestReader;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/http_asset_fetcher.dart'
     show HttpAssetFetcher;
 import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
-    show activeDocumentDataBox, changedDocumentIdBox, documentBox;
+    show
+        activeDocumentDataBox,
+        changedDocumentIdBox,
+        documentBox,
+        engineStateBox;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_document_repo.dart'
     show HiveActiveDocumentDataRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_changed_document_repo.dart'
     show HiveChangedDocumentRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_document_repo.dart'
     show HiveDocumentRepository;
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_state_repo.dart'
+    show HiveEngineStateRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/type_adapters/hive_duration_adapter.dart'
     show DurationAdapter;
 import 'package:xayn_discovery_engine/src/infrastructure/type_adapters/hive_unique_id_adapter.dart'
@@ -78,6 +86,7 @@ class EventHandler {
   late final DocumentRepository _documentRepository;
   late final ActiveDocumentDataRepository _activeDataRepository;
   late final ChangedDocumentRepository _changedDocumentRepository;
+  late final EngineStateRepository _engineStateRepository;
   late final DocumentManager _documentManager;
   late final FeedManager _feedManager;
 
@@ -157,9 +166,15 @@ class EventHandler {
     _documentRepository = HiveDocumentRepository();
     _activeDataRepository = HiveActiveDocumentDataRepository();
     _changedDocumentRepository = HiveChangedDocumentRepository();
+    _engineStateRepository = HiveEngineStateRepository();
 
     // fetch AI assets
     await _fetchAssets(config);
+
+    // load the engine serialized state
+    // TODO: pass the state to the engine
+    // ignore: unused_local_variable
+    final engineState = await _engineStateRepository.load();
 
     // init the engine
     // TODO: replace with real engine and pass in setup data
@@ -212,6 +227,7 @@ class EventHandler {
     await _openDbBox<Document>(documentBox);
     await _openDbBox<ActiveDocumentData>(activeDocumentDataBox);
     await _openDbBox<Uint8List>(changedDocumentIdBox);
+    await _openDbBox<Uint8List>(engineStateBox);
   }
 
   /// Tries to open a box persisted on disk. In case of failure opens it in memory.

--- a/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
+++ b/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
@@ -21,7 +21,4 @@ abstract class EngineStateRepository {
 
   /// Persist the state of the engine.
   Future<void> save(Uint8List bytes);
-
-  /// Clear the repository.
-  Future<void> reset();
 }

--- a/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
+++ b/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Xayn AG
+// Copyright 2022 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -12,7 +12,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const documentBox = 'document';
-const changedDocumentIdBox = 'changed_document';
-const activeDocumentDataBox = 'active_document';
-const engineStateBox = 'engine_state';
+import 'dart:typed_data' show Uint8List;
+
+/// Repository interface for serialized engine state.
+abstract class EngineStateRepository {
+  /// Fetch the current state of the engine.
+  Future<Uint8List?> load();
+
+  /// Persist the state of the engine.
+  Future<void> save(Uint8List bytes);
+
+  /// Clear the repository.
+  Future<void> reset();
+}

--- a/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
+++ b/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
@@ -31,7 +31,4 @@ class HiveEngineStateRepository implements EngineStateRepository {
 
   @override
   Future<void> save(Uint8List bytes) => box.put(stateKey, bytes);
-
-  @override
-  Future<void> reset() => box.clear();
 }

--- a/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
+++ b/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
@@ -1,0 +1,37 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:hive/hive.dart' show Hive, Box;
+import 'package:xayn_discovery_engine/src/domain/repository/engine_state_repo.dart'
+    show EngineStateRepository;
+import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
+    show engineStateBox;
+
+/// Hive repository implementation of [EngineStateRepository].
+class HiveEngineStateRepository implements EngineStateRepository {
+  static const stateKey = 0;
+
+  Box<Uint8List> get box => Hive.box<Uint8List>(engineStateBox);
+
+  @override
+  Future<Uint8List?> load() async => box.get(stateKey);
+
+  @override
+  Future<void> save(Uint8List bytes) => box.put(stateKey, bytes);
+
+  @override
+  Future<void> reset() => box.clear();
+}

--- a/discovery_engine/test/repository/hive_active_document_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_document_repo_test.dart
@@ -14,7 +14,7 @@
 
 import 'dart:typed_data' show Uint8List;
 
-import 'package:hive/hive.dart' show Hive;
+import 'package:hive/hive.dart' show Box, Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show ActiveDocumentData;
@@ -32,16 +32,23 @@ import '../logging.dart' show setupLogging;
 Future<void> main() async {
   setupLogging();
 
-  final box = await Hive.openBox<ActiveDocumentData>(
-    activeDocumentDataBox,
-    bytes: Uint8List(0),
-  );
-  final repo = HiveActiveDocumentDataRepository();
-
   group('ActiveDocumentDataRepository', () {
+    late Box<ActiveDocumentData> box;
+    late HiveActiveDocumentDataRepository repo;
     final data = ActiveDocumentData(Uint8List(0));
     final id1 = DocumentId();
     final id2 = DocumentId();
+
+    setUpAll(() async {
+      box = await Hive.openBox<ActiveDocumentData>(
+        activeDocumentDataBox,
+        bytes: Uint8List(0),
+      );
+    });
+
+    setUp(() {
+      repo = HiveActiveDocumentDataRepository();
+    });
 
     tearDown(() async {
       await box.clear();

--- a/discovery_engine/test/repository/hive_changed_document_repo_test.dart
+++ b/discovery_engine/test/repository/hive_changed_document_repo_test.dart
@@ -14,7 +14,7 @@
 
 import 'dart:typed_data' show Uint8List;
 
-import 'package:hive/hive.dart' show Hive;
+import 'package:hive/hive.dart' show Box, Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId;
@@ -28,13 +28,22 @@ import '../logging.dart' show setupLogging;
 Future<void> main() async {
   setupLogging();
 
-  final box =
-      await Hive.openBox<Uint8List>(changedDocumentIdBox, bytes: Uint8List(0));
-  final repo = HiveChangedDocumentRepository();
-
   group('ChangedDocumentRepository', () {
+    late Box<Uint8List> box;
+    late HiveChangedDocumentRepository repo;
     final id1 = DocumentId();
     final id2 = DocumentId();
+
+    setUpAll(() async {
+      box = await Hive.openBox<Uint8List>(
+        changedDocumentIdBox,
+        bytes: Uint8List(0),
+      );
+    });
+
+    setUp(() {
+      repo = HiveChangedDocumentRepository();
+    });
 
     tearDown(() async {
       await box.clear();

--- a/discovery_engine/test/repository/hive_document_repo_test.dart
+++ b/discovery_engine/test/repository/hive_document_repo_test.dart
@@ -14,7 +14,7 @@
 
 import 'dart:typed_data' show Uint8List;
 
-import 'package:hive/hive.dart' show Hive;
+import 'package:hive/hive.dart' show Box, Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document, UserReaction;
@@ -31,10 +31,9 @@ import '../logging.dart' show setupLogging;
 Future<void> main() async {
   setupLogging();
 
-  final box = await Hive.openBox<Document>(documentBox, bytes: Uint8List(0));
-  final repo = HiveDocumentRepository();
-
   group('DocumentRepository', () {
+    late Box<Document> box;
+    late HiveDocumentRepository repo;
     final stackId = StackId();
     final doc1 = Document(
       stackId: stackId,
@@ -46,6 +45,14 @@ Future<void> main() async {
       batchIndex: 1,
       resource: mockNewsResource,
     );
+
+    setUpAll(() async {
+      box = await Hive.openBox<Document>(documentBox, bytes: Uint8List(0));
+    });
+
+    setUp(() async {
+      repo = HiveDocumentRepository();
+    });
 
     tearDown(() async {
       await box.clear();

--- a/discovery_engine/test/repository/hive_engine_state_repo_test.dart
+++ b/discovery_engine/test/repository/hive_engine_state_repo_test.dart
@@ -61,17 +61,6 @@ Future<void> main() async {
         expect(_box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
       });
 
-      test('when we override data it will be updated in the box', () async {
-        await _box.put(
-          HiveEngineStateRepository.stateKey,
-          Uint8List.fromList([1, 2, 3, 4]),
-        );
-
-        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
-
-        expect(_box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
-      });
-
       test(
           'when we call "save" multiple time it will always override the state '
           'so only one entry will exist in the box', () async {
@@ -81,19 +70,6 @@ Future<void> main() async {
 
         expect(_box.values.first, equals(Uint8List.fromList([0, 1, 0, 1])));
         expect(_box.values.length, equals(1));
-      });
-    });
-
-    group('"reset" method', () {
-      test('when we reset there will be no data in the box', () async {
-        await _box.put(
-          HiveEngineStateRepository.stateKey,
-          Uint8List.fromList([1, 2, 3, 4]),
-        );
-
-        await _repo.reset();
-
-        expect(_box.isEmpty, isTrue);
       });
     });
   });

--- a/discovery_engine/test/repository/hive_engine_state_repo_test.dart
+++ b/discovery_engine/test/repository/hive_engine_state_repo_test.dart
@@ -1,0 +1,100 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:hive/hive.dart' show Box, Hive;
+import 'package:test/test.dart';
+
+import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
+    show engineStateBox;
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_state_repo.dart'
+    show HiveEngineStateRepository;
+
+Future<void> main() async {
+  group('HiveEngineStateRepository', () {
+    late Box<Uint8List> _box;
+    final _repo = HiveEngineStateRepository();
+
+    setUpAll(() async {
+      _box = await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
+    });
+
+    tearDown(() async {
+      await _box.clear();
+    });
+
+    group('"load" method', () {
+      test('when the box is empty it will return "null"', () async {
+        final state = await _repo.load();
+
+        expect(state, isNull);
+      });
+
+      test('when the box has some data it will return that data', () async {
+        await _box.put(
+          HiveEngineStateRepository.stateKey,
+          Uint8List.fromList([1, 2, 3, 4]),
+        );
+
+        final state = await _repo.load();
+
+        expect(state, equals(Uint8List.fromList([1, 2, 3, 4])));
+      });
+    });
+
+    group('"save" method', () {
+      test('when we save some data it will be present in the box', () async {
+        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
+
+        expect(_box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
+      });
+
+      test('when we override data it will be updated in the box', () async {
+        await _box.put(
+          HiveEngineStateRepository.stateKey,
+          Uint8List.fromList([1, 2, 3, 4]),
+        );
+
+        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
+
+        expect(_box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
+      });
+
+      test(
+          'when we call "save" multiple time it will always override the state '
+          'so only one entry will exist in the box', () async {
+        await _repo.save(Uint8List.fromList([1, 2, 3, 4]));
+        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
+        await _repo.save(Uint8List.fromList([0, 1, 0, 1]));
+
+        expect(_box.values.first, equals(Uint8List.fromList([0, 1, 0, 1])));
+        expect(_box.values.length, equals(1));
+      });
+    });
+
+    group('"reset" method', () {
+      test('when we reset there will be no data in the box', () async {
+        await _box.put(
+          HiveEngineStateRepository.stateKey,
+          Uint8List.fromList([1, 2, 3, 4]),
+        );
+
+        await _repo.reset();
+
+        expect(_box.isEmpty, isTrue);
+      });
+    });
+  });
+}

--- a/discovery_engine/test/repository/hive_engine_state_repo_test.dart
+++ b/discovery_engine/test/repository/hive_engine_state_repo_test.dart
@@ -24,31 +24,35 @@ import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_
 
 Future<void> main() async {
   group('HiveEngineStateRepository', () {
-    late Box<Uint8List> _box;
-    final _repo = HiveEngineStateRepository();
+    late Box<Uint8List> box;
+    late HiveEngineStateRepository repo;
 
     setUpAll(() async {
-      _box = await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
+      box = await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
+    });
+
+    setUp(() async {
+      repo = HiveEngineStateRepository();
     });
 
     tearDown(() async {
-      await _box.clear();
+      await box.clear();
     });
 
     group('"load" method', () {
       test('when the box is empty it will return "null"', () async {
-        final state = await _repo.load();
+        final state = await repo.load();
 
         expect(state, isNull);
       });
 
       test('when the box has some data it will return that data', () async {
-        await _box.put(
+        await box.put(
           HiveEngineStateRepository.stateKey,
           Uint8List.fromList([1, 2, 3, 4]),
         );
 
-        final state = await _repo.load();
+        final state = await repo.load();
 
         expect(state, equals(Uint8List.fromList([1, 2, 3, 4])));
       });
@@ -56,20 +60,20 @@ Future<void> main() async {
 
     group('"save" method', () {
       test('when we save some data it will be present in the box', () async {
-        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
+        await repo.save(Uint8List.fromList([5, 6, 7, 8]));
 
-        expect(_box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
+        expect(box.values.first, equals(Uint8List.fromList([5, 6, 7, 8])));
       });
 
       test(
           'when we call "save" multiple time it will always override the state '
           'so only one entry will exist in the box', () async {
-        await _repo.save(Uint8List.fromList([1, 2, 3, 4]));
-        await _repo.save(Uint8List.fromList([5, 6, 7, 8]));
-        await _repo.save(Uint8List.fromList([0, 1, 0, 1]));
+        await repo.save(Uint8List.fromList([1, 2, 3, 4]));
+        await repo.save(Uint8List.fromList([5, 6, 7, 8]));
+        await repo.save(Uint8List.fromList([0, 1, 0, 1]));
 
-        expect(_box.values.first, equals(Uint8List.fromList([0, 1, 0, 1])));
-        expect(_box.values.length, equals(1));
+        expect(box.values.first, equals(Uint8List.fromList([0, 1, 0, 1])));
+        expect(box.values.length, equals(1));
       });
     });
   });


### PR DESCRIPTION
[Jira ref TY-2379](https://xainag.atlassian.net/browse/TY-2379)
[Jira ref TY-2380](https://xainag.atlassian.net/browse/TY-2380)

This PR adds an interface for `EngineStateRepository` and it's Hive implementation, together with some tests and updated initialisation steps of the event handler.

`EngineStateRepository` will hold engine state serialized into a byte array (`Uint8List`).