### PR TITLE
[Merged by Bors] - Always fail dart-check on infos from dart analyze.

### DIFF
--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -83,7 +83,7 @@ jobs:
     needs: [selection, cargo-test]
     if: ${{ always()}}
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check cargo-test
         run: |

--- a/justfile
+++ b/justfile
@@ -74,11 +74,11 @@ fmt: rust-fmt dart-fmt
 # Checks dart code, fails on info on CI
 dart-check: dart-build
     cd "$DART_WORKSPACE"; \
-    dart analyze {{ if env_var_or_default("CI", "false") == "true" { "--fatal-infos" } else { "" } }}
+    dart analyze --fatal-infos
 
 flutter-check: dart-build flutter-deps
     cd "$FLUTTER_WORKSPACE"; \
-    dart analyze {{ if env_var_or_default("CI", "false") == "true" { "--fatal-infos" } else { "" } }}
+    dart analyze --fatal-infos
 
 flutter-test: dart-build flutter-deps
     cd "$FLUTTER_WORKSPACE"; \


### PR DESCRIPTION
Since check now also runs flutter it's really easy to overlook "infos" when running `just check`.

As we anyway treat them as errors later on and I already run multiple times into situation where 
I overlooked some I would argue it's best to always fail on `info` (they are also always easy to
fix).

