### PR TITLE
[Merged by Bors] - TY-2366 build ios prod

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,8 @@ ANDROID_PLATFORM_VERSION="21"
 IOS_TARGETS="aarch64-apple-ios x86_64-apple-ios"
 IOS_LIB_BASE="libxayn_discovery_engine_bindings"
 
+PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes"
+
 JUST_VERSION=0.10.5
 # In the cases we want to use nightly we use the following version
 RUST_NIGHTLY=nightly-2021-09-09

--- a/.github/workflows/ci_build_ios.yml
+++ b/.github/workflows/ci_build_ios.yml
@@ -2,6 +2,12 @@ name: Build iOS library
 
 on:
   workflow_call:
+    inputs:
+      production:
+        description: Builds iOS libraries for production release (with additional optimizations)
+        default: false
+        required: false
+        type: boolean
     outputs:
       artifact-dir-base:
         description: The base name of artifact directory (without the target suffix)
@@ -14,10 +20,8 @@ jobs:
     strategy:
       matrix:
         target: ["aarch64-apple-ios", "x86_64-apple-ios"]
-    env:
-      ARTIFACT_DIR_BASE: ${{ github.job }}
     outputs:
-      artifact-dir-base: ${{ env.ARTIFACT_DIR_BASE }}
+      artifact-dir-base: ${{ steps.build.outputs.artifact-dir-base }}
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
@@ -29,7 +33,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build iOS library ${{ matrix.target }}
-        run: just compile-ios ${{ matrix.target }}
+        id: build
+        run: |
+          ARTIFACT_DIR_BASE=${{ github.job }}
+          if ${{ inputs.production }}; then
+            just compile-ios-ci ${{ matrix.target }} --prod
+            ARTIFACT_DIR_BASE+="production"
+          else
+            just compile-ios-ci ${{ matrix.target }}
+          fi
+          echo "::set-output name=artifact-dir-base::$ARTIFACT_DIR_BASE"
 
       - name: Prepare lib for upload
         id: lib
@@ -43,7 +56,7 @@ jobs:
       - name: Upload library artifacts
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-          name: ${{ env.ARTIFACT_DIR_BASE }}-${{ matrix.target }}-${{ github.sha }}
+          name: ${{ steps.build.outputs.artifact-dir-base }}-${{ matrix.target }}-${{ github.sha }}
           retention-days: 1
           if-no-files-found: error
           path: ${{ steps.lib.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ permissions:
   contents: read
 
 jobs:
+  build-ios-libs:
+    uses: ./.github/workflows/ci_build_ios.yml
+    with:
+      production: true
+
   release:
     runs-on: ubuntu-20.04
     timeout-minutes: 10


### PR DESCRIPTION
Ticket:

- [TY-2366]


**Update:** lto error was addressed in #140 

---

can't use `lto` because of:
https://github.com/rust-lang/rust/issues/51009

running:
`RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes" just compile-ios-local`

gives the error:
```
error: lto can only be run for executables, cdylibs and static library outputs

error: could not compile `hyper` due to previous error
```

but `-Ccodegen-units=1` alone still decreases the size from 221mb to 144mb

[TY-2366]: https://xainag.atlassian.net/browse/TY-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ