### PR TITLE
[Merged by Bors] - TY-2394 final kpe model

### DIFF
--- a/discovery_engine/lib/assets/asset_manifest.json
+++ b/discovery_engine/lib/assets/asset_manifest.json
@@ -36,25 +36,25 @@
     {
       "id": "kpeVocab",
       "url_suffix": "kpe_v0001/vocab.txt",
-      "checksum": "eeaa9875b23b04b4c54ef759d03db9d1ba1554838f8fb26c5d96fa551df93d02",
+      "checksum": "a81a5deccae9ee2b6d003f5b65023d342c59bb06f8eac2048c8f40002255864e",
       "fragments": []
     },
     {
       "id": "kpeModel",
       "url_suffix": "kpe_v0001/bert-quantized.onnx",
-      "checksum": "5498acfbe477b6605f03473a166c19e04b1e4dea3f4e289ad3fd831d91ad3f19",
+      "checksum": "0319f474a8516de89a7f6e9efe63029021c4539d81ae4f1abb948f8d452190ad",
       "fragments": []
     },
     {
       "id": "kpeCnn",
       "url_suffix": "kpe_v0001/cnn.binparams",
-      "checksum": "ef2c1aa1feb371aa0b06e11cd74bea226933443566a73acc06654166a14dabe5",
+      "checksum": "dec262c1c0d77ca6f8ddc62cd4cc31764ac068a1434875f9a22b6b1b22c2898b",
       "fragments": []
     },
     {
       "id": "kpeClassifier",
       "url_suffix": "kpe_v0001/classifier.binparams",
-      "checksum": "64506261afe164ac950be5ed8e0a3b703c5077488d1fadcc71dde6639ea8806d",
+      "checksum": "cd78be076b246d3065c7a646fe1ca19b57c1c670424f093ce1bd5211fa21082c",
       "fragments": []
     }
   ]


### PR DESCRIPTION
**References**

- [TY-2394]
- follow up of https://github.com/xaynetwork/xayn_ai/pull/419

**Summary**

- update asset checksums of kpe
- checked that the dart example loads the new assets successfully


[TY-2394]: https://xainag.atlassian.net/browse/TY-2394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ