### PR TITLE
[Merged by Bors] - TY-2408 FFI support for NaiveDateTime

### DIFF
--- a/discovery_engine/lib/src/ffi/types/date_time.dart
+++ b/discovery_engine/lib/src/ffi/types/date_time.dart
@@ -22,15 +22,10 @@ extension NaiveDateTimeFfi on DateTime {
   void writeNative(Pointer<RustNaiveDateTime> place) {
     // micro seconds since since since midnight on
     // January 1, 1970 ignoring time zone.
-    final microSecondsSinceNaiveEpoch =
-        microsecondsSinceEpoch + timeZoneOffset.inMicroseconds;
-    if (ffi.init_naive_date_time_at(place, microSecondsSinceNaiveEpoch) != 1) {
-      throw ArgumentError.value(
-        this,
-        'dateTime',
-        'Can not convert this dart DateTime to rust',
-      );
-    }
+    ffi.init_naive_date_time_at(
+      place,
+      microsecondsSinceEpoch + timeZoneOffset.inMicroseconds,
+    );
   }
 
   static DateTime readNative(Pointer<RustNaiveDateTime> naiveDateTime) {

--- a/discovery_engine/lib/src/ffi/types/date_time.dart
+++ b/discovery_engine/lib/src/ffi/types/date_time.dart
@@ -25,7 +25,11 @@ extension NaiveDateTimeFfi on DateTime {
     final microSecondsSinceNaiveEpoch =
         microsecondsSinceEpoch + timeZoneOffset.inMicroseconds;
     if (ffi.init_naive_date_time_at(place, microSecondsSinceNaiveEpoch) != 1) {
-      throw ArgumentError.value(this, 'dateTime', 'Can not convert this dart DateTime to rust',);
+      throw ArgumentError.value(
+        this,
+        'dateTime',
+        'Can not convert this dart DateTime to rust',
+      );
     }
   }
 

--- a/discovery_engine/lib/src/ffi/types/date_time.dart
+++ b/discovery_engine/lib/src/ffi/types/date_time.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustNaiveDateTime;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+
+extension NaiveDateTimeFfi on DateTime {
+  void writeNative(Pointer<RustNaiveDateTime> place) {
+    // micro seconds since since since midnight on
+    // January 1, 1970 ignoring time zone.
+    final microSecondsSinceNaiveEpoch =
+        microsecondsSinceEpoch + timeZoneOffset.inMicroseconds;
+    if (ffi.init_naive_date_time_at(place, microSecondsSinceNaiveEpoch) != 1) {
+      throw ArgumentError.value(this, 'dateTime', 'Can not convert this dart DateTime to rust',);
+    }
+  }
+
+  static DateTime readNative(Pointer<RustNaiveDateTime> naiveDateTime) {
+    final microsecondsSinceEpochLocal =
+        ffi.get_naive_date_time_micros_since_epoch(naiveDateTime);
+    final dateTime =
+        DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpochLocal);
+    // the constructor interpreted it as micro seconds in UTC for creating a
+    // non UTC Time Zone, so time is of by the time zone offset
+    return dateTime.subtract(dateTime.timeZoneOffset);
+  }
+}

--- a/discovery_engine/test/ffi/types/date_time_test.dart
+++ b/discovery_engine/test/ffi/types/date_time_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/date_time.dart'
+    show NaiveDateTimeFfi;
+
+void main() {
+  test('reading written naive date time yields same result', () {
+    final time = DateTime.now();
+    final place = ffi.alloc_uninitialized_naive_date_time();
+    time.writeNative(place);
+    final res = NaiveDateTimeFfi.readNative(place);
+    ffi.drop_naive_date_time(place);
+    expect(res, equals(time));
+  });
+
+  test('reading written absurd large naive date time yields same result', () {
+    // At some point larger then this it will fail.
+    const HUGE_TIME_WE_STILL_SUPPORT = 200000 * 365 * 24 * 60 * 60 * 1000000;
+    final time = DateTime.fromMicrosecondsSinceEpoch(HUGE_TIME_WE_STILL_SUPPORT);
+    final place = ffi.alloc_uninitialized_naive_date_time();
+    time.writeNative(place);
+    final res = NaiveDateTimeFfi.readNative(place);
+    ffi.drop_naive_date_time(place);
+    expect(res, equals(time));
+  });
+}

--- a/discovery_engine/test/ffi/types/date_time_test.dart
+++ b/discovery_engine/test/ffi/types/date_time_test.dart
@@ -17,24 +17,29 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/date_time.dart'
     show NaiveDateTimeFfi;
 
+void readWriteTest(DateTime dateTime) {
+  final place = ffi.alloc_uninitialized_naive_date_time();
+  dateTime.writeNative(place);
+  final res = NaiveDateTimeFfi.readNative(place);
+  ffi.drop_naive_date_time(place);
+  expect(res, equals(dateTime));
+}
+
 void main() {
   test('reading written naive date time yields same result', () {
-    final time = DateTime.now();
-    final place = ffi.alloc_uninitialized_naive_date_time();
-    time.writeNative(place);
-    final res = NaiveDateTimeFfi.readNative(place);
-    ffi.drop_naive_date_time(place);
-    expect(res, equals(time));
+    readWriteTest(DateTime.now());
   });
 
   test('reading written absurd large naive date time yields same result', () {
     // At some point larger then this it will fail.
-    const HUGE_TIME_WE_STILL_SUPPORT = 200000 * 365 * 24 * 60 * 60 * 1000000;
-    final time = DateTime.fromMicrosecondsSinceEpoch(HUGE_TIME_WE_STILL_SUPPORT);
-    final place = ffi.alloc_uninitialized_naive_date_time();
-    time.writeNative(place);
-    final res = NaiveDateTimeFfi.readNative(place);
-    ffi.drop_naive_date_time(place);
-    expect(res, equals(time));
+    const hugeTimeWeStillSupport = 200000 * 365 * 24 * 60 * 60 * 1000000;
+    final dateTime =
+        DateTime.fromMicrosecondsSinceEpoch(hugeTimeWeStillSupport);
+    readWriteTest(dateTime);
+  });
+
+  test('reading written pre-epoch time yields same result', () {
+    final dateTime = DateTime.parse('0500-06-21 18:17:12');
+    readWriteTest(dateTime);
   });
 }

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -2775,6 +2775,7 @@ dependencies = [
  "async-bindgen",
  "async-bindgen-gen-dart",
  "cbindgen",
+ "chrono",
  "heck 0.4.0",
  "ndarray",
  "url",

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -6,6 +6,7 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 async-bindgen = "0.1.0"
+chrono = { version = "0.4.19", default-features = false }
 core = { package = "xayn-discovery-engine-core", path = "../core" }
 ndarray = "=0.15.3"
 url = "2.2.2"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -10,6 +10,7 @@ after_includes = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;
+typedef struct RustNaiveDateTime RustNaiveDateTime;
 typedef struct RustTimeSpent RustTimeSpent;
 typedef struct RustUrl RustUrl;
 typedef struct RustUserReacted RustUserReacted;
@@ -24,6 +25,7 @@ include = ["xayn-discovery-engine-core"]
 # Renamings to avoid name conflicts/confusion in dart.
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
+"NaiveDateTime" = "RustNaiveDateTime"
 "Option_Url" = "RustOptionUrl"
 "String" = "RustString"
 "TimeSpent" = "RustTimeSpent"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -16,6 +16,7 @@
 
 mod boxed;
 pub mod document;
+pub mod date_time;
 pub mod duration;
 pub mod embedding;
 pub mod option;

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -15,8 +15,8 @@
 //! Modules containing FFI glue for various types.
 
 mod boxed;
-pub mod document;
 pub mod date_time;
+pub mod document;
 pub mod duration;
 pub mod embedding;
 pub mod option;

--- a/discovery_engine_core/bindings/src/types/date_time.rs
+++ b/discovery_engine_core/bindings/src/types/date_time.rs
@@ -13,15 +13,24 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! FFI functions for handling date time fields.
+use std::convert::TryFrom;
 
-use chrono::NaiveDateTime;
+use chrono::{naive::MAX_DATETIME, NaiveDateTime};
 
 const NANOS_PER_MICRO: i64 = 1_000;
 const MICROS_PER_SECOND: i64 = 1_000_000;
 
+/// [`chrono::naive::MAX_DATETIME`] in micros
+const MAX_MICRO_SECONDS: i64 = 8_210_298_412_799_999_999;
+/// [`chrono::naive::MIN_DATETIME`] in micros
+const MIN_MICRO_SECONDS: i64 = -8_334_632_851_200_000_000;
+
 /// Creates a rust `NaiveDateTime` at given memory address.
 ///
 /// Returns `1` if it succeeded `0` else wise.
+///
+/// A a time above the max or below the min supported
+/// date time will be clamped to the max/min time.
 ///
 /// # Safety
 ///
@@ -31,15 +40,17 @@ const MICROS_PER_SECOND: i64 = 1_000_000;
 pub unsafe extern "C" fn init_naive_date_time_at(
     place: *mut NaiveDateTime,
     micros_since_naive_epoch: i64,
-) -> u8 {
+) {
+    let micros_since_naive_epoch =
+        micros_since_naive_epoch.clamp(MIN_MICRO_SECONDS, MAX_MICRO_SECONDS);
     let seconds = micros_since_naive_epoch / MICROS_PER_SECOND;
     let nanos = (micros_since_naive_epoch.abs() % MICROS_PER_SECOND) * NANOS_PER_MICRO;
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let nanos = nanos as u32;
-    NaiveDateTime::from_timestamp_opt(seconds, nanos).map_or(0, |date_time| {
-        unsafe { place.write(date_time) };
-        1
-    })
+    // the unwraps failing is unreachable, but we do not want to have any panic path
+    let nanos = u32::try_from(nanos).unwrap_or(u32::MAX);
+    let date_time = NaiveDateTime::from_timestamp_opt(seconds, nanos).unwrap_or(MAX_DATETIME);
+    unsafe {
+        place.write(date_time);
+    }
 }
 
 /// Returns the number of micro seconds since since midnight on January 1, 1970.
@@ -52,7 +63,7 @@ pub unsafe extern "C" fn init_naive_date_time_at(
 /// The pointer must point to a sound initialized `NaiveDateTime` instance.
 #[no_mangle]
 pub unsafe extern "C" fn get_naive_date_time_micros_since_epoch(
-    naive_date_time: *mut NaiveDateTime,
+    naive_date_time: *const NaiveDateTime,
 ) -> i64 {
     let naive_date_time = unsafe { &*naive_date_time };
     let sub_micros = naive_date_time.timestamp_subsec_micros();
@@ -74,4 +85,54 @@ pub extern "C" fn alloc_uninitialized_naive_date_time() -> *mut NaiveDateTime {
 #[no_mangle]
 pub unsafe extern "C" fn drop_naive_date_time(naive_date_time: *mut NaiveDateTime) {
     unsafe { super::boxed::drop(naive_date_time) }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{
+        naive::{MAX_DATETIME, MIN_DATETIME},
+        NaiveDate,
+        Timelike,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_max_date_is_supported() {
+        let place = &mut NaiveDate::from_ymd(1, 1, 1).and_hms(1, 1, 1);
+        unsafe { init_naive_date_time_at(place, MAX_MICRO_SECONDS) };
+        let truncated_max = MAX_DATETIME.with_nanosecond(999_999_000).unwrap();
+        assert_eq!(*place, truncated_max);
+
+        let micros = unsafe { get_naive_date_time_micros_since_epoch(&MAX_DATETIME) };
+        unsafe { init_naive_date_time_at(place, micros) };
+        assert_eq!(*place, truncated_max);
+    }
+
+    #[test]
+    fn test_min_date_is_supported() {
+        let place = &mut NaiveDate::from_ymd(1, 1, 1).and_hms(1, 1, 1);
+        unsafe { init_naive_date_time_at(place, MIN_MICRO_SECONDS) };
+        assert_eq!(*place, MIN_DATETIME);
+
+        let micros = unsafe { get_naive_date_time_micros_since_epoch(&MIN_DATETIME) };
+        unsafe { init_naive_date_time_at(place, micros) };
+        assert_eq!(*place, MIN_DATETIME);
+    }
+
+    #[test]
+    fn test_consts_max_is_sync() {
+        let seconds = MAX_DATETIME.timestamp();
+        let sub_micros = MAX_DATETIME.timestamp_subsec_micros();
+        let micros = seconds.checked_mul(MICROS_PER_SECOND).unwrap() + i64::from(sub_micros);
+        assert_eq!(micros, MAX_MICRO_SECONDS);
+    }
+
+    #[test]
+    fn test_consts_min_is_sync() {
+        let seconds = MIN_DATETIME.timestamp();
+        let sub_micros = MIN_DATETIME.timestamp_subsec_micros();
+        let micros = seconds.checked_mul(MICROS_PER_SECOND).unwrap() + i64::from(sub_micros);
+        assert_eq!(micros, MIN_MICRO_SECONDS);
+    }
 }

--- a/discovery_engine_core/bindings/src/types/date_time.rs
+++ b/discovery_engine_core/bindings/src/types/date_time.rs
@@ -1,6 +1,27 @@
-use chrono::{NaiveDateTime};
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling date time fields.
+
+use chrono::NaiveDateTime;
+
+const NANOS_PER_MICRO: i64 = 1_000;
+const MICROS_PER_SECOND: i64 = 1_000_000;
 
 /// Creates a rust `NaiveDateTime` at given memory address.
+///
+/// Returns `1` if it succeeded `0` else wise.
 ///
 /// # Safety
 ///
@@ -9,16 +30,32 @@ use chrono::{NaiveDateTime};
 #[no_mangle]
 pub unsafe extern "C" fn init_naive_date_time_at(
     place: *mut NaiveDateTime,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    minute: u32,
-    second: u32,
-    // rust millis or micros or nanos
-    // dart millis part and micros part no nanos
-) {
+    micros_since_naive_epoch: i64,
+) -> u8 {
+    let seconds = micros_since_naive_epoch / MICROS_PER_SECOND;
+    let nanos = (micros_since_naive_epoch % MICROS_PER_SECOND) * NANOS_PER_MICRO;
+    if let Some(date_time) = NaiveDateTime::from_timestamp_opt(seconds, nanos as u32) {
+        unsafe { place.write(date_time) }
+        1
+    } else {
+        0
+    }
+}
 
+/// Returns the number of micro seconds since since midnight on January 1, 1970.
+///
+/// More specifically it's the number of micro seconds since `1970-01-01T00:00:00Z` assuming
+/// the naive date time to be in UTC.
+///
+/// # Safety
+///
+/// The pointer must point to a sound initialized `NaiveDateTime` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_naive_date_time_micros_since_epoch(naive_date_time: *mut NaiveDateTime) -> i64 {
+    let naive_date_time = unsafe { &*naive_date_time };
+    let sub_micros = naive_date_time.timestamp_subsec_micros();
+    let seconds = naive_date_time.timestamp();
+    seconds * MICROS_PER_SECOND + sub_micros as i64
 }
 
 /// Alloc an uninitialized `Box<NaiveDateTime>`, mainly used for testing.

--- a/discovery_engine_core/bindings/src/types/date_time.rs
+++ b/discovery_engine_core/bindings/src/types/date_time.rs
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! FFI functions for handling date time fields.
+
 use std::convert::TryFrom;
 
 use chrono::{naive::MAX_DATETIME, NaiveDateTime};
@@ -29,7 +30,7 @@ const MIN_MICRO_SECONDS: i64 = -8_334_632_851_200_000_000;
 ///
 /// Returns `1` if it succeeded `0` else wise.
 ///
-/// A a time above the max or below the min supported
+/// A time above the max or below the min supported
 /// date time will be clamped to the max/min time.
 ///
 /// # Safety
@@ -53,7 +54,7 @@ pub unsafe extern "C" fn init_naive_date_time_at(
     }
 }
 
-/// Returns the number of micro seconds since since midnight on January 1, 1970.
+/// Returns the number of micro seconds since midnight on January 1, 1970.
 ///
 /// More specifically it's the number of micro seconds since `1970-01-01T00:00:00Z` assuming
 /// the naive date time to be in UTC.

--- a/discovery_engine_core/bindings/src/types/date_time.rs
+++ b/discovery_engine_core/bindings/src/types/date_time.rs
@@ -1,0 +1,38 @@
+use chrono::{NaiveDateTime};
+
+/// Creates a rust `NaiveDateTime` at given memory address.
+///
+/// # Safety
+///
+/// It must be valid to write a `NaiveDateTime` instance to given pointer,
+/// the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn init_naive_date_time_at(
+    place: *mut NaiveDateTime,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+    // rust millis or micros or nanos
+    // dart millis part and micros part no nanos
+) {
+
+}
+
+/// Alloc an uninitialized `Box<NaiveDateTime>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_naive_date_time() -> *mut NaiveDateTime {
+    super::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<NaiveDateTime>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent an initialized `Box<NaiveDateTime>`.
+#[no_mangle]
+pub unsafe extern "C" fn drop_naive_date_time(naive_date_time: *mut NaiveDateTime) {
+    unsafe { super::boxed::drop(naive_date_time) }
+}


### PR DESCRIPTION
Adds FFI support for converting rust `NaiveDateTime` from/to dart `DateTime`.

Required by #105/[TY-2392](https://xainag.atlassian.net/browse/TY-2392).