### PR TITLE
[Merged by Bors] - update rust deps

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#fe195d99954c691c5e606ebbb3c77d371ba0e65b"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#a299c69aacb1f017c0f062a83203b5f6225c462f"
 dependencies = [
  "async-bindgen-derive",
  "once_cell",
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-derive"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#fe195d99954c691c5e606ebbb3c77d371ba0e65b"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#a299c69aacb1f017c0f062a83203b5f6225c462f"
 dependencies = [
  "heck 0.4.0",
  "once_cell",
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-gen-dart"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#fe195d99954c691c5e606ebbb3c77d371ba0e65b"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#a299c69aacb1f017c0f062a83203b5f6225c462f"
 dependencies = [
  "anyhow",
  "handlebars",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#4726d75f35513a80eb8df753b54099254cf0dc7d"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#bf1423f2eaf5b3c1914b8a0a6696ebbff7872f73"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#4726d75f35513a80eb8df753b54099254cf0dc7d"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#bf1423f2eaf5b3c1914b8a0a6696ebbff7872f73"
 dependencies = [
  "bindgen",
  "cc",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -2198,9 +2198,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -2208,6 +2208,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -9,7 +9,7 @@ async-bindgen = "0.1.0"
 chrono = { version = "0.4.19", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
 ndarray = "=0.15.3"
-tokio = { version = "1.16.1", default-features = false, features = ["sync"] }
+tokio = { version = "1.17.0", default-features = false, features = ["sync"] }
 url = "2.2.2"
 uuid = "0.8.2"
 xayn-discovery-engine-core = { path = "../core" }

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -11,12 +11,12 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
-rand = "0.8.4"
-rand_distr = "0.4.2"
-serde = { version = "1.0.130", features = ["derive"] }
+rand = "0.8.5"
+rand_distr = "0.4.3"
+serde = { version = "1.0.136", features = ["derive"] }
 serde_repr = "0.1.7"
 thiserror = "1.0.30"
-tokio = { version = "1.16.1", default-features = false, features = ["sync"] }
+tokio = { version = "1.17.0", default-features = false, features = ["sync"] }
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 xayn-ai = { git = "https://github.com/xaynetwork/xayn_ai", branch = "master" }
@@ -26,4 +26,4 @@ xayn-discovery-engine-providers = { path = "../providers" }
 claim = "0.5.0"
 float-cmp = "0.9.0"
 mockall = "0.11.0"
-tokio = { version = "1.16.1", default-features = false, features = ["macros", "rt", "sync"] }
+tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt", "sync"] }

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { version = "0.4", default_features = false, features = ["serde"] }
+chrono = { version = "0.4.19", default_features = false, features = ["serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 reqwest = { version = "0.11.9", features = ["json", "rustls-tls"], default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
 thiserror = "1.0.30"
 
 [dev-dependencies]
 claim = "0.5.0"
-tokio = { version = "1.15.0", features = ["rt", "macros"] }
-wiremock = "0.5"
+tokio = { version = "1.17.0", features = ["rt", "macros"] }
+wiremock = "0.5.10"


### PR DESCRIPTION
**Summary**

- update rust dependencies for the release (we should configure dependabot for this repo)

**Todo**

- ~update `xayn_dart_api_dl` & `async_bindgen` deps once https://github.com/xaynetwork/xayn_dart_api_dl/pull/9 & https://github.com/xaynetwork/xayn_async_bindgen/pull/13 are merged (already tested locally with `path`-patched deps)~