### PR TITLE
[Merged by Bors] - TY-2321 adapt ffi types

### DIFF
--- a/discovery_engine/lib/src/ffi/types/box.dart
+++ b/discovery_engine/lib/src/ffi/types/box.dart
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'dart:ffi' show NativeType, Pointer;
 
 class Boxed<RT extends NativeType> {

--- a/discovery_engine/lib/src/ffi/types/box.dart
+++ b/discovery_engine/lib/src/ffi/types/box.dart
@@ -1,0 +1,62 @@
+import 'dart:ffi' show NativeType, Pointer;
+
+class Boxed<RT extends NativeType> {
+  Pointer<RT> _ptr;
+  final void Function(Pointer<RT>) _free;
+
+  /// Creates a new wrapper instance.
+  ///
+  /// Ptr must point to a non-dangling instance of `RT`.
+  Boxed(this._ptr, this._free);
+
+  /// True if `free` or `move` was called.
+  bool get moved => _ptr.address == 0;
+
+  /// Returns the equivalent of an `&mut RT`.
+  ///
+  /// While the returned pointer is used _anywhere_ you must not:
+  ///
+  /// - call mut
+  /// - call ref
+  /// - call free
+  /// - call move
+  Pointer<RT> get mut {
+    if (moved) {
+      throw StateError('the pointer is no longer valid, either freed or moved');
+    }
+    return _ptr;
+  }
+
+  /// Returns the equivalent of an `&RT`.
+  ///
+  /// While the returned pointer is used _anywhere_ you must not:
+  ///
+  /// - call mut
+  /// - call free
+  /// - call move
+  Pointer<RT> get ref {
+    if (moved) {
+      throw StateError('the pointer is no longer valid, either freed or moved');
+    }
+    return _ptr;
+  }
+
+  /// Frees/drops the boxed type, if it wasn't already dropped or moved.
+  ///
+  /// Is always safe to call if this type was constructed/used correctly.
+  void free() {
+    if (!moved) {
+      _free(move());
+    }
+  }
+
+  /// Moves the instance out of this wrapper.
+  Pointer<RT> move() {
+    if (moved) {
+      throw StateError('the pointer is no longer valid, either freed or moved');
+    }
+    final res = _ptr;
+    _ptr = Pointer.fromAddress(0);
+    return res;
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/document/time_spent.dart
+++ b/discovery_engine/lib/src/ffi/types/document/time_spent.dart
@@ -21,6 +21,7 @@ import 'package:xayn_discovery_engine/discovery_engine.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustTimeSpent;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/document/user_reaction.dart'
     show UserReactionFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/duration.dart'
@@ -43,7 +44,7 @@ class TimeSpentFfi with EquatableMixin {
     required this.reaction,
   });
 
-  factory TimeSpentFfi.readFrom(final Pointer<RustTimeSpent> place) {
+  factory TimeSpentFfi.readNative(final Pointer<RustTimeSpent> place) {
     return TimeSpentFfi(
       id: DocumentIdFfi.readNative(ffi.time_spent_place_of_id(place)),
       smbertEmbedding: EmbeddingFfi.readNative(
@@ -56,7 +57,13 @@ class TimeSpentFfi with EquatableMixin {
     );
   }
 
-  void writeTo(final Pointer<RustTimeSpent> place) {
+  Boxed<RustTimeSpent> allocNative() {
+    final place = ffi.alloc_uninitialized_time_spend();
+    writeNative(place);
+    return Boxed(place, ffi.drop_time_spent);
+  }
+
+  void writeNative(final Pointer<RustTimeSpent> place) {
     id.writeNative(ffi.time_spent_place_of_id(place));
     smbertEmbedding
         .writeNative(ffi.time_spent_place_of_smbert_embedding(place));

--- a/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
+++ b/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
@@ -23,6 +23,7 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustUserReacted;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/document/user_reaction.dart'
     show UserReactionFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
@@ -46,7 +47,7 @@ class UserReactedFfi with EquatableMixin {
     required this.reaction,
   });
 
-  factory UserReactedFfi.readFrom(final Pointer<RustUserReacted> place) {
+  factory UserReactedFfi.readNative(final Pointer<RustUserReacted> place) {
     return UserReactedFfi(
       id: DocumentIdFfi.readNative(ffi.user_reacted_place_of_id(place)),
       stackId: StackIdFfi.readNative(ffi.user_reacted_place_of_stack_id(place)),
@@ -60,7 +61,13 @@ class UserReactedFfi with EquatableMixin {
     );
   }
 
-  void writeTo(final Pointer<RustUserReacted> place) {
+  Boxed<RustUserReacted> allocNative() {
+    final place = ffi.alloc_uninitialized_user_reacted();
+    writeNative(place);
+    return Boxed(place, ffi.drop_user_reacted);
+  }
+
+  void writeNative(final Pointer<RustUserReacted> place) {
     id.writeNative(ffi.user_reacted_place_of_id(place));
     stackId.writeNative(ffi.user_reacted_place_of_stack_id(place));
     snippet.writeNative(ffi.user_reacted_place_of_snippet(place));

--- a/discovery_engine/lib/src/ffi/types/feed_market_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/feed_market_vec.dart
@@ -18,6 +18,7 @@ import 'package:xayn_discovery_engine/discovery_engine.dart' show FeedMarket;
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustMarket, RustMarketVec;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market.dart'
     show FeedMarketFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/list.dart';
@@ -42,6 +43,12 @@ extension FeedMarketSliceFfi on List<FeedMarket> {
     final int len,
   ) =>
       _adapter.readSlice(ptr, len);
+
+  Boxed<RustMarketVec> allocVec() {
+    final place = ffi.alloc_uninitialized_market_vec();
+    writeVec(place);
+    return Boxed(place, ffi.drop_market_vec);
+  }
 
   /// Writes a rust-`Vec<RustMarket>` to given place.
   void writeVec(

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -23,10 +23,12 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustInitConfig;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
-import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
+    show NativeSetupData;
 
 class InitConfigFfi with EquatableMixin {
   final String apiKey;
@@ -79,6 +81,13 @@ class InitConfigFfi with EquatableMixin {
     required this.kpeCnn,
     required this.kpeClassifier,
   });
+
+  /// Allocates a `Box<RustInitConfig>` initialized based on this instance.
+  Boxed<RustInitConfig> allocNative() {
+    final place = ffi.alloc_uninitialized_init_config();
+    writeNative(place);
+    return Boxed(place, ffi.drop_init_config);
+  }
 
   void writeNative(Pointer<RustInitConfig> place) {
     apiKey.writeNative(ffi.init_config_place_of_api_key(place));

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -1,0 +1,71 @@
+import 'dart:ffi' show NativeType, Pointer;
+
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+import 'package:xayn_discovery_engine/src/ffi/types/document/document_vec.dart'
+    show DocumentSliceFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show Uint8ListFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+
+class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
+    RustOk extends NativeType, RustErr extends NativeType> {
+  final Pointer<RustOk> Function(Pointer<RustResult>) getOk;
+  final Pointer<RustErr> Function(Pointer<RustResult>) getErr;
+  final Ok Function(Pointer<RustOk>) readNativeOk;
+  final Err Function(Pointer<RustErr>) readNativeErr;
+
+  ResultFfiAdapter({
+    required this.getOk,
+    required this.getErr,
+    required this.readNativeOk,
+    required this.readNativeErr,
+  });
+
+  Ok readNative(
+    Pointer<RustResult> result, {
+    required Exception Function(Err) mapErr,
+  }) {
+    final ok = getOk(result);
+    if (ok.address != 0) {
+      return readNativeOk(ok);
+    }
+    final err = getErr(result);
+    if (err.address != 0) {
+      throw mapErr(readNativeErr(err));
+    }
+    throw AssertionError('result should be either Ok or Err');
+  }
+
+  Ok consumeNative(
+    Boxed<RustResult> result, {
+    required Exception Function(Err) mapErr,
+  }) {
+    try {
+      return readNative(result.ref, mapErr: mapErr);
+    } finally {
+      result.free();
+    }
+  }
+}
+
+final resultVoidStringFfiAdapter = ResultFfiAdapter(
+  getOk: ffi.get_result_void_string_ok,
+  getErr: ffi.get_result_void_string_err,
+  readNativeOk: (_) {},
+  readNativeErr: StringFfi.readNative,
+);
+
+final resultVecU8StringFfiAdapter = ResultFfiAdapter(
+  getOk: ffi.get_result_vec_u8_string_ok,
+  getErr: ffi.get_result_vec_u8_string_err,
+  readNativeOk: Uint8ListFfi.readNative,
+  readNativeErr: StringFfi.readNative,
+);
+
+final resultVecDocumentStringFfiAdapter = ResultFfiAdapter(
+  getOk: ffi.get_result_vec_document_string_ok,
+  getErr: ffi.get_result_vec_document_string_err,
+  readNativeOk: DocumentSliceFfi.readVec,
+  readNativeErr: StringFfi.readNative,
+);

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'dart:ffi' show NativeType, Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;

--- a/discovery_engine/test/ffi/types/box_test.dart
+++ b/discovery_engine/test/ffi/types/box_test.dart
@@ -1,4 +1,18 @@
-import 'dart:ffi';
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi' show Pointer, Uint32;
 
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;

--- a/discovery_engine/test/ffi/types/box_test.dart
+++ b/discovery_engine/test/ffi/types/box_test.dart
@@ -1,0 +1,47 @@
+import 'dart:ffi';
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+
+void main() {
+  const address = 4;
+  final dangling = Pointer<Uint32>.fromAddress(address);
+
+  test('ref/mut point to the right address', () {
+    final box = Boxed(dangling, (_) {
+      throw AssertionError('free is not supposed to be called here');
+    });
+    expect(box.ref, equals(dangling));
+    expect(box.mut, equals(dangling));
+  });
+  
+  test('move moves the ownership', () {
+    final box = Boxed(dangling, (_) {
+      throw AssertionError('free is not supposed to be called here');
+    });
+    expect(box.moved, isFalse);
+    expect(box.ref, equals(dangling));
+    expect(box.mut, equals(dangling));
+    expect(box.move(), equals(dangling));
+    expect(box.moved, isTrue);
+    expect(() {
+      box.ref;
+    }, throwsStateError,);
+    expect(() {
+      box.mut;
+    }, throwsStateError,);
+  });
+
+  test('free calls free and moves ownership', () {
+    var freed = false;
+    final box = Boxed(dangling, (ptr) {
+      expect(ptr, equals(dangling));
+      freed = true;
+    });
+    expect(box.moved, isFalse);
+    expect(box.ref, equals(dangling));
+    box.free();
+    expect(freed, isTrue);
+    expect(box.moved, isTrue);
+  });
+}

--- a/discovery_engine/test/ffi/types/box_test.dart
+++ b/discovery_engine/test/ffi/types/box_test.dart
@@ -14,7 +14,7 @@ void main() {
     expect(box.ref, equals(dangling));
     expect(box.mut, equals(dangling));
   });
-  
+
   test('move moves the ownership', () {
     final box = Boxed(dangling, (_) {
       throw AssertionError('free is not supposed to be called here');
@@ -24,12 +24,18 @@ void main() {
     expect(box.mut, equals(dangling));
     expect(box.move(), equals(dangling));
     expect(box.moved, isTrue);
-    expect(() {
-      box.ref;
-    }, throwsStateError,);
-    expect(() {
-      box.mut;
-    }, throwsStateError,);
+    expect(
+      () {
+        box.ref;
+      },
+      throwsStateError,
+    );
+    expect(
+      () {
+        box.mut;
+      },
+      throwsStateError,
+    );
   });
 
   test('free calls free and moves ownership', () {

--- a/discovery_engine/test/ffi/types/document/time_spent_test.dart
+++ b/discovery_engine/test/ffi/types/document/time_spent_test.dart
@@ -31,8 +31,8 @@ void main() {
       reaction: UserReaction.negative,
     );
     final place = ffi.alloc_uninitialized_time_spend();
-    timeSpent.writeTo(place);
-    final res = TimeSpentFfi.readFrom(place);
+    timeSpent.writeNative(place);
+    final res = TimeSpentFfi.readNative(place);
     ffi.drop_time_spent(place);
     expect(res, equals(timeSpent));
   });

--- a/discovery_engine/test/ffi/types/document/user_reacted_test.dart
+++ b/discovery_engine/test/ffi/types/document/user_reacted_test.dart
@@ -18,7 +18,6 @@ import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart';
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
-import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/user_reacted.dart'
     show UserReactedFfi;
 
@@ -31,10 +30,9 @@ void main() {
       smbertEmbedding: Float32List.fromList([.9, .1]),
       reaction: UserReaction.negative,
     );
-    final place = ffi.alloc_uninitialized_user_reacted();
-    document.writeTo(place);
-    final res = UserReactedFfi.readFrom(place);
-    ffi.drop_user_reacted(place);
+    final boxed = document.allocNative();
+    final res = UserReactedFfi.readNative(boxed.ref);
+    boxed.free();
     expect(res, equals(document));
   });
 }

--- a/discovery_engine/test/ffi/types/embedding_test.dart
+++ b/discovery_engine/test/ffi/types/embedding_test.dart
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:typed_data';
+import 'dart:typed_data' show Float32List;
 
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;

--- a/discovery_engine/test/ffi/types/feed_market_vec_test.dart
+++ b/discovery_engine/test/ffi/types/feed_market_vec_test.dart
@@ -14,7 +14,6 @@
 
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/api/api.dart';
-import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
 
@@ -30,9 +29,9 @@ void main() {
         langCode: 'ED',
       )
     ];
-    final ptr = market.createSlice();
-    final res = FeedMarketSliceFfi.readSlice(ptr, market.length);
-    ffi.drop_market_slice(ptr, market.length);
+    final boxed = market.allocVec();
+    final res = FeedMarketSliceFfi.readVec(boxed.ref);
+    boxed.free();
     expect(market, equals(res));
   });
 }

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -13,8 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:test/test.dart';
-import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart';
-import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
+    show FeedMarket;
 import 'package:xayn_discovery_engine/src/ffi/types/init_config.dart'
     show InitConfigFfi;
 
@@ -34,10 +34,9 @@ void main() {
       kpeCnn: 'abc',
       kpeClassifier: 'magic',
     );
-    final place = ffi.alloc_uninitialized_init_config();
-    config.writeNative(place);
-    final res = InitConfigFfi.readNative(place);
-    ffi.drop_init_config(place);
+    final boxed = config.allocNative();
+    final res = InitConfigFfi.readNative(boxed.ref);
+    boxed.free();
     expect(res, equals(config));
   });
 }

--- a/discovery_engine/test/ffi/types/primitives_test.dart
+++ b/discovery_engine/test/ffi/types/primitives_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show Uint8ListFfi;
+
+void main() {
+  test('reading written bytes', () {
+    final bytes = Uint8List.fromList([1, 4, 3, 2]);
+    final nativeBytes = bytes.allocNative();
+    final res = Uint8ListFfi.readNative(nativeBytes.ref);
+    nativeBytes.free();
+    expect(res, equals(bytes));
+  });
+}

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -19,6 +19,7 @@ typedef struct RustTimeSpent RustTimeSpent;
 typedef struct RustUrl RustUrl;
 typedef struct RustUserReacted RustUserReacted;
 typedef struct RustUuid RustUuid;
+typedef struct RustVecU8 RustVecU8;
 """
 
 [parse]
@@ -29,6 +30,7 @@ include = ["xayn-discovery-engine-core"]
 # Renamings to avoid name conflicts/confusion in dart.
 "Document" = "RustDocument"
 "Vec_Document" = "RustDocumentVec"
+"Vec_u8" = "RustVecU8"
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
 "InitConfig" = "RustInitConfig"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -19,7 +19,6 @@ typedef struct RustTimeSpent RustTimeSpent;
 typedef struct RustUrl RustUrl;
 typedef struct RustUserReacted RustUserReacted;
 typedef struct RustUuid RustUuid;
-typedef struct RustVecU8 RustVecU8;
 """
 
 [parse]
@@ -39,6 +38,9 @@ include = ["xayn-discovery-engine-core"]
 "Market" = "RustMarket"
 "Option_f32" = "RustOptionF32"
 "Option_Url" = "RustOptionUrl"
+"Result_String" = "RustResultVoidString"
+"Result_Vec_Document_____String" = "RustResultVecDocumentString"
+"Result_Vec_u8_____String" = "RustResultVecU8String"
 "String" = "RustString"
 "TimeSpent" = "RustTimeSpent"
 "Url" = "RustUrl"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -24,6 +24,7 @@ pub mod market;
 pub mod market_vec;
 pub mod option;
 pub mod primitives;
+pub mod result;
 pub mod slice;
 pub mod string;
 pub mod url;

--- a/discovery_engine_core/bindings/src/types/embedding.rs
+++ b/discovery_engine_core/bindings/src/types/embedding.rs
@@ -94,7 +94,7 @@ mod tests {
 
     use ndarray::arr1;
 
-    use crate::types::slice::alloc_uninitialized_f32_slice;
+    use crate::types::primitives::alloc_uninitialized_f32_slice;
 
     use super::*;
 

--- a/discovery_engine_core/bindings/src/types/market_vec.rs
+++ b/discovery_engine_core/bindings/src/types/market_vec.rs
@@ -21,6 +21,8 @@ use crate::types::{
     vec::{get_vec_buffer, get_vec_len},
 };
 
+use super::boxed::{self, alloc_uninitialized};
+
 /// Initializes a `Vec<Market>` at given place.
 ///
 /// This moves the passed in slice into the vector,
@@ -49,6 +51,34 @@ pub extern "C" fn alloc_uninitialized_market_slice(len: usize) -> *mut Market {
     alloc_uninitialized_slice(len)
 }
 
+/// Drop a `Box<[Market]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[Market]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_market_slice(markets: *mut Market, len: usize) {
+    drop(unsafe { boxed_slice_from_raw_parts(markets, len) });
+}
+
+/// Alloc an uninitialized `Box<Vec<Market>>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_market_vec() -> *mut Vec<Market> {
+    alloc_uninitialized()
+}
+
+/// Drop a `Box<Vec<Market>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Vec<Market>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_market_vec(markets: *mut Vec<Market>) {
+    unsafe {
+        boxed::drop(markets);
+    }
+}
+
 /// Given a pointer to a [`Market`] in a slice return the pointer to the next [`Market`].
 ///
 /// This also works if the slice is uninitialized.
@@ -61,16 +91,6 @@ pub extern "C" fn alloc_uninitialized_market_slice(len: usize) -> *mut Market {
 #[no_mangle]
 pub unsafe extern "C" fn next_market(place: *mut Market) -> *mut Market {
     unsafe { next_element(place) }
-}
-
-/// Drop a `Box<[Market]>`.
-///
-/// # Safety
-///
-/// The pointer must represent a valid `Box<[Market]>` instance.
-#[no_mangle]
-pub unsafe extern "C" fn drop_market_slice(markets: *mut Market, len: usize) {
-    drop(unsafe { boxed_slice_from_raw_parts(markets, len) });
 }
 
 /// Returns the length of a `Box<Vec<Market>>`.

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -14,7 +14,12 @@
 
 //! Modules containing FFI glue for handling primitives (expect `str`/`slice`).
 
-use super::{option::get_option_some, slice::{boxed_slice_from_raw_parts, alloc_uninitialized_slice}, vec::{alloc_vec, get_vec_len, get_vec_buffer}, boxed};
+use super::{
+    boxed,
+    option::get_option_some,
+    slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts},
+    vec::{alloc_vec, get_vec_buffer, get_vec_len},
+};
 
 /// Initializes a rust `Option<f32>` to `Some(value)`.
 ///
@@ -53,7 +58,6 @@ pub unsafe extern "C" fn init_none_f32_at(place: *mut Option<f32>) {
 pub unsafe extern "C" fn get_option_f32_some(option: *const Option<f32>) -> *const f32 {
     unsafe { get_option_some(option) }
 }
-
 
 /// Allocates an uninitialized array of floats.
 #[no_mangle]
@@ -98,6 +102,10 @@ pub unsafe extern "C" fn alloc_vec_u8(slice_ptr: *mut u8, slice_len: usize) -> *
 }
 
 /// Drops a `Box<Vec<u8>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a `Box<Vec<u8>>`.
 #[no_mangle]
 pub unsafe extern "C" fn drop_vec_u8(ptr: *mut Vec<u8>) {
     unsafe { boxed::drop(ptr) }

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -14,7 +14,7 @@
 
 //! Modules containing FFI glue for handling primitives (expect `str`/`slice`).
 
-use super::option::get_option_some;
+use super::{option::get_option_some, slice::{boxed_slice_from_raw_parts, alloc_uninitialized_slice}, vec::{alloc_vec, get_vec_len, get_vec_buffer}, boxed};
 
 /// Initializes a rust `Option<f32>` to `Some(value)`.
 ///
@@ -52,4 +52,73 @@ pub unsafe extern "C" fn init_none_f32_at(place: *mut Option<f32>) {
 #[no_mangle]
 pub unsafe extern "C" fn get_option_f32_some(option: *const Option<f32>) -> *const f32 {
     unsafe { get_option_some(option) }
+}
+
+
+/// Allocates an uninitialized array of floats.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_f32_slice(len: usize) -> *mut f32 {
+    alloc_uninitialized_slice(len)
+}
+
+/// Drops a `Box<[f32]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[f32]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_f32_slice(ptr: *mut f32, len: usize) {
+    drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
+}
+
+/// Allocates an uninitialized array of bytes.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_bytes(len: usize) -> *mut u8 {
+    alloc_uninitialized_slice(len)
+}
+
+/// Drops a `Box<[u8]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[u8]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: usize) {
+    drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
+}
+
+/// Allocates a `Box<Vec<u8>>` moving given boxed slice into it.
+///
+/// # Safety
+///
+/// - Constructing a `Box<[u8]>` from given `slice_ptr`,`slice_len` must be sound.
+#[no_mangle]
+pub unsafe extern "C" fn alloc_vec_u8(slice_ptr: *mut u8, slice_len: usize) -> *mut Vec<u8> {
+    unsafe { alloc_vec(slice_ptr, slice_len) }
+}
+
+/// Drops a `Box<Vec<u8>>`.
+#[no_mangle]
+pub unsafe extern "C" fn drop_vec_u8(ptr: *mut Vec<u8>) {
+    unsafe { boxed::drop(ptr) }
+}
+
+/// Returns the length of a `Box<Vec<u8>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<u8>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_vec_u8_len(vec: *mut Vec<u8>) -> usize {
+    unsafe { get_vec_len(vec) }
+}
+
+/// Returns the `*mut u8` to the beginning of the buffer of a `Box<Vec<u8>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<u8>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_vec_u8_buffer(vec: *mut Vec<u8>) -> *mut u8 {
+    unsafe { get_vec_buffer(vec) }
 }

--- a/discovery_engine_core/bindings/src/types/result.rs
+++ b/discovery_engine_core/bindings/src/types/result.rs
@@ -1,0 +1,143 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Modules containing FFI glue for handling `Result` instances.
+
+use std::ptr;
+
+use core::document::Document;
+
+use super::boxed;
+
+/// Returns a pointer to the `Result::Ok` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<O, E>` instance.
+pub(super) unsafe fn get_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
+    match unsafe { &mut *res } {
+        Ok(value) => value,
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Returns a pointer to the `Result::Err` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<O, E>` instance.
+pub(super) unsafe fn get_result_err<O, E>(res: *mut Result<O, E>) -> *mut E {
+    match unsafe { &mut *res } {
+        Ok(_) => ptr::null_mut(),
+        Err(err) => err,
+    }
+}
+
+/// Returns a pointer to the `Result::Ok` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Vec<u8>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_vec_u8_string_ok(
+    res: *mut Result<Vec<u8>, String>,
+) -> *mut Vec<u8> {
+    unsafe { get_result_ok(res) }
+}
+
+/// Returns a pointer to the `Result::Err` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Vec<u8>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_vec_u8_string_err(
+    res: *mut Result<Vec<u8>, String>,
+) -> *mut String {
+    unsafe { get_result_err(res) }
+}
+
+/// Drops a `Box<Result<Vec<u8>, String>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Result<Vec<u8>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_result_vec_u8_string(res: *mut Box<Result<Vec<u8>, String>>) {
+    unsafe { boxed::drop(res) }
+}
+
+/// Returns a pointer to the `Result::Ok` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Vec<Document>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_vec_document_string_ok(
+    res: *mut Result<Vec<Document>, String>,
+) -> *mut Vec<Document> {
+    unsafe { get_result_ok(res) }
+}
+
+/// Returns a pointer to the `Result::Err` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Vec<Document>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_vec_document_string_err(
+    res: *mut Result<Vec<Document>, String>,
+) -> *mut String {
+    unsafe { get_result_err(res) }
+}
+
+/// Drops a `Result<Vec<Document>, String>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Result<Vec<Document>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_result_vec_document_string(res: *mut Result<Vec<Document>, String>) {
+    unsafe { boxed::drop(res) }
+}
+
+/// Returns a pointer to the `Result::Ok` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<(), String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_void_string_ok(res: *mut Result<(), String>) -> *mut () {
+    unsafe { get_result_ok(res) }
+}
+
+/// Returns a pointer to the `Result::Err` value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<()>, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_void_string_err(res: *mut Result<(), String>) -> *mut String {
+    unsafe { get_result_err(res) }
+}
+
+/// Drops a `Result<(), String>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Result<(), String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_result_void_string(res: *mut Result<(), String>) {
+    unsafe { boxed::drop(res) }
+}

--- a/discovery_engine_core/bindings/src/types/slice.rs
+++ b/discovery_engine_core/bindings/src/types/slice.rs
@@ -42,35 +42,3 @@ pub(super) unsafe fn boxed_slice_from_raw_parts<T>(ptr: *mut T, len: usize) -> B
 pub(super) unsafe fn next_element<T>(element: *mut T) -> *mut T {
     unsafe { element.offset(1) }
 }
-
-/// Allocates an uninitialized array of floats.
-#[no_mangle]
-pub extern "C" fn alloc_uninitialized_f32_slice(len: usize) -> *mut f32 {
-    alloc_uninitialized_slice(len)
-}
-
-/// Drops a `Box<[f32]>`.
-///
-/// # Safety
-///
-/// The pointer must represent a valid `Box<[f32]>` instance.
-#[no_mangle]
-pub unsafe extern "C" fn drop_f32_slice(ptr: *mut f32, len: usize) {
-    drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
-}
-
-/// Allocates an uninitialized array of bytes.
-#[no_mangle]
-pub extern "C" fn alloc_uninitialized_bytes(len: usize) -> *mut u8 {
-    alloc_uninitialized_slice(len)
-}
-
-/// Drops a `Box<[u8]>`.
-///
-/// # Safety
-///
-/// The pointer must represent a valid `Box<[u8]>` instance.
-#[no_mangle]
-pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: usize) {
-    drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
-}

--- a/discovery_engine_core/bindings/src/types/vec.rs
+++ b/discovery_engine_core/bindings/src/types/vec.rs
@@ -14,6 +14,8 @@
 
 //! Modules containing FFI glue for `Vec<T>`.
 
+use super::slice::boxed_slice_from_raw_parts;
+
 /// Get length of a `Box<Vec<T>>`.
 pub(super) unsafe fn get_vec_len<T>(vec: *mut Vec<T>) -> usize {
     unsafe { &*vec }.len()
@@ -22,4 +24,14 @@ pub(super) unsafe fn get_vec_len<T>(vec: *mut Vec<T>) -> usize {
 /// Get a pointer to the beginning of a `Box<Vec<T>>`'s buffer.
 pub(super) unsafe fn get_vec_buffer<T>(vec: *mut Vec<T>) -> *mut T {
     unsafe { &mut *vec }.as_mut_ptr()
+}
+
+/// Allocates a `Box<Vec<T>>` moving given boxed slice into it.
+///
+/// # Safety
+///
+/// - Constructing a `Box<[T]>` from given `slice_ptr`,`slice_len` must be sound.
+pub(super) unsafe fn alloc_vec<T>(slice_ptr: *mut T, slice_len: usize) -> *mut Vec<T> {
+    let boxed_slice = unsafe { boxed_slice_from_raw_parts(slice_ptr, slice_len) };
+    Box::into_raw(Box::new(Vec::from(boxed_slice)))
 }

--- a/discovery_engine_core/bindings/src/types/vec.rs
+++ b/discovery_engine_core/bindings/src/types/vec.rs
@@ -15,13 +15,11 @@
 //! Modules containing FFI glue for `Vec<T>`.
 
 /// Get length of a `Box<Vec<T>>`.
-#[allow(dead_code)]
 pub(super) unsafe fn get_vec_len<T>(vec: *mut Vec<T>) -> usize {
     unsafe { &*vec }.len()
 }
 
 /// Get a pointer to the beginning of a `Box<Vec<T>>`'s buffer.
-#[allow(dead_code)]
 pub(super) unsafe fn get_vec_buffer<T>(vec: *mut Vec<T>) -> *mut T {
     unsafe { &mut *vec }.as_mut_ptr()
 }

--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ _codegen-order-workaround:
 # Checks rust code, fails on warnings on CI
 rust-check: _codegen-order-workaround
     cd "$RUST_WORKSPACE"; \
-    cargo clippy --all-targets --locked #TODO DENY WARNINGS ON CI
+    cargo clippy --all-targets --locked
 
 # Checks rust and dart code, fails if there are any issues on CI
 check: rust-check dart-check flutter-check


### PR DESCRIPTION
 
- [x] adds a `Boxed` type in dart we can use for the `InitConfig`, `UserReacted`, `Vec<u8>`, `Vec<Market>` FFI types (and `allocNative` dart function)
- [x] add boxed `Result` support `Box<Result<(), String>>`, `Box<Result<Vec<core::document::Document>, String>>`,  `Box<Result<Vec<u8>, String>>`,