### PR TITLE
[Merged by Bors] - TY-2448 ai config

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
 
 [[package]]
 name = "anymap2"
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "kpe"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#06a290651f98c13dcd2ccc18b1a65ca7e1329074"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#fbdd5417ee6d5ee4156a4e61a0fd004fc28f8d89"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "layer"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#06a290651f98c13dcd2ccc18b1a65ca7e1329074"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#fbdd5417ee6d5ee4156a4e61a0fd004fc28f8d89"
 dependencies = [
  "bincode",
  "displaydoc",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "rubert"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#06a290651f98c13dcd2ccc18b1a65ca7e1329074"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#fbdd5417ee6d5ee4156a4e61a0fd004fc28f8d89"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1885,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "rubert-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#06a290651f98c13dcd2ccc18b1a65ca7e1329074"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#fbdd5417ee6d5ee4156a4e61a0fd004fc28f8d89"
 dependencies = [
  "displaydoc",
  "num-traits",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "xayn-ai"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#06a290651f98c13dcd2ccc18b1a65ca7e1329074"
+source = "git+https://github.com/xaynetwork/xayn_ai?branch=master#fbdd5417ee6d5ee4156a4e61a0fd004fc28f8d89"
 dependencies = [
  "anyhow",
  "bincode",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -352,6 +352,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "nom 7.1.0",
+ "pathdiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
 dependencies = [
  "async-trait",
- "config",
+ "config 0.10.1",
  "crossbeam-queue",
  "num_cpus",
  "serde",
@@ -1407,6 +1421,12 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "peeking_take_while"
@@ -2803,6 +2823,7 @@ dependencies = [
  "bincode",
  "chrono",
  "claim",
+ "config 0.12.0",
  "derivative",
  "derive_more",
  "displaydoc",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -361,20 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
-dependencies = [
- "async-trait",
- "lazy_static",
- "nom 7.1.0",
- "pathdiff",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
 dependencies = [
  "async-trait",
- "config 0.10.1",
+ "config",
  "crossbeam-queue",
  "num_cpus",
  "serde",
@@ -1443,12 +1429,6 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "peeking_take_while"
@@ -2854,7 +2834,6 @@ dependencies = [
  "bincode",
  "chrono",
  "claim",
- "config 0.12.0",
  "derivative",
  "derive_more",
  "displaydoc",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -116,6 +116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +572,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
+dependencies = [
+ "atomic",
+ "serde",
+ "serde_json",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -2447,6 +2469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,6 +2858,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "displaydoc",
+ "figment",
  "float-cmp",
  "mockall",
  "rand 0.8.5",

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -12,6 +12,7 @@ config = { version = "0.12.0", default-features = false, features = ["json"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
+figment = { version = "0.10.6", default-features = false, features = ["json"] }
 rand = "0.8.5"
 rand_distr = "0.4.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 async-trait = "0.1.52"
 bincode = "1.3.3"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
-config = { version = "0.12.0", default-features = false, features = ["json"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 async-trait = "0.1.52"
 bincode = "1.3.3"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
+config = { version = "0.12.0", default-features = false, features = ["json"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -22,12 +22,12 @@ use figment::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::RwLock;
+
 use xayn_ai::{
-    ranker::{AveragePooler, Builder, Config as RankerConfig},
+    ranker::{AveragePooler, Builder, CoiSystemConfig},
     KpeConfig,
     SMBertConfig,
 };
-
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
@@ -356,18 +356,14 @@ pub type XaynAiEngine = Engine<xayn_ai::ranker::Ranker>;
 impl XaynAiEngine {
     /// Creates a discovery engine with [`xayn_ai::ranker::Ranker`] as a ranker.
     pub async fn from_config(config: InitConfig, state: Option<&[u8]>) -> Result<Self, Error> {
-        let ai_config = Figment::new()
-            .merge(Serialized::defaults(RankerConfig::default()))
-            .merge(Serialized::default("kpe_token_size", 150))
-            .merge(Serialized::default("smbert_token_size", 52))
-            // TODO: TY-2449
-            .merge(Json::string(r#"{}"#));
+        // TODO: TY-2449
+        let ai_config = ai_config_from_json("{}");
 
         let smbert_config = SMBertConfig::from_files(&config.smbert_vocab, &config.smbert_model)
             .map_err(|err| Error::Ranker(err.into()))?
             .with_token_size(
                 ai_config
-                    .extract_inner("smbert_token_size")
+                    .extract_inner("smbert.token_size")
                     .map_err(|err| Error::Ranker(err.into()))?,
             )
             .map_err(|err| Error::Ranker(err.into()))?
@@ -384,18 +380,19 @@ impl XaynAiEngine {
         .map_err(|err| Error::Ranker(err.into()))?
         .with_token_size(
             ai_config
-                .extract_inner("kpe_token_size")
+                .extract_inner("kpe.token_size")
                 .map_err(|err| Error::Ranker(err.into()))?,
         )
         .map_err(|err| Error::Ranker(err.into()))?
         .with_accents(false)
         .with_lowercase(false);
 
-        let ranker_config = ai_config
+        let coi_system_config = ai_config
             .extract()
             .map_err(|err| Error::Ranker(err.into()))?;
 
-        let builder = Builder::from(smbert_config, kpe_config).with_ranker_config(ranker_config);
+        let builder =
+            Builder::from(smbert_config, kpe_config).with_coi_system_config(coi_system_config);
 
         let stack_ops = vec![
             Box::new(BreakingNews::default()) as BoxedOps,
@@ -417,6 +414,14 @@ impl XaynAiEngine {
     }
 }
 
+fn ai_config_from_json(json: &str) -> Figment {
+    Figment::new()
+        .merge(Serialized::defaults(CoiSystemConfig::default()))
+        .merge(Serialized::default("kpe.token_size", 150))
+        .merge(Serialized::default("smbert.token_size", 52))
+        .merge(Json::string(json))
+}
+
 /// A wrapper around a dynamic error type, similar to `anyhow::Error`,
 /// but without the need to declare `anyhow` as a dependency.
 pub(crate) type GenericError = Box<dyn std::error::Error + Sync + Send + 'static>;
@@ -433,4 +438,51 @@ struct State {
     engine: StackState,
     /// The serialized ranker state.
     ranker: RankerState,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn test_ai_config_from_json_default() -> Result<(), Box<dyn Error>> {
+        let ai_config = ai_config_from_json("{}");
+        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 52);
+        assert_eq!(
+            ai_config.extract::<CoiSystemConfig>()?,
+            CoiSystemConfig::default(),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ai_config_from_json_modified() -> Result<(), Box<dyn Error>> {
+        let ai_config = ai_config_from_json(
+            r#"{
+                "coi": {
+                    "threshold": 0.42
+                },
+                "kpe": {
+                    "penalty": [0.99, 0.66, 0.33]
+                },
+                "smbert": {
+                    "token_size": 42,
+                    "foo": "bar"
+                },
+                "baz": 0
+            }"#,
+        );
+        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 42);
+        assert_eq!(
+            ai_config.extract::<CoiSystemConfig>()?,
+            CoiSystemConfig::default()
+                .with_threshold(0.42)?
+                .with_penalty(&[0.99, 0.66, 0.33])?,
+        );
+        Ok(())
+    }
 }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -12,10 +12,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
-use config::{Config, File, FileFormat};
 use displaydoc::Display;
+use figment::{
+    providers::{Format, Json, Serialized},
+    Figment,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -352,37 +355,19 @@ pub type XaynAiEngine = Engine<xayn_ai::ranker::Ranker>;
 
 impl XaynAiEngine {
     /// Creates a discovery engine with [`xayn_ai::ranker::Ranker`] as a ranker.
-    #[allow(clippy::too_many_lines)] // TODO: TY-2447
     pub async fn from_config(config: InitConfig, state: Option<&[u8]>) -> Result<Self, Error> {
-        let ai_config = Config::builder()
-            .set_default("coi_shift_factor", 0.1)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("coi_threshold", 0.67)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("coi_min_positive_cois", 2)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("coi_min_negative_cois", 2)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("kpe_horizon", 30)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("kpe_gamma", 0.9)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("kpe_penalty", vec![1., 0.75, 0.66])
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("kpe_token_size", 150)
-            .map_err(|err| Error::Ranker(err.into()))?
-            .set_default("smbert_token_size", 52)
-            .map_err(|err| Error::Ranker(err.into()))?
-            // TODO: add json-encoded string to InitConfig
-            .add_source(File::from_str(r#"{}"#, FileFormat::Json))
-            .build()
-            .map_err(|err| Error::Ranker(err.into()))?;
+        let ai_config = Figment::new()
+            .merge(Serialized::defaults(RankerConfig::default()))
+            .merge(Serialized::default("kpe_token_size", 150))
+            .merge(Serialized::default("smbert_token_size", 52))
+            // TODO: TY-2449
+            .merge(Json::string(r#"{}"#));
 
         let smbert_config = SMBertConfig::from_files(&config.smbert_vocab, &config.smbert_model)
             .map_err(|err| Error::Ranker(err.into()))?
             .with_token_size(
                 ai_config
-                    .get::<usize>("smbert_token_size")
+                    .extract_inner("smbert_token_size")
                     .map_err(|err| Error::Ranker(err.into()))?,
             )
             .map_err(|err| Error::Ranker(err.into()))?
@@ -399,56 +384,15 @@ impl XaynAiEngine {
         .map_err(|err| Error::Ranker(err.into()))?
         .with_token_size(
             ai_config
-                .get::<usize>("kpe_token_size")
+                .extract_inner("kpe_token_size")
                 .map_err(|err| Error::Ranker(err.into()))?,
         )
         .map_err(|err| Error::Ranker(err.into()))?
         .with_accents(false)
         .with_lowercase(false);
 
-        let ranker_config = RankerConfig::default()
-            .with_shift_factor(
-                ai_config
-                    .get::<f32>("coi_shift_factor")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
-            .map_err(|err| Error::Ranker(err.into()))?
-            .with_threshold(
-                ai_config
-                    .get::<f32>("coi_threshold")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
-            .map_err(|err| Error::Ranker(err.into()))?
-            .with_horizon(Duration::from_secs({
-                const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
-                let days = ai_config
-                    .get::<u64>("kpe_horizon")
-                    .map_err(|err| Error::Ranker(err.into()))?;
-                SECONDS_PER_DAY * days
-            }))
-            .with_gamma(
-                ai_config
-                    .get::<f32>("kpe_gamma")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
-            .map_err(|err| Error::Ranker(err.into()))?
-            .with_penalty(
-                &ai_config
-                    .get::<Vec<f32>>("kpe_penalty")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
-            .map_err(|err| Error::Ranker(err.into()))?
-            .with_min_positive_cois(
-                ai_config
-                    .get::<usize>("coi_min_positive_cois")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
-            .map_err(|err| Error::Ranker(err.into()))?
-            .with_min_negative_cois(
-                ai_config
-                    .get::<usize>("coi_min_negative_cois")
-                    .map_err(|err| Error::Ranker(err.into()))?,
-            )
+        let ranker_config = ai_config
+            .extract()
             .map_err(|err| Error::Ranker(err.into()))?;
 
         let builder = Builder::from(smbert_config, kpe_config).with_ranker_config(ranker_config);

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -372,8 +372,8 @@ impl XaynAiEngine {
             .map_err(|err| Error::Ranker(err.into()))?
             .set_default("smbert_token_size", 52)
             .map_err(|err| Error::Ranker(err.into()))?
-            // TODO: add json string to InitConfig
-            .add_source(File::from_str("", FileFormat::Json))
+            // TODO: add json-encoded string to InitConfig
+            .add_source(File::from_str(r#"{}"#, FileFormat::Json))
             .build()
             .map_err(|err| Error::Ranker(err.into()))?;
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -352,6 +352,7 @@ pub type XaynAiEngine = Engine<xayn_ai::ranker::Ranker>;
 
 impl XaynAiEngine {
     /// Creates a discovery engine with [`xayn_ai::ranker::Ranker`] as a ranker.
+    #[allow(clippy::too_many_lines)] // TODO: TY-2447
     pub async fn from_config(config: InitConfig, state: Option<&[u8]>) -> Result<Self, Error> {
         let ai_config = Config::builder()
             .set_default("coi_shift_factor", 0.1)


### PR DESCRIPTION
**References**

- [TY-2448]
- requires https://github.com/xaynetwork/xayn_ai/pull/424
- followed by #177

**Summary**

- add JSON parser of AI configuration to DE constructor
- use AI config values in smbert, kpe & coi system configs
- the Config can be deserialized from the following kind of JSON:

```
{
    "coi": {
        "shift_factor": 0.1,
        "threshold": 0.67,
        "min_positive_cois": 2,
        "min_negative_cois": 2
    },
    "kpe": {
        "horizon": 30,
        "gamma": 0.9,
        "penalty": [1., 0.75, 0.66],
        "token_size": 150
    },
    "smbert": {
        "token_size": 52
    }
}
```

**Todo**

- ~point `xayn_ai` back once https://github.com/xaynetwork/xayn_ai/pull/424 is merged~


[TY-2448]: https://xainag.atlassian.net/browse/TY-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
