### PR TITLE
[Merged by Bors] - TY-2416 decouple ranker from ops

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -208,7 +208,6 @@ pub struct UserReacted {
     pub reaction: UserReaction,
 }
 
-#[allow(dead_code)]
 pub(crate) fn document_from_article(
     article: Article,
     stack_id: StackId,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -25,7 +25,7 @@ use xayn_ai::{
 };
 
 use crate::{
-    document::{Document, TimeSpent, UserReacted},
+    document::{self, document_from_article, Document, TimeSpent, UserReacted},
     mab::{self, BetaSampler, SelectionIter},
     ranker::Ranker,
     stack::{
@@ -65,6 +65,9 @@ pub enum Error {
 
     /// Error while using the ranker.
     Ranker(#[from] GenericError),
+
+    /// Document-related error.
+    Document(#[from] document::Error),
 
     /// A list of errors that could occur during some operation.
     Errors(Vec<Error>),
@@ -292,15 +295,34 @@ where
         let mut errors = Vec::new();
         for stack in self.stacks.write().await.values_mut() {
             if stack.len() <= request_new {
-                match stack.ops.new_items(key_phrases).await {
-                    Ok(documents) => {
-                        if let Err(error) = stack.update(&documents, &mut self.ranker) {
-                            errors.push(Error::StackOpFailed(error));
-                        } else {
-                            stack.data.retain_top(self.core_config.keep_top);
+                match stack.ops.new_items(key_phrases).await.and_then(|articles| {
+                    articles
+                        .into_iter()
+                        .map(|article| {
+                            self.ranker
+                                .compute_smbert(article.title.as_str())
+                                .map(|embedding| (article, embedding))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                }) {
+                    Err(gen_err) => errors.push(gen_err.into()),
+                    Ok(art_embs) => {
+                        let id = stack.id();
+                        match art_embs
+                            .into_iter()
+                            .map(|(art, emb)| document_from_article(art, id, emb))
+                            .collect::<Result<Vec<_>, _>>()
+                        {
+                            Ok(documents) => {
+                                if let Err(error) = stack.update(&documents, &mut self.ranker) {
+                                    errors.push(Error::StackOpFailed(error));
+                                } else {
+                                    stack.data.retain_top(self.core_config.keep_top);
+                                }
+                            }
+                            Err(error) => errors.push(error.into()),
                         }
                     }
-                    Err(error) => errors.push(error.into()),
                 }
             }
         }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -295,7 +295,11 @@ where
         let mut errors = Vec::new();
         for stack in self.stacks.write().await.values_mut() {
             if stack.len() <= request_new {
-                let articles = stack.filter_new_articles(key_phrases).await;
+                let articles = stack
+                    .new_items(key_phrases)
+                    .await
+                    .and_then(|articles| stack.filter_articles(articles));
+
                 match articles.map_err(Error::StackOpFailed).and_then(|articles| {
                     let id = stack.id();
                     articles

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -57,11 +57,8 @@ pub enum Error {
     /// Invalid stack id: {0}.
     InvalidStackId(StackId),
 
-    /// An operation on a stack failed with a stack error: {0}.
+    /// An operation on a stack failed: {0}.
     StackOpFailed(#[source] stack::Error),
-
-    /// An operation on a stack failed with a generic error: {0}.
-    StackOpGen(#[source] GenericError),
 
     /// Error while selecting the documents to return: {0}.
     Selection(#[from] mab::Error),
@@ -298,8 +295,8 @@ where
         let mut errors = Vec::new();
         for stack in self.stacks.write().await.values_mut() {
             if stack.len() <= request_new {
-                let articles = stack.ops.new_items(key_phrases).await;
-                match articles.map_err(Error::StackOpGen).and_then(|articles| {
+                let articles = stack.filter_new_articles(key_phrases).await;
+                match articles.map_err(Error::StackOpFailed).and_then(|articles| {
                     let id = stack.id();
                     articles
                         .into_iter()

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -292,7 +292,7 @@ where
         let mut errors = Vec::new();
         for stack in self.stacks.write().await.values_mut() {
             if stack.len() <= request_new {
-                match stack.ops.new_items(key_phrases, &self.ranker).await {
+                match stack.ops.new_items(key_phrases).await {
                     Ok(documents) => {
                         if let Err(error) = stack.update(&documents, &mut self.ranker) {
                             errors.push(Error::StackOpFailed(error));

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -41,6 +41,9 @@ pub trait Ranker {
 
     /// Serializes the state of the `Ranker`.
     fn serialize(&self) -> Result<Vec<u8>, GenericError>;
+
+    /// Computes the S-mBert embedding of the given `sequence`.
+    fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError>;
 }
 
 impl Ranker for xayn_ai::ranker::Ranker {
@@ -72,6 +75,10 @@ impl Ranker for xayn_ai::ranker::Ranker {
 
     fn serialize(&self) -> Result<Vec<u8>, GenericError> {
         self.serialize().map_err(Into::into)
+    }
+
+    fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError> {
+        self.compute_smbert(sequence).map_err(Into::into)
     }
 }
 

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -206,7 +206,7 @@ mod tests {
     // TODO use our own when exposed as a crate
     use float_cmp::approx_eq;
 
-    use crate::{document::Id as DocumentId, stack::ops::tests::MockOps};
+    use crate::{document::Id as DocumentId, stack::ops::MockOps};
 
     use super::*;
 

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -20,6 +20,7 @@ use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+use xayn_discovery_engine_providers::Article;
 
 use crate::{
     document::{Document, Id as DocumentId, UserReaction},
@@ -162,12 +163,16 @@ impl Stack {
         self.data.documents.is_empty()
     }
 
-    /// Returns a filtered list of new articles.
-    pub(crate) async fn filter_new_articles(
+    /// Returns a list of new articles.
+    pub(crate) async fn new_items(
         &self,
         key_phrases: &[xayn_ai::ranker::KeyPhrase],
-    ) -> Result<Vec<xayn_discovery_engine_providers::Article>, Error> {
-        let articles = self.ops.new_items(key_phrases).await.map_err(Error::New)?;
+    ) -> Result<Vec<Article>, Error> {
+        self.ops.new_items(key_phrases).await.map_err(Error::New)
+    }
+
+    /// Filters a list of articles
+    pub(crate) fn filter_articles(&self, articles: Vec<Article>) -> Result<Vec<Article>, Error> {
         self.ops
             .filter_articles(&self.data.documents, articles)
             .map_err(Error::Filter)

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -44,7 +44,7 @@ pub trait Ops {
     ///
     /// Personalized key phrases can be optionally used to return items
     /// tailored to the user's interests.
-    async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Document>, GenericError>;
+    async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError>;
 
     /// Filter `articles` based on `current` documents.
     fn filter_articles(
@@ -75,7 +75,7 @@ pub(crate) mod tests {
             async fn new_items(
                 &self,
                 key_phrases: &[KeyPhrase],
-            ) -> Result<Vec<Document>, GenericError>;
+            ) -> Result<Vec<Article>, GenericError>;
 
             fn filter_articles(
                 &self,

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -25,10 +25,14 @@ use crate::{
 };
 use xayn_ai::ranker::KeyPhrase;
 
+#[cfg(test)]
+use mockall::automock;
+
 /// Operations to customize the behaviour of a stack.
 ///
 /// Each stack can get and select new items using different sources
 /// or different strategies.
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait Ops {
     /// Get the id for this set of operations.
@@ -59,37 +63,7 @@ pub trait Ops {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use mockall::mock;
-
     use super::*;
-
-    mock! {
-        pub(crate) Ops {}
-
-        #[async_trait]
-        impl Ops for Ops {
-            fn id(&self) -> Id;
-
-            fn configure(&mut self, config: &EndpointConfig);
-
-            async fn new_items(
-                &self,
-                key_phrases: &[KeyPhrase],
-            ) -> Result<Vec<Article>, GenericError>;
-
-            fn filter_articles(
-                &self,
-                current: &[Document],
-                articles: Vec<Article>,
-            ) -> Result<Vec<Article>, GenericError>;
-
-            fn merge(
-                &self,
-                current: &[Document],
-                new: &[Document],
-            ) -> Result<Vec<Document>, GenericError>;
-        }
-    }
 
     // check that Ops is object safe
     #[test]

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use xayn_ai::ranker::KeyPhrase;
+use xayn_discovery_engine_providers::Article;
 
 use crate::{
     document::Document,
     engine::{EndpointConfig, GenericError, Market},
-    ranker::Ranker,
     stack::Id,
 };
 
@@ -44,11 +44,15 @@ impl Ops for BreakingNews {
         self.markets.replace(Arc::clone(&config.markets));
     }
 
-    async fn new_items<'a>(
+    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Document>, GenericError> {
+        todo!();
+    }
+
+    fn filter_articles(
         &self,
-        _key_phrases: &[KeyPhrase],
-        _ranker: &'a (dyn Ranker + Sync),
-    ) -> Result<Vec<Document>, GenericError> {
+        _current: &[Document],
+        _articles: Vec<Article>,
+    ) -> Result<Vec<Article>, GenericError> {
         todo!();
     }
 

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -44,7 +44,7 @@ impl Ops for BreakingNews {
         self.markets.replace(Arc::clone(&config.markets));
     }
 
-    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Document>, GenericError> {
+    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
         todo!();
     }
 

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -44,7 +44,7 @@ impl Ops for PersonalizedNews {
         self.markets.replace(Arc::clone(&config.markets));
     }
 
-    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Document>, GenericError> {
+    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
         todo!();
     }
 

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use xayn_ai::ranker::KeyPhrase;
+use xayn_discovery_engine_providers::Article;
 
 use crate::{
     document::Document,
     engine::{EndpointConfig, GenericError, Market},
-    ranker::Ranker,
     stack::Id,
 };
 
@@ -44,11 +44,15 @@ impl Ops for PersonalizedNews {
         self.markets.replace(Arc::clone(&config.markets));
     }
 
-    async fn new_items<'a>(
+    async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Document>, GenericError> {
+        todo!();
+    }
+
+    fn filter_articles(
         &self,
-        _key_phrases: &[KeyPhrase],
-        _ranker: &'a (dyn Ranker + Sync),
-    ) -> Result<Vec<Document>, GenericError> {
+        _current: &[Document],
+        _articles: Vec<Article>,
+    ) -> Result<Vec<Article>, GenericError> {
         todo!();
     }
 


### PR DESCRIPTION
**Summary**

- changes to `Ops::new_items` method:
  - it no longer takes a ranker
  - it returns `Article`s rather than `Document`s
- also introduces an additional method `filter_articles` to `Ops`.
- `Stack` convenience methods to expose the above.  
- `compute_smbert` exposed through to `Ranker` trait.
- `Engine::update_stacks` changed accordingly using the above to build documents from articles.