### PR TITLE
[Merged by Bors] - TY-2423 improve result ffi

### DIFF
--- a/discovery_engine/lib/src/ffi/types/box.dart
+++ b/discovery_engine/lib/src/ffi/types/box.dart
@@ -14,19 +14,19 @@
 
 import 'dart:ffi' show NativeType, nullptr, Pointer;
 
-class Boxed<RT extends NativeType> {
-  Pointer<RT> _ptr;
-  final void Function(Pointer<RT>) _free;
+class Boxed<RustType extends NativeType> {
+  Pointer<RustType> _ptr;
+  final void Function(Pointer<RustType>) _free;
 
   /// Creates a new wrapper instance.
   ///
-  /// Ptr must point to a non-dangling instance of `RT`.
+  /// Ptr must point to a non-dangling instance of `RustType`.
   Boxed(this._ptr, this._free);
 
   /// True if `free` or `move` was called.
   bool get moved => _ptr == nullptr;
 
-  /// Returns the equivalent of an `&mut RT`.
+  /// Returns the equivalent of an `&mut RustType`.
   ///
   /// While the returned pointer is used _anywhere_ you must not:
   ///
@@ -34,21 +34,21 @@ class Boxed<RT extends NativeType> {
   /// - call ref
   /// - call free
   /// - call move
-  Pointer<RT> get mut {
+  Pointer<RustType> get mut {
     if (moved) {
       throw StateError('the pointer is no longer valid, either freed or moved');
     }
     return _ptr;
   }
 
-  /// Returns the equivalent of an `&RT`.
+  /// Returns the equivalent of an `&RustType`.
   ///
   /// While the returned pointer is used _anywhere_ you must not:
   ///
   /// - call mut
   /// - call free
   /// - call move
-  Pointer<RT> get ref {
+  Pointer<RustType> get ref {
     if (moved) {
       throw StateError('the pointer is no longer valid, either freed or moved');
     }
@@ -65,7 +65,7 @@ class Boxed<RT extends NativeType> {
   }
 
   /// Moves the instance out of this wrapper.
-  Pointer<RT> move() {
+  Pointer<RustType> move() {
     if (moved) {
       throw StateError('the pointer is no longer valid, either freed or moved');
     }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -75,10 +75,8 @@ class DiscoveryEngineFfi {
     );
     final Pointer<RustSharedEngine> sharedEngine;
     try {
-      sharedEngine = resultSharedEngineStringFfiAdapter.readNative(
-        boxedResult.mut,
-        mapErr: (error) => Exception(error),
-      );
+      sharedEngine =
+          resultSharedEngineStringFfiAdapter.readNative(boxedResult.mut);
     } catch (_) {
       boxedResult.free();
       rethrow;
@@ -89,74 +87,47 @@ class DiscoveryEngineFfi {
 
   /// Serializes the engine.
   Future<Uint8List> serialize() async {
-    final boxedResult = Boxed(
-      await asyncFfi.serialize(_sharedEngine),
-      ffi.drop_result_vec_u8_string,
-    );
+    final result = await asyncFfi.serialize(_sharedEngine);
 
-    return resultVecU8StringFfiAdapter.consumeNative(
-      boxedResult,
-      mapErr: (error) => Exception(error),
-    );
+    return resultVecU8StringFfiAdapter.consumeNative(result);
   }
 
   /// Sets the markets.
   Future<void> setMarkets(final List<FeedMarket> markets) async {
     final boxedMarkets = markets.allocVec();
-    final boxedResult = Boxed(
-      await asyncFfi.setMarkets(_sharedEngine, boxedMarkets.move()),
-      ffi.drop_result_void_string,
-    );
+    final result =
+        await asyncFfi.setMarkets(_sharedEngine, boxedMarkets.move());
 
-    return resultVoidStringFfiAdapter.consumeNative(
-      boxedResult,
-      mapErr: (error) => Exception(error),
-    );
+    return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
   /// Gets feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     final int maxDocuments,
   ) async {
-    final boxedResult = Boxed(
-      await asyncFfi.getFeedDocuments(_sharedEngine, maxDocuments),
-      ffi.drop_result_vec_document_string,
-    );
+    final result = await asyncFfi.getFeedDocuments(_sharedEngine, maxDocuments);
 
     return resultVecDocumentStringFfiAdapter
-        .consumeNative(
-          boxedResult,
-          mapErr: (error) => Exception(error),
-        )
+        .consumeNative(result)
         .toDocumentListWithActiveData();
   }
 
   /// Processes time spent.
   Future<void> timeSpent(final TimeSpent timeSpent) async {
     final boxedTimeSpent = timeSpent.allocNative();
-    final boxedResult = Boxed(
-      await asyncFfi.timeSpent(_sharedEngine, boxedTimeSpent.move()),
-      ffi.drop_result_void_string,
-    );
+    final result =
+        await asyncFfi.timeSpent(_sharedEngine, boxedTimeSpent.move());
 
-    return resultVoidStringFfiAdapter.consumeNative(
-      boxedResult,
-      mapErr: (error) => Exception(error),
-    );
+    return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
   /// Processes user reaction.
   Future<void> userReacted(final UserReacted userReacted) async {
     final boxedUserReacted = userReacted.allocNative();
-    final boxedResult = Boxed(
-      await asyncFfi.userReacted(_sharedEngine, boxedUserReacted.move()),
-      ffi.drop_result_void_string,
-    );
+    final result =
+        await asyncFfi.userReacted(_sharedEngine, boxedUserReacted.move());
 
-    return resultVoidStringFfiAdapter.consumeNative(
-      boxedResult,
-      mapErr: (error) => Exception(error),
-    );
+    return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
   /// Drops the engine.

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show NativeType, Pointer;
+import 'dart:ffi' show NativeType, nullptr, Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustSharedEngine;
@@ -28,28 +28,36 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
     RustOk extends NativeType, RustErr extends NativeType> {
   final Pointer<RustOk> Function(Pointer<RustResult>) getOk;
   final Pointer<RustErr> Function(Pointer<RustResult>) getErr;
+  final Pointer<RustOk> Function(Pointer<RustResult>) moveOk;
+  final Pointer<RustErr> Function(Pointer<RustResult>) moveErr;
   final Ok Function(Pointer<RustOk>) readNativeOk;
   final Err Function(Pointer<RustErr>) readNativeErr;
   final Never Function(Err) throwErr;
+  final void Function(Pointer<RustOk>) freeOk;
+  final void Function(Pointer<RustErr>) freeErr;
   final void Function(Pointer<RustResult>) freeResult;
 
   ResultFfiAdapter({
     required this.getOk,
     required this.getErr,
+    required this.moveOk,
+    required this.moveErr,
     required this.readNativeOk,
     required this.readNativeErr,
     required this.throwErr,
+    required this.freeOk,
+    required this.freeErr,
     required this.freeResult,
   });
 
   /// Reads the result and returns the success value or throws in case of an error value.
   Ok readNative(Pointer<RustResult> result) {
     final ok = getOk(result);
-    if (ok.address != 0) {
+    if (ok != nullptr) {
       return readNativeOk(ok);
     }
     final err = getErr(result);
-    if (err.address != 0) {
+    if (err != nullptr) {
       throwErr(readNativeErr(err));
     }
     throw AssertionError('result should be either Ok or Err');
@@ -60,13 +68,31 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
   /// # Safety
   /// Must only be called on owned pointers.
   Ok consumeNative(Pointer<RustResult> result) {
-    final boxedResult = Boxed(result, freeResult);
     try {
-      return readNative(boxedResult.ref);
+      return readNative(result);
     } finally {
-      boxedResult.free();
+      freeResult(result);
     }
   }
+
+  /// Consumes the result and moves the success value or throws in case of an error value.
+  ///
+  /// # Safety
+  /// Must only be called on owned pointers.
+  Boxed<RustOk> moveNative(Pointer<RustResult> result) {
+    try {
+      readNative(result);
+    } catch (_) {
+      freeResult(result);
+      rethrow;
+    }
+
+    return Boxed(moveOk(result), freeOk);
+  }
+}
+
+Never _moveUnsupported<RustType extends NativeType>(Pointer<RustType> _) {
+  throw UnsupportedError('get the value or consume the whole result');
 }
 
 Never _throwStringErr(final String error) {
@@ -76,35 +102,51 @@ Never _throwStringErr(final String error) {
 final resultVoidStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_void_string_ok,
   getErr: ffi.get_result_void_string_err,
+  moveOk: _moveUnsupported,
+  moveErr: _moveUnsupported,
   readNativeOk: (_) {},
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
+  freeOk: _moveUnsupported,
+  freeErr: _moveUnsupported,
   freeResult: ffi.drop_result_void_string,
 );
 
 final resultVecU8StringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_u8_string_ok,
   getErr: ffi.get_result_vec_u8_string_err,
+  moveOk: _moveUnsupported,
+  moveErr: _moveUnsupported,
   readNativeOk: Uint8ListFfi.readNative,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
+  freeOk: _moveUnsupported,
+  freeErr: _moveUnsupported,
   freeResult: ffi.drop_result_vec_u8_string,
 );
 
 final resultVecDocumentStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_document_string_ok,
   getErr: ffi.get_result_vec_document_string_err,
+  moveOk: _moveUnsupported,
+  moveErr: _moveUnsupported,
   readNativeOk: DocumentSliceFfi.readVec,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
+  freeOk: _moveUnsupported,
+  freeErr: _moveUnsupported,
   freeResult: ffi.drop_result_vec_document_string,
 );
 
 final resultSharedEngineStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_shared_engine_string_ok,
   getErr: ffi.get_result_shared_engine_string_err,
+  moveOk: ffi.move_result_shared_engine_string_ok,
+  moveErr: ffi.move_result_shared_engine_string_err,
   readNativeOk: (final Pointer<RustSharedEngine> sharedEngine) => sharedEngine,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
+  freeOk: ffi.drop_shared_engine,
+  freeErr: ffi.drop_string,
   freeResult: ffi.drop_result_shared_engine_string,
 );

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -24,116 +24,155 @@ import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
     show Uint8ListFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
 
-class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
+abstract class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
     RustOk extends NativeType, RustErr extends NativeType> {
-  final Pointer<RustOk> Function(Pointer<RustResult>) getOk;
-  final Pointer<RustErr> Function(Pointer<RustResult>) getErr;
-  final Pointer<RustOk> Function(Pointer<RustResult>) moveOk;
-  final Ok Function(Pointer<RustOk>) readNativeOk;
-  final Err Function(Pointer<RustErr>) readNativeErr;
-  final Never Function(Err) throwErr;
-  final void Function(Pointer<RustOk>) freeOk;
-  final void Function(Pointer<RustResult>) freeResult;
-
-  ResultFfiAdapter({
-    required this.getOk,
-    required this.getErr,
-    required this.moveOk,
-    required this.readNativeOk,
-    required this.readNativeErr,
-    required this.throwErr,
-    required this.freeOk,
-    required this.freeResult,
-  });
+  late final Pointer<RustOk> Function(Pointer<RustResult>) _getOk;
+  late final Pointer<RustErr> Function(Pointer<RustResult>) _getErr;
+  late final Ok Function(Pointer<RustOk>) _readNativeOk;
+  late final Err Function(Pointer<RustErr>) _readNativeErr;
+  late final Never Function(Err) _throwErr;
+  late final void Function(Pointer<RustResult>) _freeResult;
 
   /// Reads the result and returns the success value or throws in case of an error value.
   Ok readNative(Pointer<RustResult> result) {
-    final ok = getOk(result);
+    final ok = _getOk(result);
     if (ok != nullptr) {
-      return readNativeOk(ok);
+      return _readNativeOk(ok);
     }
-    final err = getErr(result);
+    final err = _getErr(result);
     if (err != nullptr) {
-      throwErr(readNativeErr(err));
+      _throwErr(_readNativeErr(err));
     }
     throw AssertionError('result should be either Ok or Err');
   }
 
+  /// Frees the result.
+  ///
+  /// # Safety
+  /// Must only be called on owned pointers and not more than once.
+  void freeNative(Pointer<RustResult> result) {
+    _freeResult(result);
+  }
+}
+
+mixin ConsumeResultFfiMixin<Ok, Err, RustResult extends NativeType,
+        RustOk extends NativeType, RustErr extends NativeType>
+    on ResultFfiAdapter<Ok, Err, RustResult, RustOk, RustErr> {
   /// Consumes the result and returns the success value or throws in case of an error value.
   ///
   /// # Safety
   ///
-  /// Must only be called on owned pointers.
+  /// Must only be called on owned pointers and not more than once.
   Ok consumeNative(Pointer<RustResult> result) {
     try {
       return readNative(result);
     } finally {
-      freeResult(result);
+      freeNative(result);
     }
   }
+}
+
+mixin MoveResultFfiMixin<Ok, Err, RustResult extends NativeType,
+        RustOk extends NativeType, RustErr extends NativeType>
+    on ResultFfiAdapter<Ok, Err, RustResult, RustOk, RustErr> {
+  late final Pointer<RustOk> Function(Pointer<RustResult>) _moveOk;
+  late final void Function(Pointer<RustOk>) _freeOk;
 
   /// Consumes the result and moves the success value or throws in case of an error value.
   ///
   /// # Safety
   ///
-  /// Must only be called on owned pointers.
+  /// Must only be called on owned pointers and not more than once.
   Boxed<RustOk> moveNative(Pointer<RustResult> result) {
     try {
       readNative(result);
     } catch (_) {
-      freeResult(result);
+      freeNative(result);
       rethrow;
     }
 
-    return Boxed(moveOk(result), freeOk);
+    return Boxed(_moveOk(result), _freeOk);
   }
 }
 
-Never _throwUnsupported<RustType extends NativeType>(Pointer<RustType> _) {
-  throw UnsupportedError(
-    'moving the value is unsupported for this result: '
-    'read the value or consume the whole result instead',
-  );
+class ConsumeResultFfiAdapter<Ok, Err, RustResult extends NativeType,
+        RustOk extends NativeType, RustErr extends NativeType>
+    extends ResultFfiAdapter<Ok, Err, RustResult, RustOk, RustErr>
+    with ConsumeResultFfiMixin<Ok, Err, RustResult, RustOk, RustErr> {
+  ConsumeResultFfiAdapter({
+    required final Pointer<RustOk> Function(Pointer<RustResult>) getOk,
+    required final Pointer<RustErr> Function(Pointer<RustResult>) getErr,
+    required final Ok Function(Pointer<RustOk>) readNativeOk,
+    required final Err Function(Pointer<RustErr>) readNativeErr,
+    required final Never Function(Err) throwErr,
+    required final void Function(Pointer<RustResult>) freeResult,
+  }) {
+    _getOk = getOk;
+    _getErr = getErr;
+    _readNativeOk = readNativeOk;
+    _readNativeErr = readNativeErr;
+    _throwErr = throwErr;
+    _freeResult = freeResult;
+  }
+}
+
+class MoveResultFfiAdapter<Ok, Err, RustResult extends NativeType,
+        RustOk extends NativeType, RustErr extends NativeType>
+    extends ResultFfiAdapter<Ok, Err, RustResult, RustOk, RustErr>
+    with MoveResultFfiMixin<Ok, Err, RustResult, RustOk, RustErr> {
+  MoveResultFfiAdapter({
+    required final Pointer<RustOk> Function(Pointer<RustResult>) getOk,
+    required final Pointer<RustErr> Function(Pointer<RustResult>) getErr,
+    required final Pointer<RustOk> Function(Pointer<RustResult>) moveOk,
+    required final Ok Function(Pointer<RustOk>) readNativeOk,
+    required final Err Function(Pointer<RustErr>) readNativeErr,
+    required final Never Function(Err) throwErr,
+    required final void Function(Pointer<RustOk>) freeOk,
+    required final void Function(Pointer<RustResult>) freeResult,
+  }) {
+    _getOk = getOk;
+    _getErr = getErr;
+    _moveOk = moveOk;
+    _readNativeOk = readNativeOk;
+    _readNativeErr = readNativeErr;
+    _throwErr = throwErr;
+    _freeOk = freeOk;
+    _freeResult = freeResult;
+  }
 }
 
 Never _throwStringErr(final String error) {
   throw Exception(error);
 }
 
-final resultVoidStringFfiAdapter = ResultFfiAdapter(
+final resultVoidStringFfiAdapter = ConsumeResultFfiAdapter(
   getOk: ffi.get_result_void_string_ok,
   getErr: ffi.get_result_void_string_err,
-  moveOk: _throwUnsupported,
   readNativeOk: (_) {},
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _throwUnsupported,
   freeResult: ffi.drop_result_void_string,
 );
 
-final resultVecU8StringFfiAdapter = ResultFfiAdapter(
+final resultVecU8StringFfiAdapter = ConsumeResultFfiAdapter(
   getOk: ffi.get_result_vec_u8_string_ok,
   getErr: ffi.get_result_vec_u8_string_err,
-  moveOk: _throwUnsupported,
   readNativeOk: Uint8ListFfi.readNative,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _throwUnsupported,
   freeResult: ffi.drop_result_vec_u8_string,
 );
 
-final resultVecDocumentStringFfiAdapter = ResultFfiAdapter(
+final resultVecDocumentStringFfiAdapter = ConsumeResultFfiAdapter(
   getOk: ffi.get_result_vec_document_string_ok,
   getErr: ffi.get_result_vec_document_string_err,
-  moveOk: _throwUnsupported,
   readNativeOk: DocumentSliceFfi.readVec,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _throwUnsupported,
   freeResult: ffi.drop_result_vec_document_string,
 );
 
-final resultSharedEngineStringFfiAdapter = ResultFfiAdapter(
+final resultSharedEngineStringFfiAdapter = MoveResultFfiAdapter(
   getOk: ffi.get_result_shared_engine_string_ok,
   getErr: ffi.get_result_shared_engine_string_err,
   moveOk: ffi.move_result_shared_engine_string_ok,

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -91,8 +91,11 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
   }
 }
 
-Never _moveUnsupported<RustType extends NativeType>(Pointer<RustType> _) {
-  throw UnsupportedError('get the value or consume the whole result');
+Never _throwUnsupported<RustType extends NativeType>(Pointer<RustType> _) {
+  throw UnsupportedError(
+    'moving the value is unsupported for this result: '
+    'read the value or consume the whole result instead',
+  );
 }
 
 Never _throwStringErr(final String error) {
@@ -102,39 +105,39 @@ Never _throwStringErr(final String error) {
 final resultVoidStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_void_string_ok,
   getErr: ffi.get_result_void_string_err,
-  moveOk: _moveUnsupported,
-  moveErr: _moveUnsupported,
+  moveOk: _throwUnsupported,
+  moveErr: _throwUnsupported,
   readNativeOk: (_) {},
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _moveUnsupported,
-  freeErr: _moveUnsupported,
+  freeOk: _throwUnsupported,
+  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_void_string,
 );
 
 final resultVecU8StringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_u8_string_ok,
   getErr: ffi.get_result_vec_u8_string_err,
-  moveOk: _moveUnsupported,
-  moveErr: _moveUnsupported,
+  moveOk: _throwUnsupported,
+  moveErr: _throwUnsupported,
   readNativeOk: Uint8ListFfi.readNative,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _moveUnsupported,
-  freeErr: _moveUnsupported,
+  freeOk: _throwUnsupported,
+  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_vec_u8_string,
 );
 
 final resultVecDocumentStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_document_string_ok,
   getErr: ffi.get_result_vec_document_string_err,
-  moveOk: _moveUnsupported,
-  moveErr: _moveUnsupported,
+  moveOk: _throwUnsupported,
+  moveErr: _throwUnsupported,
   readNativeOk: DocumentSliceFfi.readVec,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
-  freeOk: _moveUnsupported,
-  freeErr: _moveUnsupported,
+  freeOk: _throwUnsupported,
+  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_vec_document_string,
 );
 

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -29,24 +29,20 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
   final Pointer<RustOk> Function(Pointer<RustResult>) getOk;
   final Pointer<RustErr> Function(Pointer<RustResult>) getErr;
   final Pointer<RustOk> Function(Pointer<RustResult>) moveOk;
-  final Pointer<RustErr> Function(Pointer<RustResult>) moveErr;
   final Ok Function(Pointer<RustOk>) readNativeOk;
   final Err Function(Pointer<RustErr>) readNativeErr;
   final Never Function(Err) throwErr;
   final void Function(Pointer<RustOk>) freeOk;
-  final void Function(Pointer<RustErr>) freeErr;
   final void Function(Pointer<RustResult>) freeResult;
 
   ResultFfiAdapter({
     required this.getOk,
     required this.getErr,
     required this.moveOk,
-    required this.moveErr,
     required this.readNativeOk,
     required this.readNativeErr,
     required this.throwErr,
     required this.freeOk,
-    required this.freeErr,
     required this.freeResult,
   });
 
@@ -66,6 +62,7 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
   /// Consumes the result and returns the success value or throws in case of an error value.
   ///
   /// # Safety
+  ///
   /// Must only be called on owned pointers.
   Ok consumeNative(Pointer<RustResult> result) {
     try {
@@ -78,6 +75,7 @@ class ResultFfiAdapter<Ok, Err, RustResult extends NativeType,
   /// Consumes the result and moves the success value or throws in case of an error value.
   ///
   /// # Safety
+  ///
   /// Must only be called on owned pointers.
   Boxed<RustOk> moveNative(Pointer<RustResult> result) {
     try {
@@ -106,12 +104,10 @@ final resultVoidStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_void_string_ok,
   getErr: ffi.get_result_void_string_err,
   moveOk: _throwUnsupported,
-  moveErr: _throwUnsupported,
   readNativeOk: (_) {},
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
   freeOk: _throwUnsupported,
-  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_void_string,
 );
 
@@ -119,12 +115,10 @@ final resultVecU8StringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_u8_string_ok,
   getErr: ffi.get_result_vec_u8_string_err,
   moveOk: _throwUnsupported,
-  moveErr: _throwUnsupported,
   readNativeOk: Uint8ListFfi.readNative,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
   freeOk: _throwUnsupported,
-  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_vec_u8_string,
 );
 
@@ -132,12 +126,10 @@ final resultVecDocumentStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_vec_document_string_ok,
   getErr: ffi.get_result_vec_document_string_err,
   moveOk: _throwUnsupported,
-  moveErr: _throwUnsupported,
   readNativeOk: DocumentSliceFfi.readVec,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
   freeOk: _throwUnsupported,
-  freeErr: _throwUnsupported,
   freeResult: ffi.drop_result_vec_document_string,
 );
 
@@ -145,11 +137,9 @@ final resultSharedEngineStringFfiAdapter = ResultFfiAdapter(
   getOk: ffi.get_result_shared_engine_string_ok,
   getErr: ffi.get_result_shared_engine_string_err,
   moveOk: ffi.move_result_shared_engine_string_ok,
-  moveErr: ffi.move_result_shared_engine_string_err,
   readNativeOk: (final Pointer<RustSharedEngine> sharedEngine) => sharedEngine,
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
   freeOk: ffi.drop_shared_engine,
-  freeErr: ffi.drop_string,
   freeResult: ffi.drop_result_shared_engine_string,
 );

--- a/discovery_engine_core/bindings/src/types/engine.rs
+++ b/discovery_engine_core/bindings/src/types/engine.rs
@@ -19,6 +19,18 @@ use tokio::sync::Mutex;
 
 use xayn_discovery_engine_core::XaynAiEngine;
 
+use super::boxed;
+
 /// A shared discovery engine with a lock.
 #[derive(AsRef, From)]
 pub struct SharedEngine(Mutex<XaynAiEngine>);
+
+/// Drops a `Box<SharedEngine>`.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<SharedEngine>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_shared_engine(engine: *mut SharedEngine) {
+    unsafe { boxed::drop(engine) }
+}

--- a/discovery_engine_core/bindings/src/types/result.rs
+++ b/discovery_engine_core/bindings/src/types/result.rs
@@ -56,18 +56,6 @@ unsafe fn move_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
     }
 }
 
-/// Returns a pointer to the moved `Result::Err` error value or a nullptr.
-///
-/// # Safety
-///
-/// - The pointer must represent a valid `Box<Result<O, E>>` instance.
-unsafe fn move_result_err<O, E>(res: *mut Result<O, E>) -> *mut E {
-    match *unsafe { Box::from_raw(res) } {
-        Ok(_) => ptr::null_mut(),
-        Err(err) => Box::into_raw(Box::new(err)),
-    }
-}
-
 /// Returns a pointer to the `Vec<u8>` success value or a nullptr.
 ///
 /// # Safety
@@ -210,16 +198,4 @@ pub unsafe extern "C" fn move_result_shared_engine_string_ok(
     res: *mut Result<SharedEngine, String>,
 ) -> *mut SharedEngine {
     unsafe { move_result_ok(res) }
-}
-
-/// Returns a pointer to the moved `String` error value or a nullptr.
-///
-/// # Safety
-///
-/// - The pointer must represent a valid `Box<Result<SharedEngine>, String>>` instance.
-#[no_mangle]
-pub unsafe extern "C" fn move_result_shared_engine_string_err(
-    res: *mut Result<SharedEngine, String>,
-) -> *mut String {
-    unsafe { move_result_err(res) }
 }

--- a/discovery_engine_core/bindings/src/types/result.rs
+++ b/discovery_engine_core/bindings/src/types/result.rs
@@ -25,7 +25,7 @@ use super::{boxed, engine::SharedEngine};
 /// # Safety
 ///
 /// - The pointer must point to a sound `Result<O, E>` instance.
-pub(super) unsafe fn get_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
+unsafe fn get_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
     match unsafe { &mut *res } {
         Ok(value) => value,
         Err(_) => ptr::null_mut(),
@@ -37,10 +37,34 @@ pub(super) unsafe fn get_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
 /// # Safety
 ///
 /// - The pointer must point to a sound `Result<O, E>` instance.
-pub(super) unsafe fn get_result_err<O, E>(res: *mut Result<O, E>) -> *mut E {
+unsafe fn get_result_err<O, E>(res: *mut Result<O, E>) -> *mut E {
     match unsafe { &mut *res } {
         Ok(_) => ptr::null_mut(),
         Err(err) => err,
+    }
+}
+
+/// Returns a pointer to the moved `Result::Ok` success value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<Result<O, E>>` instance.
+unsafe fn move_result_ok<O, E>(res: *mut Result<O, E>) -> *mut O {
+    match *unsafe { Box::from_raw(res) } {
+        Ok(value) => Box::into_raw(Box::new(value)),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Returns a pointer to the moved `Result::Err` error value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<Result<O, E>>` instance.
+unsafe fn move_result_err<O, E>(res: *mut Result<O, E>) -> *mut E {
+    match *unsafe { Box::from_raw(res) } {
+        Ok(_) => ptr::null_mut(),
+        Err(err) => Box::into_raw(Box::new(err)),
     }
 }
 
@@ -72,7 +96,7 @@ pub unsafe extern "C" fn get_result_vec_u8_string_err(
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Result<Vec<u8>, String>` instance.
+/// - The pointer must represent a valid `Box<Result<Vec<u8>, String>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_result_vec_u8_string(res: *mut Result<Vec<u8>, String>) {
     unsafe { boxed::drop(res) }
@@ -106,7 +130,7 @@ pub unsafe extern "C" fn get_result_vec_document_string_err(
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Result<Vec<Document>, String>>` instance.
+/// - The pointer must represent a valid `Box<Result<Vec<Document>, String>>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_result_vec_document_string(res: *mut Result<Vec<Document>, String>) {
     unsafe { boxed::drop(res) }
@@ -136,7 +160,7 @@ pub unsafe extern "C" fn get_result_void_string_err(res: *mut Result<(), String>
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Result<(), String>>` instance.
+/// - The pointer must represent a valid `Box<Result<(), String>>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_result_void_string(res: *mut Result<(), String>) {
     unsafe { boxed::drop(res) }
@@ -170,8 +194,32 @@ pub unsafe extern "C" fn get_result_shared_engine_string_err(
 ///
 /// # Safety
 ///
-/// The pointer must represent a valid `Box<Result<SharedEngine, String>>` instance.
+/// - The pointer must represent a valid `Box<Result<SharedEngine, String>>` instance.
 #[no_mangle]
 pub unsafe extern "C" fn drop_result_shared_engine_string(res: *mut Result<SharedEngine, String>) {
     unsafe { boxed::drop(res) }
+}
+
+/// Returns a pointer to the moved `SharedEngine` success value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<Result<SharedEngine, String>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn move_result_shared_engine_string_ok(
+    res: *mut Result<SharedEngine, String>,
+) -> *mut SharedEngine {
+    unsafe { move_result_ok(res) }
+}
+
+/// Returns a pointer to the moved `String` error value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<Result<SharedEngine>, String>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn move_result_shared_engine_string_err(
+    res: *mut Result<SharedEngine, String>,
+) -> *mut String {
+    unsafe { move_result_err(res) }
 }


### PR DESCRIPTION
**References**

- [TY-2423]
- follow up from https://github.com/xaynetwork/xayn_discovery_engine/pull/142#pullrequestreview-883679114

**Summary**

rust side:
- add ffi to move ok and err values out of results into new boxes
- add ffi to drop `SharedEngine`

dart side:
- move boxing of pointer logic into `consumeNative()`
- add `move` and `free` handles to the `ResultFfiAdapter` and impl `moveNative()`
- align generics names for `Boxed`

**Notes**

- ~we could remove the move of error values, i just included it for completeness, but i'd also be ok omitting it~

[TY-2302]: https://xainag.atlassian.net/browse/TY-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-2423]: https://xainag.atlassian.net/browse/TY-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ