### PR TITLE
[Merged by Bors] - Ty-2381 Save serialized Engine state

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -26,14 +26,22 @@ import 'package:xayn_discovery_engine/src/domain/repository/active_document_repo
     show ActiveDocumentDataRepository;
 import 'package:xayn_discovery_engine/src/domain/repository/document_repo.dart'
     show DocumentRepository;
+import 'package:xayn_discovery_engine/src/domain/repository/engine_state_repo.dart'
+    show EngineStateRepository;
 
 /// Business logic concerning the management of documents.
 class DocumentManager {
   final Engine _engine;
   final DocumentRepository _documentRepo;
   final ActiveDocumentDataRepository _activeRepo;
+  final EngineStateRepository _engineStateRepo;
 
-  DocumentManager(this._engine, this._documentRepo, this._activeRepo);
+  DocumentManager(
+    this._engine,
+    this._documentRepo,
+    this._activeRepo,
+    this._engineStateRepo,
+  );
 
   /// Handle the given document client event.
   ///
@@ -72,6 +80,7 @@ class DocumentManager {
       smbertEmbedding: smbertEmbedding,
       reaction: userReaction,
     );
+    await _engineStateRepo.save(_engine.serialize());
   }
 
   /// Add additional viewing time for the given active document.
@@ -108,5 +117,6 @@ class DocumentManager {
       seconds: sumDuration,
       reaction: doc.userReaction,
     );
+    await _engineStateRepo.save(_engine.serialize());
   }
 }

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -23,6 +23,9 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
 
 /// Interface to Discovery Engine core.
 abstract class Engine {
+  /// Serializes the state of the [Engine] state.
+  Uint8List serialize();
+
   /// Retrieves at most [maxDocuments] feed documents.
   Map<Document, ActiveDocumentData> getFeedDocuments(int maxDocuments);
 

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -80,7 +80,10 @@ class MockEngine implements Engine {
   }
 
   @override
-  Uint8List serialize() => Uint8List(0);
+  Uint8List serialize() {
+    _incrementCount('serialize');
+    return Uint8List(0);
+  }
 
   @override
   Map<Document, ActiveDocumentData> getFeedDocuments(int maxDocuments) {

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -80,6 +80,9 @@ class MockEngine implements Engine {
   }
 
   @override
+  Uint8List serialize() => Uint8List(0);
+
+  @override
   Map<Document, ActiveDocumentData> getFeedDocuments(int maxDocuments) {
     _incrementCount('getFeedDocuments');
 

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -185,6 +185,7 @@ class EventHandler {
       engine,
       _documentRepository,
       _activeDataRepository,
+      _engineStateRepository,
     );
     _feedManager = FeedManager(
       engine,
@@ -192,6 +193,7 @@ class EventHandler {
       _documentRepository,
       _activeDataRepository,
       _changedDocumentRepository,
+      _engineStateRepository,
     );
 
     return engine;

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -26,6 +26,8 @@ import 'package:xayn_discovery_engine/src/domain/repository/changed_document_rep
     show ChangedDocumentRepository;
 import 'package:xayn_discovery_engine/src/domain/repository/document_repo.dart'
     show DocumentRepository;
+import 'package:xayn_discovery_engine/src/domain/repository/engine_state_repo.dart'
+    show EngineStateRepository;
 
 /// Business logic concerning the management of the feed.
 class FeedManager {
@@ -34,6 +36,7 @@ class FeedManager {
   final DocumentRepository _docRepo;
   final ActiveDocumentDataRepository _activeRepo;
   final ChangedDocumentRepository _changedRepo;
+  final EngineStateRepository _engineStateRepo;
 
   FeedManager(
     this._engine,
@@ -41,6 +44,7 @@ class FeedManager {
     this._docRepo,
     this._activeRepo,
     this._changedRepo,
+    this._engineStateRepo,
   );
 
   /// Handle the given feed client event.
@@ -76,6 +80,7 @@ class FeedManager {
   /// Obtain the next batch of feed documents and persist to repositories.
   Future<EngineEvent> nextFeedBatch() async {
     final feedDocs = _engine.getFeedDocuments(_maxDocs);
+    await _engineStateRepo.save(_engine.serialize());
 
     await _docRepo.updateMany(feedDocs.keys);
     for (final feedDoc in feedDocs.entries) {

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -58,7 +58,8 @@ Future<void> main() async {
   );
   final changedBox =
       await Hive.openBox<Uint8List>(changedDocumentIdBox, bytes: Uint8List(0));
-  await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
+  final stateBox =
+      await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
 
   final engine = MockEngine();
   final docRepo = HiveDocumentRepository();
@@ -100,6 +101,7 @@ Future<void> main() async {
       await docBox.clear();
       await activeBox.clear();
       await changedBox.clear();
+      await stateBox.clear();
 
       // reset test data
       doc1.isActive = true;
@@ -143,6 +145,9 @@ Future<void> main() async {
         docBox.values,
         unorderedEquals(<Document>[doc1..userReaction = newReaction, doc2]),
       );
+      // serialize should be called and state saved
+      expect(engine.getCallCount('serialize'), equals(1));
+      expect(stateBox.isNotEmpty, isTrue);
       // other repos unchanged
       expect(activeBox, hasLength(1));
       expect(await activeRepo.fetchById(id1), equals(data));
@@ -191,6 +196,11 @@ Future<void> main() async {
       await mgr.addActiveDocumentTime(id1, mode, 5);
 
       expect(activeBox, hasLength(1));
+
+      // serialize should be called and state saved
+      expect(engine.getCallCount('serialize'), equals(1));
+      expect(stateBox.isNotEmpty, isTrue);
+
       var dataUpdated = await activeRepo.fetchById(id1);
       expect(dataUpdated, isNotNull);
       expect(dataUpdated!.smbertEmbedding, equals(data.smbertEmbedding));
@@ -204,6 +214,7 @@ Future<void> main() async {
       await mgr.addActiveDocumentTime(id1, mode, 3);
 
       expect(activeBox, hasLength(1));
+      expect(engine.getCallCount('serialize'), equals(2));
       dataUpdated = await activeRepo.fetchById(id1);
       expect(dataUpdated, isNotNull);
       expect(dataUpdated!.smbertEmbedding, equals(data.smbertEmbedding));

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -29,13 +29,19 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
 import 'package:xayn_discovery_engine/src/domain/models/view_mode.dart'
     show DocumentViewMode;
 import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
-    show documentBox, activeDocumentDataBox, changedDocumentIdBox;
+    show
+        activeDocumentDataBox,
+        changedDocumentIdBox,
+        documentBox,
+        engineStateBox;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_document_repo.dart'
     show HiveActiveDocumentDataRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_changed_document_repo.dart'
     show HiveChangedDocumentRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_document_repo.dart'
     show HiveDocumentRepository;
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_state_repo.dart'
+    show HiveEngineStateRepository;
 
 import 'discovery_engine/utils/utils.dart';
 import 'logging.dart' show setupLogging;
@@ -52,13 +58,15 @@ Future<void> main() async {
   );
   final changedBox =
       await Hive.openBox<Uint8List>(changedDocumentIdBox, bytes: Uint8List(0));
+  await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
 
   final engine = MockEngine();
   final docRepo = HiveDocumentRepository();
   final activeRepo = HiveActiveDocumentDataRepository();
   final changedRepo = HiveChangedDocumentRepository();
+  final engineStateRepo = HiveEngineStateRepository();
 
-  final mgr = DocumentManager(engine, docRepo, activeRepo);
+  final mgr = DocumentManager(engine, docRepo, activeRepo, engineStateRepo);
 
   group('DocumentManager', () {
     final data = ActiveDocumentData(Uint8List(0));

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -58,7 +58,8 @@ Future<void> main() async {
   );
   final changedBox =
       await Hive.openBox<Uint8List>(changedDocumentIdBox, bytes: Uint8List(0));
-  await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
+  final stateBox =
+      await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
 
   final engine = MockEngine();
   const maxBatch = 5;
@@ -112,6 +113,7 @@ Future<void> main() async {
       await docBox.clear();
       await activeBox.clear();
       await changedBox.clear();
+      await stateBox.clear();
     });
 
     test('deactivate documents', () async {
@@ -152,6 +154,10 @@ Future<void> main() async {
       expect(activeBox, hasLength(3));
       expect(activeBox.values, contains(engine.active0));
       expect(activeBox.values, contains(engine.active1));
+
+      // serialize should be called and state saved
+      expect(engine.getCallCount('serialize'), equals(1));
+      expect(stateBox.isNotEmpty, isTrue);
     });
 
     test('restore feed', () async {

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -29,13 +29,19 @@ import 'package:xayn_discovery_engine/src/domain/models/document.dart'
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
-    show documentBox, activeDocumentDataBox, changedDocumentIdBox;
+    show
+        documentBox,
+        activeDocumentDataBox,
+        changedDocumentIdBox,
+        engineStateBox;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_document_repo.dart'
     show HiveActiveDocumentDataRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_changed_document_repo.dart'
     show HiveChangedDocumentRepository;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_document_repo.dart'
     show HiveDocumentRepository;
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_state_repo.dart'
+    show HiveEngineStateRepository;
 
 import 'discovery_engine/utils/utils.dart';
 import 'logging.dart' show setupLogging;
@@ -52,14 +58,23 @@ Future<void> main() async {
   );
   final changedBox =
       await Hive.openBox<Uint8List>(changedDocumentIdBox, bytes: Uint8List(0));
+  await Hive.openBox<Uint8List>(engineStateBox, bytes: Uint8List(0));
 
   final engine = MockEngine();
   const maxBatch = 5;
   final docRepo = HiveDocumentRepository();
   final activeRepo = HiveActiveDocumentDataRepository();
   final changedRepo = HiveChangedDocumentRepository();
+  final engineStateRepo = HiveEngineStateRepository();
 
-  final mgr = FeedManager(engine, maxBatch, docRepo, activeRepo, changedRepo);
+  final mgr = FeedManager(
+    engine,
+    maxBatch,
+    docRepo,
+    activeRepo,
+    changedRepo,
+    engineStateRepo,
+  );
 
   group('FeedManager', () {
     late ActiveDocumentData data;


### PR DESCRIPTION
[Jira ref](https://xainag.atlassian.net/browse/TY-2381)

This PR adds `serialize` method to the `Engine` interface and updates the managers so that after each call to the engine that changes its state, the state is serialized and stored in a database via `EngineStateRepository`.