### PR TITLE
[Merged by Bors] - TY-2465 historic document vec

### DIFF
--- a/discovery_engine/lib/src/ffi/types/history.dart
+++ b/discovery_engine/lib/src/ffi/types/history.dart
@@ -65,7 +65,7 @@ final _listFfiAdapter = ListFfiAdapter(
   writeNativeVec: ffi.init_historic_document_vec_at,
 );
 
-extension HistoricDocumentSliceFfi on List<HistoricDocument> {
+extension HistoricDocumentVecFfi on List<HistoricDocument> {
   Boxed<RustVecHistoricDocument> allocNative() {
     final place = ffi.alloc_uninitialized_historic_document_vec();
     _listFfiAdapter.writeVec(this, place);

--- a/discovery_engine/test/ffi/types/feed_market_vec_test.dart
+++ b/discovery_engine/test/ffi/types/feed_market_vec_test.dart
@@ -13,7 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:test/test.dart';
-import 'package:xayn_discovery_engine/src/api/api.dart';
+import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
+    show FeedMarket;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
 

--- a/discovery_engine/test/ffi/types/history_test.dart
+++ b/discovery_engine/test/ffi/types/history_test.dart
@@ -18,7 +18,7 @@ import 'package:xayn_discovery_engine/src/domain/models/history.dart'
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId;
 import 'package:xayn_discovery_engine/src/ffi/types/history.dart'
-    show HistoricDocumentFfi;
+    show HistoricDocumentFfi, HistoricDocumentSliceFfi;
 
 void main() {
   test('reading written HistoricDocument works', () {
@@ -32,5 +32,26 @@ void main() {
     final res = HistoricDocumentFfi.readNative(boxed.ref);
     boxed.free();
     expect(res, equals(document));
+  });
+
+  test('reading written Vec<HistoricDocument> works', () {
+    final docs = [
+      HistoricDocument(
+        id: DocumentId(),
+        url: Uri.parse('https://foo.example/'),
+        snippet: 'foo',
+        title: 'bar',
+      ),
+      HistoricDocument(
+        id: DocumentId(),
+        url: Uri.parse('https://foo.example/'),
+        snippet: 'dodo',
+        title: 'bird',
+      )
+    ];
+
+    final boxed = docs.allocNative();
+    final res = HistoricDocumentSliceFfi.consumeNative(boxed);
+    expect(res, equals(docs));
   });
 }

--- a/discovery_engine/test/ffi/types/history_test.dart
+++ b/discovery_engine/test/ffi/types/history_test.dart
@@ -18,7 +18,7 @@ import 'package:xayn_discovery_engine/src/domain/models/history.dart'
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId;
 import 'package:xayn_discovery_engine/src/ffi/types/history.dart'
-    show HistoricDocumentFfi, HistoricDocumentSliceFfi;
+    show HistoricDocumentFfi, HistoricDocumentVecFfi;
 
 void main() {
   test('reading written HistoricDocument works', () {
@@ -51,7 +51,7 @@ void main() {
     ];
 
     final boxed = docs.allocNative();
-    final res = HistoricDocumentSliceFfi.consumeNative(boxed);
+    final res = HistoricDocumentVecFfi.consumeNative(boxed);
     expect(res, equals(docs));
   });
 }

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -43,5 +43,6 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "UserReaction" = "RustUserReaction"
 "Uuid" = "RustUuid"
 "Vec_Document" = "RustVecDocument"
+"Vec_HistoricDocument" = "RustVecHistoricDocument"
 "Vec_Market" = "RustVecMarket"
 "Vec_u8" = "RustVecU8"

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -21,6 +21,7 @@ pub mod duration;
 pub mod embedding;
 pub mod engine;
 pub mod history;
+pub mod history_vec;
 pub mod init_config;
 pub mod market;
 pub mod market_vec;

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -33,7 +33,7 @@ use super::boxed::alloc_uninitialized;
 /// - It must be valid to write a `Vec<HistoricDocument>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 /// - It must be valid to construct a `Box<[HistoricDocument]>` from given `slice_ptr`
-///   and `len`.
+///   and `slice_len`.
 #[no_mangle]
 pub unsafe extern "C" fn init_historic_document_vec_at(
     place: *mut Vec<HistoricDocument>,

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -1,0 +1,123 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling slices and vectors of [`HistoricDocuments`].
+
+use xayn_discovery_engine_core::document::HistoricDocument;
+
+use crate::types::{
+    slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts, next_element},
+    vec::{get_vec_buffer, get_vec_len},
+};
+
+use super::boxed::alloc_uninitialized;
+
+/// Initializes a `Vec<HistoricDocument>` at given place.
+///
+/// This moves the passed in slice into the vector,
+/// i.e. `slice_ptr, len` map to `Box<[HistoricDocument]>`.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Vec<HistoricDocument>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+/// - It must be valid to construct a `Box<[HistoricDocument]>` from given `slice_ptr`
+///   and `len`.
+#[no_mangle]
+pub unsafe extern "C" fn init_historic_document_vec_at(
+    place: *mut Vec<HistoricDocument>,
+    slice_ptr: *mut HistoricDocument,
+    slice_len: usize,
+) {
+    unsafe {
+        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
+    }
+}
+
+/// Alloc an uninitialized `Box<[HistoricDocument]>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_historic_document_slice(len: usize) -> *mut HistoricDocument {
+    alloc_uninitialized_slice(len)
+}
+
+/// Alloc an uninitialized `Box<Vec<HistoricDocument>>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_historic_document_vec() -> *mut Vec<HistoricDocument> {
+    alloc_uninitialized()
+}
+
+/// Given a pointer to a [`HistoricDocument`] in a slice return the pointer to the next [`HistoricDocument`].
+///
+/// This also works for uninitialized historic document slices.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `HistoricDocument` memory object, it might
+/// be uninitialized. If it's the last object in an array the returned pointer
+/// must not be dereferenced.
+#[no_mangle]
+pub unsafe extern "C" fn next_historic_document(
+    place: *mut HistoricDocument,
+) -> *mut HistoricDocument {
+    unsafe { next_element(place) }
+}
+
+/// Drop a `Box<[HistoricDocument]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[HistoricDocument]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_historic_document_slice(
+    documents: *mut HistoricDocument,
+    len: usize,
+) {
+    drop(unsafe { boxed_slice_from_raw_parts(documents, len) });
+}
+
+/// Returns the length of a `Box<Vec<HistoricDocument>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<HistoricDocument>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_historic_document_vec_len(
+    documents: *mut Vec<HistoricDocument>,
+) -> usize {
+    unsafe { get_vec_len(documents) }
+}
+
+/// Returns the `*mut HistoricDocument` to the beginning of the buffer of a `Box<Vec<HistoricDocument>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<HistoricDocument>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_historic_document_vec_buffer(
+    documents: *mut Vec<HistoricDocument>,
+) -> *mut HistoricDocument {
+    unsafe { get_vec_buffer(documents) }
+}
+
+/// Drop a `Box<Vec<HistoricDocument>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Vec<HistoricDocument>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_historic_document_vec(documents: *mut Vec<HistoricDocument>) {
+    unsafe {
+        crate::types::boxed::drop(documents);
+    }
+}

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! FFI functions for handling slices and vectors of [`HistoricDocuments`].
+//! FFI functions for handling slices and vectors of [`HistoricDocument`]s.
 
 use xayn_discovery_engine_core::document::HistoricDocument;
 


### PR DESCRIPTION
Added support for passing a `Vec<HistoricDocument>` to dart.

*References:*

- [TY-2465](https://xainag.atlassian.net/browse/TY-2465)

*Based on:*

- #170 