### PR TITLE
[Merged by Bors] - TY-2425 historic document

### DIFF
--- a/discovery_engine/lib/src/domain/models/history.dart
+++ b/discovery_engine/lib/src/domain/models/history.dart
@@ -12,8 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:equatable/equatable.dart';
-import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
+import 'package:equatable/equatable.dart' show EquatableMixin;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
 
 /// A compact representation of a `Document` in the document history.
 class HistoricDocument with EquatableMixin {

--- a/discovery_engine/lib/src/domain/models/history.dart
+++ b/discovery_engine/lib/src/domain/models/history.dart
@@ -12,23 +12,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Modules containing FFI glue for various types.
+import 'package:equatable/equatable.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
 
-mod boxed;
-pub mod date_time;
-pub mod document;
-pub mod duration;
-pub mod embedding;
-pub mod engine;
-pub mod history;
-pub mod init_config;
-pub mod market;
-pub mod market_vec;
-pub mod option;
-pub mod primitives;
-pub mod result;
-pub mod slice;
-pub mod string;
-pub mod url;
-pub mod uuid;
-pub mod vec;
+/// A compact representation of a `Document` in the document history.
+class HistoricDocument with EquatableMixin {
+  final DocumentId id;
+  final Uri url;
+  final String snippet;
+  final String title;
+
+  HistoricDocument({
+    required this.id,
+    required this.url,
+    required this.snippet,
+    required this.title,
+  });
+
+  @override
+  List<Object?> get props => [id, url, snippet, title];
+}

--- a/discovery_engine/lib/src/ffi/types/history.dart
+++ b/discovery_engine/lib/src/ffi/types/history.dart
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'dart:ffi' show Pointer;
 
 import 'package:meta/meta.dart' show visibleForTesting;

--- a/discovery_engine/lib/src/ffi/types/history.dart
+++ b/discovery_engine/lib/src/ffi/types/history.dart
@@ -1,0 +1,40 @@
+import 'dart:ffi' show Pointer;
+
+import 'package:meta/meta.dart' show visibleForTesting;
+import 'package:xayn_discovery_engine/src/domain/models/history.dart'
+    show HistoricDocument;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustHistoricDocument;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uri.dart' show UriFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
+    show DocumentIdFfi;
+
+extension HistoricDocumentFfi on HistoricDocument {
+  void writeNative(Pointer<RustHistoricDocument> place) {
+    id.writeNative(ffi.historic_document_place_of_id(place));
+    url.writeNative(ffi.historic_document_place_of_url(place));
+    snippet.writeNative(ffi.historic_document_place_of_snippet(place));
+    title.writeNative(ffi.historic_document_place_of_title(place));
+  }
+
+  @visibleForTesting
+  Boxed<RustHistoricDocument> allocNative() {
+    final place = ffi.alloc_uninitialized_historic_document();
+    writeNative(place);
+    return Boxed(place, ffi.drop_historic_document);
+  }
+
+  @visibleForTesting
+  static HistoricDocument readNative(Pointer<RustHistoricDocument> doc) {
+    return HistoricDocument(
+      id: DocumentIdFfi.readNative(ffi.historic_document_place_of_id(doc)),
+      url: UriFfi.readNative(ffi.historic_document_place_of_url(doc)),
+      snippet:
+          StringFfi.readNative(ffi.historic_document_place_of_snippet(doc)),
+      title: StringFfi.readNative(ffi.historic_document_place_of_title(doc)),
+    );
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/history.dart
+++ b/discovery_engine/lib/src/ffi/types/history.dart
@@ -6,7 +6,7 @@ import 'package:xayn_discovery_engine/src/domain/models/history.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustHistoricDocument;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
-import 'package:xayn_discovery_engine/src/ffi/types/box.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uri.dart' show UriFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'

--- a/discovery_engine/test/ffi/types/history.dart
+++ b/discovery_engine/test/ffi/types/history.dart
@@ -1,0 +1,33 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:test/test.dart';
+import 'package:xayn_discovery_engine/src/domain/models/history.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
+import 'package:xayn_discovery_engine/src/ffi/types/history.dart';
+
+void main() {
+  test('reading written HistoricDocument works', () {
+    final document = HistoricDocument(
+      id: DocumentId(),
+      url: Uri.parse('https://www.test.test/foo'),
+      snippet: 'foo, bar and foobar',
+      title: 'Foobar',
+    );
+    final boxed = document.allocNative();
+    final res = HistoricDocumentFfi.readNative(boxed.ref);
+    boxed.free();
+    expect(res, equals(document));
+  });
+}

--- a/discovery_engine/test/ffi/types/history_test.dart
+++ b/discovery_engine/test/ffi/types/history_test.dart
@@ -13,9 +13,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:test/test.dart';
-import 'package:xayn_discovery_engine/src/domain/models/history.dart';
-import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
-import 'package:xayn_discovery_engine/src/ffi/types/history.dart';
+import 'package:xayn_discovery_engine/src/domain/models/history.dart'
+    show HistoricDocument;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
+import 'package:xayn_discovery_engine/src/ffi/types/history.dart'
+    show HistoricDocumentFfi;
 
 void main() {
   test('reading written HistoricDocument works', () {

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -24,6 +24,7 @@ include = ["xayn-discovery-engine-core"]
 "Document" = "RustDocument"
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
+"HistoricDocument" = "RustHistoricDocument"
 "InitConfig" = "RustInitConfig"
 "Market" = "RustMarket"
 "NaiveDateTime" = "RustNaiveDateTime"

--- a/discovery_engine_core/bindings/src/types/history.rs
+++ b/discovery_engine_core/bindings/src/types/history.rs
@@ -1,0 +1,85 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling [`HistoricDocument`].
+
+use std::ptr::addr_of_mut;
+
+use url::Url;
+use uuid::Uuid;
+use xayn_discovery_engine_core::document::HistoricDocument;
+
+/// Returns a pointer to the `id` field of a [`HistoricDocument`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`HistoricDocument`] memory object, it
+/// might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn historic_document_place_of_id(place: *mut HistoricDocument) -> *mut Uuid {
+    unsafe { addr_of_mut!((*place).id) }.cast::<Uuid>()
+}
+
+/// Returns a pointer to the `url` field of a [`HistoricDocument`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`HistoricDocument`] memory object, it
+/// might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn historic_document_place_of_url(place: *mut HistoricDocument) -> *mut Url {
+    unsafe { addr_of_mut!((*place).url) }
+}
+
+/// Returns a pointer to the `snippet` field of a [`HistoricDocument`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`HistoricDocument`] memory object, it
+/// might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn historic_document_place_of_snippet(
+    place: *mut HistoricDocument,
+) -> *mut String {
+    unsafe { addr_of_mut!((*place).snippet) }
+}
+
+/// Returns a pointer to the `title` field of a [`HistoricDocument`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`HistoricDocument`] memory object, it
+/// might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn historic_document_place_of_title(
+    place: *mut HistoricDocument,
+) -> *mut String {
+    unsafe { addr_of_mut!((*place).title) }
+}
+
+/// Alloc an uninitialized `Box<HistoricDocument>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_historic_document() -> *mut HistoricDocument {
+    crate::types::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<HistoricDocument>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<HistoricDocument>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_historic_document(doc: *mut HistoricDocument) {
+    unsafe { crate::types::boxed::drop(doc) };
+}

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -221,6 +221,19 @@ pub(crate) fn document_from_article(
     })
 }
 
+/// Represents a [`Document`] in the document history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoricDocument {
+    /// See  [`Document::id`].
+    pub id: Id,
+    /// See [`NewsResource::url`].
+    pub url: Url,
+    /// See [`NewsResource::snippet`].
+    pub snippet: String,
+    /// See [`NewsResource::title`].
+    pub title: String,
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -353,7 +353,6 @@ fn rank_stacks<'a>(
 }
 
 /// A discovery engine with [`xayn_ai::ranker::Ranker`] as a ranker.
-#[allow(clippy::module_name_repetitions)]
 pub type XaynAiEngine = Engine<xayn_ai::ranker::Ranker>;
 
 impl XaynAiEngine {

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -24,7 +24,11 @@
     unused_qualifications
 )]
 #![warn(missing_docs, unreachable_pub)]
-#![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions
+)]
 
 pub mod document;
 mod engine;

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -57,7 +57,7 @@ pub trait Ops {
         articles: Vec<Article>,
     ) -> Result<Vec<Article>, GenericError>;
 
-    /// Merge current and new items.
+    /// Merge stacked and new items.
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;
 }
 

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -50,15 +50,15 @@ pub trait Ops {
     /// tailored to the user's interests.
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError>;
 
-    /// Filter `articles` based on `current` documents.
+    /// Filter `articles` based on `stack` documents.
     fn filter_articles(
         &self,
-        current: &[Document],
+        stack: &[Document],
         articles: Vec<Article>,
     ) -> Result<Vec<Article>, GenericError>;
 
     /// Merge current and new items.
-    fn merge(&self, current: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;
+    fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a `HistoricDocument` type and FFI bindings for it.

*References:*

- [TY-2425](https://xainag.atlassian.net/browse/TY-2425)