### PR TITLE
[Merged by Bors] - TY-2409 ChangedDocumentsReporter

### DIFF
--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -41,6 +41,8 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         FetchingAssetsFinished,
         SystemEngineEvent,
         ClientEventSucceeded,
+        DocumentEngineEvent,
+        DocumentsUpdated,
         EngineExceptionRaised,
         EngineExceptionReason;
 export 'package:xayn_discovery_engine/src/api/models/document.dart';

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -35,6 +35,11 @@ abstract class SystemEngineEvent {}
 /// AI assets fetching process.
 abstract class AssetsStatusEngineEvent {}
 
+/// Abstract class implemented by events like [DocumentsUpdated].
+///
+/// Used to group events related to [Document] changes.
+abstract class DocumentEngineEvent implements EngineEvent {}
+
 enum FeedFailureReason {
   @JsonValue(0)
   notAuthorised,
@@ -128,6 +133,13 @@ class EngineEvent with _$EngineEvent {
   const factory EngineEvent.engineExceptionRaised(
     EngineExceptionReason reason,
   ) = EngineExceptionRaised;
+
+  /// Event created as a successful response to some client events which are
+  /// updating a [Document] (currently only "UserReactionChanged").
+  /// Passes back to the client a list of changed [Document] entities.
+  @Implements<DocumentEngineEvent>()
+  const factory EngineEvent.documentsUpdated(List<Document> items) =
+      DocumentsUpdated;
 
   /// Converts json Map to [EngineEvent].
   factory EngineEvent.fromJson(Map<String, Object?> json) =>

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -307,6 +307,7 @@ extension _MapEvent on EngineEvent {
     bool? fetchingAssetsFinished,
     bool? clientEventSucceeded,
     bool? engineExceptionRaised,
+    bool? documentsUpdated,
   }) =>
       map(
         feedRequestSucceeded: _maybePassThrough(feedRequestSucceeded),
@@ -321,6 +322,7 @@ extension _MapEvent on EngineEvent {
         fetchingAssetsFinished: _maybePassThrough(fetchingAssetsFinished),
         clientEventSucceeded: _maybePassThrough(clientEventSucceeded),
         engineExceptionRaised: _maybePassThrough(engineExceptionRaised),
+        documentsUpdated: _maybePassThrough(documentsUpdated),
       );
 
   EngineEvent Function(EngineEvent) _maybePassThrough(bool? condition) {

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -110,14 +110,14 @@ class DiscoveryEngine {
       }
 
       return DiscoveryEngine._(manager);
-    } catch (error) {
+    } catch (error, stackTrace) {
+      const message =
+          'Something went wrong during Discovery Engine initialization';
+      logger.e(message, error, stackTrace);
       // rethrow exception thrown by issue with configuration
       if (error is EngineInitException) rethrow;
       // throw for the client to catch
-      throw EngineInitException(
-        'Something went wrong during Discovery Engine initialization',
-        error,
-      );
+      throw EngineInitException(message, error);
     }
   }
 
@@ -275,19 +275,20 @@ class DiscoveryEngine {
     try {
       // we need to await the result otherwise catch won't work
       return await fn();
-    } catch (e) {
+    } catch (error, stackTrace) {
       var reason = EngineExceptionReason.genericError;
 
-      if (e is ConverterException) {
+      if (error is ConverterException) {
         reason = EngineExceptionReason.converterException;
-      } else if (e is ResponseTimeoutException) {
+      } else if (error is ResponseTimeoutException) {
         reason = EngineExceptionReason.responseTimeout;
-      } else if (e is ManagerDisposedException) {
+      } else if (error is ManagerDisposedException) {
         reason = EngineExceptionReason.engineDisposed;
       }
 
+      const message = 'Something went wrong when trying to send a ClientEvent';
       // log the error
-      logger.e(e);
+      logger.e(message, error, stackTrace);
 
       // into [EngineExceptionRaised] event with a specific reason
       return EngineEvent.engineExceptionRaised(reason);

--- a/discovery_engine/lib/src/discovery_engine_worker.dart
+++ b/discovery_engine/lib/src/discovery_engine_worker.dart
@@ -35,9 +35,7 @@ class DiscoveryEngineWorker extends Worker<ClientEvent, EngineEvent> {
   Converter<EngineEvent, Object> get responseConverter => _responseConverter;
 
   DiscoveryEngineWorker(Object message) : super(message) {
-    _handler.assetsProgress.listen((event) {
-      send(event as EngineEvent);
-    });
+    _handler.events.listen((event) => send(event));
   }
 
   Sender? _getSenderFromMessageOrNull(Object? incomingMessage) {
@@ -77,6 +75,12 @@ class DiscoveryEngineWorker extends Worker<ClientEvent, EngineEvent> {
     final clientEvent = request.payload;
     final response = await _handler.handleMessage(clientEvent);
     send(response, request.sender);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await super.dispose();
+    await _handler.close();
   }
 }
 

--- a/discovery_engine/lib/src/domain/assets/asset_reporter.dart
+++ b/discovery_engine/lib/src/domain/assets/asset_reporter.dart
@@ -16,7 +16,7 @@ import 'dart:async' show StreamController;
 
 import 'package:xayn_discovery_engine/src/api/api.dart'
     show
-        AssetsStatusEngineEvent,
+        EngineEvent,
         FetchingAssetsFinished,
         FetchingAssetsProgressed,
         FetchingAssetsStarted;
@@ -26,8 +26,8 @@ import 'package:xayn_discovery_engine/src/domain/assets/asset.dart'
 class AssetReporter {
   int _totalNbOfAssets = 0;
   final Set<String> _fetchedUrls = {};
-  final _statusCtrl = StreamController<AssetsStatusEngineEvent>.broadcast();
-  Stream<AssetsStatusEngineEvent> get progress => _statusCtrl.stream;
+  final _statusCtrl = StreamController<EngineEvent>.broadcast();
+  Stream<EngineEvent> get progress => _statusCtrl.stream;
 
   void fetchingStarted(Manifest manifest) {
     _totalNbOfAssets = manifest.assets.fold<int>(

--- a/discovery_engine/lib/src/domain/changed_documents_reporter.dart
+++ b/discovery_engine/lib/src/domain/changed_documents_reporter.dart
@@ -1,0 +1,35 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:async' show StreamController;
+import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
+    show EngineEvent, DocumentsUpdated;
+import 'package:xayn_discovery_engine/src/domain/models/document.dart'
+    show Document;
+
+/// Class that manages a stream of [DocumentsUpdated] events.
+class ChangedDocumentsReporter {
+  final _changedDocsCtrl = StreamController<EngineEvent>.broadcast();
+  Stream<EngineEvent> get changedDocuments => _changedDocsCtrl.stream;
+
+  void notifyChanged(List<Document> documents) {
+    final payload = documents.map((it) => it.toApiDocument()).toList();
+    final event = DocumentsUpdated(payload);
+    _changedDocsCtrl.add(event);
+  }
+
+  Future<void> close() async {
+    await _changedDocsCtrl.close();
+  }
+}

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -14,6 +14,8 @@
 
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show DocumentClientEvent;
+import 'package:xayn_discovery_engine/src/domain/changed_documents_reporter.dart'
+    show ChangedDocumentsReporter;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
@@ -39,13 +41,15 @@ class DocumentManager {
   final DocumentRepository _documentRepo;
   final ActiveDocumentDataRepository _activeRepo;
   final EngineStateRepository _engineStateRepo;
+  final ChangedDocumentsReporter? _changedDocsReporter;
 
   DocumentManager(
     this._engine,
     this._documentRepo,
     this._activeRepo,
-    this._engineStateRepo,
-  );
+    this._engineStateRepo, [
+    this._changedDocsReporter,
+  ]);
 
   /// Handle the given document client event.
   ///
@@ -87,6 +91,8 @@ class DocumentManager {
       ),
     );
     await _engineStateRepo.save(await _engine.serialize());
+
+    _changedDocsReporter?.notifyChanged([doc]);
   }
 
   /// Add additional viewing time for the given active document.

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -41,15 +41,15 @@ class DocumentManager {
   final DocumentRepository _documentRepo;
   final ActiveDocumentDataRepository _activeRepo;
   final EngineStateRepository _engineStateRepo;
-  final ChangedDocumentsReporter? _changedDocsReporter;
+  final ChangedDocumentsReporter _changedDocsReporter;
 
   DocumentManager(
     this._engine,
     this._documentRepo,
     this._activeRepo,
-    this._engineStateRepo, [
+    this._engineStateRepo,
     this._changedDocsReporter,
-  ]);
+  );
 
   /// Handle the given document client event.
   ///
@@ -92,7 +92,7 @@ class DocumentManager {
     );
     await _engineStateRepo.save(await _engine.serialize());
 
-    _changedDocsReporter?.notifyChanged([doc]);
+    _changedDocsReporter.notifyChanged([doc]);
   }
 
   /// Add additional viewing time for the given active document.

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -59,7 +59,8 @@ class DocumentManager {
         userReactionChanged: (id, reaction) => updateUserReaction(id, reaction),
         documentTimeSpent: (id, mode, sec) =>
             addActiveDocumentTime(id, mode, sec),
-        orElse: throw UnimplementedError('handler not implemented for $evt'),
+        orElse: () =>
+            throw UnimplementedError('handler not implemented for $evt'),
       );
 
   /// Update user reaction for the given document.

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -168,9 +168,9 @@ class EventHandler {
           EngineExceptionReason.wrongEventRequested,
         );
       }
-    } catch (e) {
+    } catch (e, s) {
       // log the error
-      logger.e(e);
+      logger.e('Handling ClientEvent by one of the managers failed', e, s);
 
       response = const EngineEvent.engineExceptionRaised(
         EngineExceptionReason.genericError,

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -55,7 +55,8 @@ class FeedManager {
         feedRequested: () => restoreFeed(),
         nextFeedBatchRequested: () => nextFeedBatch(),
         feedDocumentsClosed: (ids) => deactivateDocuments(ids),
-        orElse: throw UnimplementedError('handler not implemented for $event'),
+        orElse: () =>
+            throw UnimplementedError('handler not implemented for $event'),
       );
 
   /// Generates the feed of active documents, ordered by their global rank.

--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -13,8 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:xayn_discovery_engine/discovery_engine.dart';
 import 'package:xayn_discovery_engine/src/domain/assets/asset.dart';
+import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart';
 
 part 'configuration.freezed.dart';
 

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=2.14.2 <3.0.0'
 
 dependencies:
+  async: ^2.8.2
   crypto: ^3.0.1
   equatable: ^2.0.3
   freezed_annotation: ^1.1.0

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.14.2 <3.0.0'
 
 dependencies:
-  async: ^2.8.2
+  async: ^2.8.1
   crypto: ^3.0.1
   equatable: ^2.0.3
   freezed_annotation: ^1.1.0

--- a/discovery_engine/test/codecs/mocks.dart
+++ b/discovery_engine/test/codecs/mocks.dart
@@ -19,11 +19,10 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         Configuration,
         ConfigurationChanged,
         Document,
-        UserReaction,
-        DocumentViewMode,
-        UserReactionChanged,
         DocumentId,
         DocumentTimeSpent,
+        DocumentViewMode,
+        DocumentsUpdated,
         EngineEvent,
         EngineExceptionRaised,
         EngineExceptionReason,
@@ -40,7 +39,9 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         NextFeedBatchAvailable,
         NextFeedBatchRequestFailed,
         NextFeedBatchRequestSucceeded,
-        NextFeedBatchRequested;
+        NextFeedBatchRequested,
+        UserReaction,
+        UserReactionChanged;
 
 class BadClientEvent implements ClientEvent {
   const BadClientEvent();
@@ -180,6 +181,7 @@ class BadEngineEvent implements EngineEvent {
     required TResult Function(ClientEventSucceeded value) clientEventSucceeded,
     required TResult Function(EngineExceptionRaised value)
         engineExceptionRaised,
+    required TResult Function(DocumentsUpdated value) documentsUpdated,
   }) {
     throw UnimplementedError();
   }
@@ -198,6 +200,7 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(FetchingAssetsFinished value)? fetchingAssetsFinished,
     TResult Function(ClientEventSucceeded value)? clientEventSucceeded,
     TResult Function(EngineExceptionRaised value)? engineExceptionRaised,
+    TResult Function(DocumentsUpdated value)? documentsUpdated,
   }) {
     throw UnimplementedError();
   }
@@ -217,6 +220,7 @@ class BadEngineEvent implements EngineEvent {
     TResult Function(FetchingAssetsFinished value)? fetchingAssetsFinished,
     TResult Function(ClientEventSucceeded value)? clientEventSucceeded,
     TResult Function(EngineExceptionRaised value)? engineExceptionRaised,
+    TResult Function(DocumentsUpdated value)? documentsUpdated,
   }) {
     throw UnimplementedError();
   }
@@ -234,6 +238,7 @@ class BadEngineEvent implements EngineEvent {
     TResult Function()? fetchingAssetsFinished,
     TResult Function()? clientEventSucceeded,
     TResult Function(EngineExceptionReason reason)? engineExceptionRaised,
+    TResult Function(List<Document> items)? documentsUpdated,
   }) {
     throw UnimplementedError();
   }
@@ -258,6 +263,7 @@ class BadEngineEvent implements EngineEvent {
     required TResult Function() clientEventSucceeded,
     required TResult Function(EngineExceptionReason reason)
         engineExceptionRaised,
+    required TResult Function(List<Document> items) documentsUpdated,
   }) {
     throw UnimplementedError();
   }
@@ -274,6 +280,7 @@ class BadEngineEvent implements EngineEvent {
     TResult Function()? fetchingAssetsFinished,
     TResult Function()? clientEventSucceeded,
     TResult Function(EngineExceptionReason reason)? engineExceptionRaised,
+    TResult Function(List<Document> items)? documentsUpdated,
   }) {
     throw UnimplementedError();
   }

--- a/discovery_engine/test/discovery_engine/configuration_test.dart
+++ b/discovery_engine/test/discovery_engine/configuration_test.dart
@@ -14,7 +14,6 @@
 
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/discovery_engine.dart';
-import 'package:xayn_discovery_engine/src/domain/assets/asset.dart';
 
 import '../logging.dart' show setupLogging;
 

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -133,7 +133,7 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id3, UserReaction.positive),
         throwsArgumentError,
       );
-      expect(changedDocsReporter.changedDocuments, emitsDone);
+      expect(changedDocsReporter.changedDocuments, neverEmits(anything));
       await changedDocsReporter.close();
     });
 
@@ -142,7 +142,7 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id2, UserReaction.positive),
         throwsArgumentError,
       );
-      expect(changedDocsReporter.changedDocuments, emitsDone);
+      expect(changedDocsReporter.changedDocuments, neverEmits(anything));
       await changedDocsReporter.close();
     });
 
@@ -156,7 +156,7 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id1, UserReaction.positive),
         throwsStateError,
       );
-      expect(changedDocsReporter.changedDocuments, emitsDone);
+      expect(changedDocsReporter.changedDocuments, neverEmits(anything));
       await changedDocsReporter.close();
     });
 

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -16,6 +16,9 @@ import 'dart:typed_data' show Uint8List;
 
 import 'package:hive/hive.dart' show Hive;
 import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/api/events/engine_events.dart';
+import 'package:xayn_discovery_engine/src/domain/changed_documents_reporter.dart'
+    show ChangedDocumentsReporter;
 import 'package:xayn_discovery_engine/src/domain/document_manager.dart'
     show DocumentManager;
 import 'package:xayn_discovery_engine/src/domain/engine/mock_engine.dart'
@@ -69,8 +72,6 @@ Future<void> main() async {
   final changedRepo = HiveChangedDocumentRepository();
   final engineStateRepo = HiveEngineStateRepository();
 
-  final mgr = DocumentManager(engine, docRepo, activeRepo, engineStateRepo);
-
   group('DocumentManager', () {
     final data = ActiveDocumentData(Embedding.fromList([4, 1]));
     final stackId = StackId();
@@ -90,7 +91,19 @@ Future<void> main() async {
     final id2 = doc2.documentId;
     final id3 = DocumentId();
 
+    late ChangedDocumentsReporter changedDocsReporter;
+    late DocumentManager mgr;
+
     setUp(() async {
+      changedDocsReporter = ChangedDocumentsReporter();
+      mgr = DocumentManager(
+        engine,
+        docRepo,
+        activeRepo,
+        engineStateRepo,
+        changedDocsReporter,
+      );
+
       // doc1 is active & changed, doc2 is neither
       await docRepo.updateMany([doc1, doc2]);
       await activeRepo.update(id1, data);
@@ -100,6 +113,8 @@ Future<void> main() async {
     });
 
     tearDown(() async {
+      await changedDocsReporter.close();
+
       await docBox.clear();
       await activeBox.clear();
       await changedBox.clear();
@@ -118,6 +133,8 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id3, UserReaction.positive),
         throwsArgumentError,
       );
+      expect(changedDocsReporter.changedDocuments, emitsDone);
+      await changedDocsReporter.close();
     });
 
     test('update inactive document user reaction', () async {
@@ -125,6 +142,8 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id2, UserReaction.positive),
         throwsArgumentError,
       );
+      expect(changedDocsReporter.changedDocuments, emitsDone);
+      await changedDocsReporter.close();
     });
 
     test(
@@ -137,11 +156,21 @@ Future<void> main() async {
         () => mgr.updateUserReaction(id1, UserReaction.positive),
         throwsStateError,
       );
+      expect(changedDocsReporter.changedDocuments, emitsDone);
+      await changedDocsReporter.close();
     });
 
     test('update active document user reaction', () async {
       const newReaction = UserReaction.positive;
+      final updatedDoc = (doc1..userReaction = newReaction).toApiDocument();
+
+      expect(
+        changedDocsReporter.changedDocuments,
+        emits(equals(DocumentsUpdated([updatedDoc]))),
+      );
+
       await mgr.updateUserReaction(id1, newReaction);
+
       expect(engine.getCallCount('userReacted'), equals(1));
       expect(
         docBox.values,


### PR DESCRIPTION
[Jira ref](https://xainag.atlassian.net/browse/TY-2409)

This PR adds a `ChangedDocumentsReporter` class to manage a stream of `DocumentsUpdated` engine event, which is sent when `Document` entities that are exposed to the app change their internal state. This event acts as a notification that something has updated, so that the app can replace changed documents in the state that it manages.

For now this notyfication will happen only in response to `UserReactionChanged` event, and will be extended if needed for other events.