### PR TITLE
[Merged by Bors] - TY-2449 optional ai config

### DIFF
--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -26,7 +26,8 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
-import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart'
+    show OptionStringFfi, StringFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
     show NativeSetupData;
 
@@ -40,6 +41,7 @@ class InitConfigFfi with EquatableMixin {
   final String kpeModel;
   final String kpeCnn;
   final String kpeClassifier;
+  final String? aiConfig;
 
   @override
   List<Object?> get props => [
@@ -52,12 +54,14 @@ class InitConfigFfi with EquatableMixin {
         kpeModel,
         kpeCnn,
         kpeClassifier,
+        aiConfig,
       ];
 
   factory InitConfigFfi(
     Configuration configuration,
-    NativeSetupData setupData,
-  ) =>
+    NativeSetupData setupData, [
+    String? aiConfig,
+  ]) =>
       InitConfigFfi.fromParts(
         apiKey: configuration.apiKey,
         apiBaseUrl: configuration.apiBaseUrl,
@@ -68,6 +72,7 @@ class InitConfigFfi with EquatableMixin {
         kpeModel: setupData.kpeModel,
         kpeCnn: setupData.kpeCnn,
         kpeClassifier: setupData.kpeClassifier,
+        aiConfig: aiConfig,
       );
 
   InitConfigFfi.fromParts({
@@ -80,6 +85,7 @@ class InitConfigFfi with EquatableMixin {
     required this.kpeModel,
     required this.kpeCnn,
     required this.kpeClassifier,
+    this.aiConfig,
   });
 
   /// Allocates a `Box<RustInitConfig>` initialized based on this instance.
@@ -99,6 +105,7 @@ class InitConfigFfi with EquatableMixin {
     kpeModel.writeNative(ffi.init_config_place_of_kpe_model(place));
     kpeCnn.writeNative(ffi.init_config_place_of_kpe_cnn(place));
     kpeClassifier.writeNative(ffi.init_config_place_of_kpe_classifier(place));
+    aiConfig.writeNative(ffi.init_config_place_of_ai_config(place));
   }
 
   @visibleForTesting
@@ -120,6 +127,9 @@ class InitConfigFfi with EquatableMixin {
       kpeCnn: StringFfi.readNative(ffi.init_config_place_of_kpe_cnn(config)),
       kpeClassifier:
           StringFfi.readNative(ffi.init_config_place_of_kpe_classifier(config)),
+      aiConfig: OptionStringFfi.readNative(
+        ffi.init_config_place_of_ai_config(config),
+      ),
     );
   }
 }

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -13,10 +13,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:convert' show utf8;
-import 'dart:ffi' show Pointer, Uint8, Uint8Pointer;
+import 'dart:ffi' show nullptr, Pointer, Uint8, Uint8Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
-    show RustString;
+    show RustOptionString, RustString;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 
 extension StringFfi on String {
@@ -32,6 +32,26 @@ extension StringFfi on String {
         ffi.get_string_buffer(place),
         ffi.get_string_len(place),
       ).readNative();
+}
+
+extension OptionStringFfi on String? {
+  void writeNative(final Pointer<RustOptionString> place) {
+    if (this == null) {
+      ffi.init_option_string_none_at(place);
+    } else {
+      final str = BoxedStr.create(this!);
+      ffi.init_option_string_some_at(place, str.ptr, str.len);
+    }
+  }
+
+  static String? readNative(final Pointer<RustOptionString> place) {
+    final str = ffi.get_option_string_some(place);
+    if (str == nullptr) {
+      return null;
+    } else {
+      return StringFfi.readNative(str);
+    }
+  }
 }
 
 class BoxedStr {

--- a/discovery_engine/test/ffi/types/feed_market_vec_test.dart
+++ b/discovery_engine/test/ffi/types/feed_market_vec_test.dart
@@ -27,7 +27,7 @@ void main() {
       ),
       FeedMarket(
         countryCode: 'DE',
-        langCode: 'ED',
+        langCode: 'de',
       )
     ];
     final boxed = market.allocVec();

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -24,8 +24,8 @@ void main() {
       apiKey: 'hjlsdfhjfdhjk',
       apiBaseUrl: 'https://foo.example/api/v1',
       feedMarkets: [
-        const FeedMarket(countryCode: 'DE', langCode: 'DE'),
-        const FeedMarket(countryCode: 'US', langCode: 'EN'),
+        const FeedMarket(countryCode: 'DE', langCode: 'de'),
+        const FeedMarket(countryCode: 'US', langCode: 'en'),
       ],
       smbertVocab: 'foo/bar',
       smbertModel: 'bar/foot',
@@ -45,8 +45,8 @@ void main() {
       apiKey: 'hjlsdfhjfdhjk',
       apiBaseUrl: 'https://foo.example/api/v1',
       feedMarkets: [
-        const FeedMarket(countryCode: 'DE', langCode: 'DE'),
-        const FeedMarket(countryCode: 'US', langCode: 'EN'),
+        const FeedMarket(countryCode: 'DE', langCode: 'de'),
+        const FeedMarket(countryCode: 'US', langCode: 'en'),
       ],
       smbertVocab: 'foo/bar',
       smbertModel: 'bar/foot',

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -19,7 +19,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/init_config.dart'
     show InitConfigFfi;
 
 void main() {
-  test('reading written init config ffi works', () {
+  test('reading written init config ffi without ai config works', () {
     final config = InitConfigFfi.fromParts(
       apiKey: 'hjlsdfhjfdhjk',
       apiBaseUrl: 'https://foo.example/api/v1',
@@ -33,6 +33,28 @@ void main() {
       kpeModel: 'yo.lo',
       kpeCnn: 'abc',
       kpeClassifier: 'magic',
+    );
+    final boxed = config.allocNative();
+    final res = InitConfigFfi.readNative(boxed.ref);
+    boxed.free();
+    expect(res, equals(config));
+  });
+
+  test('reading written init config ffi with ai config works', () {
+    final config = InitConfigFfi.fromParts(
+      apiKey: 'hjlsdfhjfdhjk',
+      apiBaseUrl: 'https://foo.example/api/v1',
+      feedMarkets: [
+        const FeedMarket(countryCode: 'DE', langCode: 'DE'),
+        const FeedMarket(countryCode: 'US', langCode: 'EN'),
+      ],
+      smbertVocab: 'foo/bar',
+      smbertModel: 'bar/foot',
+      kpeVocab: 'do.do',
+      kpeModel: 'yo.lo',
+      kpeCnn: 'abc',
+      kpeClassifier: 'magic',
+      aiConfig: '{ "key": "value" }',
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine/test/ffi/types/string_test.dart
+++ b/discovery_engine/test/ffi/types/string_test.dart
@@ -14,7 +14,8 @@
 
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
-import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/string.dart'
+    show OptionStringFfi, StringFfi;
 
 void main() {
   test('reading written empty string works', () {
@@ -33,5 +34,24 @@ void main() {
     final res = StringFfi.readNative(place);
     ffi.drop_string(place);
     expect(res, equals(string));
+  });
+
+  test('reading written some string yields same result', () {
+    // ignore: unnecessary_cast
+    const String? string = 'a&+KLA)&+fjw)&+f' as String?;
+    final place = ffi.alloc_uninitialized_option_string();
+    string.writeNative(place);
+    final res = OptionStringFfi.readNative(place);
+    ffi.drop_option_string(place);
+    expect(res, equals(string));
+  });
+
+  test('reading written none string yields same result', () {
+    const String? string = null;
+    final place = ffi.alloc_uninitialized_option_string();
+    string.writeNative(place);
+    final res = OptionStringFfi.readNative(place);
+    ffi.drop_option_string(place);
+    expect(res, isNull);
   });
 }

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -30,6 +30,7 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "NaiveDateTime" = "RustNaiveDateTime"
 "NewsResource" = "RustNewsResource"
 "Option_f32" = "RustOptionF32"
+"Option_String" = "RustOptionString"
 "Option_Url" = "RustOptionUrl"
 "Result_SharedEngine__String" = "RustResultSharedEngineString"
 "Result_String" = "RustResultVoidString"

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -119,6 +119,19 @@ pub unsafe extern "C" fn init_config_place_of_kpe_classifier(
     unsafe { addr_of_mut!((*place).kpe_classifier) }
 }
 
+/// Returns a pointer to the `ai_config` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_ai_config(
+    place: *mut InitConfig,
+) -> *mut Option<String> {
+    unsafe { addr_of_mut!((*place).ai_config) }
+}
+
 /// Alloc an uninitialized `Box<InitConfig>`, mainly used for testing.
 #[no_mangle]
 pub extern "C" fn alloc_uninitialized_init_config() -> *mut InitConfig {

--- a/discovery_engine_core/bindings/src/types/option.rs
+++ b/discovery_engine_core/bindings/src/types/option.rs
@@ -23,8 +23,8 @@ use std::ptr;
 /// # Safety
 ///
 /// - The pointer must point to a sound initialized `Option<T>`.
-pub(super) unsafe fn get_option_some<T>(opt_url: *const Option<T>) -> *const T {
-    match unsafe { &*opt_url } {
+pub(super) unsafe fn get_option_some<T>(opt: *const Option<T>) -> *const T {
+    match unsafe { &*opt } {
         Some(val) => val,
         None => ptr::null(),
     }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -97,8 +97,10 @@ pub struct InitConfig {
     pub kpe_model: String,
     /// KPE CNN path.
     pub kpe_cnn: String,
-    /// KPR classifier path.
+    /// KPE classifier path.
     pub kpe_classifier: String,
+    /// AI config in JSON format.
+    pub ai_config: Option<String>,
 }
 
 /// Discovery Engine endpoint settings.


### PR DESCRIPTION
**References**

- [TY-2449]
- requires #164
- followed by #178

**Summary**

- add `Option<String>` handling to ffi
- add `ai_config: Option<String>` field to `InitConfig` & update ffi


[TY-2449]: https://xainag.atlassian.net/browse/TY-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ