### PR TITLE
[Merged by Bors] - Export logging function with a name prefix

### DIFF
--- a/discovery_engine/lib/discovery_engine.dart
+++ b/discovery_engine/lib/discovery_engine.dart
@@ -17,11 +17,16 @@
 /// More dartdocs go here.
 library discovery_engine;
 
+import 'package:logger/logger.dart' show Logger;
+import 'package:xayn_discovery_engine/src/logger.dart' show initLogger, logger;
+
 export 'package:xayn_discovery_engine/src/api/api.dart';
 export 'package:xayn_discovery_engine/src/discovery_engine_base.dart';
 export 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
     show Manifest, kAssetsPath;
 export 'package:xayn_discovery_engine/src/infrastructure/assets/assets.dart'
     show createManifestReader;
-export 'package:xayn_discovery_engine/src/logger.dart';
 export 'package:xayn_discovery_engine/src/worker/common/exceptions.dart';
+
+void discoveryEngineInitLogger(Logger logger) => initLogger(logger);
+Logger get discoveryEngineLogger => logger;

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -12,7 +12,7 @@ packages:
     dependency: transitive
     description:
       path: async_bindgen_dart_utils
-      ref: HEAD
+      ref: fe195d99954c691c5e606ebbb3c77d371ba0e65b
       resolved-ref: fe195d99954c691c5e606ebbb3c77d371ba0e65b
       url: "https://github.com/xaynetwork/xayn_async_bindgen.git"
     source: git

--- a/discovery_engine_flutter/lib/src/assets/asset_copier.dart
+++ b/discovery_engine_flutter/lib/src/assets/asset_copier.dart
@@ -17,7 +17,7 @@ import 'dart:typed_data' show ByteData;
 
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:xayn_discovery_engine/discovery_engine.dart'
-    show Manifest, kAssetsPath, logger;
+    show Manifest, kAssetsPath, discoveryEngineLogger;
 
 /// A signature for a function loading the assets from bundle.
 typedef AssetLoader = Future<ByteData> Function(String key);
@@ -56,7 +56,7 @@ class FlutterBundleAssetCopier {
       } catch (e, s) {
         final message =
             'Couldn\'t copy the asset "$urlSuffix" to the path: ${fileRef.path}';
-        logger.e(message, e, s);
+        discoveryEngineLogger.e(message, e, s);
       }
     }
   }


### PR DESCRIPTION
Export functions with different names to avoid name conflicts.
'initLogger' -> 'discoveryEngineInitLogger'
'logger' -> 'discoveryEngineLogger'