### PR TITLE
[Merged by Bors] - Don't expose the isActive field

### DIFF
--- a/discovery_engine/lib/src/api/models/document.dart
+++ b/discovery_engine/lib/src/api/models/document.dart
@@ -33,7 +33,6 @@ class Document with _$Document {
     required NewsResource resource,
     required UserReaction userReaction,
     required int batchIndex,
-    required bool isActive,
   }) = _Document;
 
   /// Converts json Map to [Document].

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -65,7 +65,6 @@ class Document {
         resource: resource,
         userReaction: userReaction,
         batchIndex: batchIndex,
-        isActive: isActive,
       );
 }
 


### PR DESCRIPTION
We don't have cases in which we return the non active document so it does not make sense to expose it.