### PR TITLE
[Merged by Bors] - TY 2490 Do not do a query if there no keywords

### DIFF
--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -47,6 +47,9 @@ impl Ops for PersonalizedNews {
     }
 
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
+        if key_phrases.is_empty() {
+            return Ok(vec![]);
+        }
         if let Some(markets) = self.markets.as_ref() {
             let mut articles = Vec::new();
             let mut errors = Vec::new();

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -14,7 +14,7 @@
 
 //! Client to get new documents.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use displaydoc::Display as DisplayDoc;
 use thiserror::Error;
@@ -67,7 +67,7 @@ impl Client {
 
     /// Retrieve news from the remote API
     pub async fn news(&self, params: &NewsQuery) -> Result<Vec<Article>, Error> {
-        let mut query: HashMap<String, String> = HashMap::new();
+        let mut query: BTreeMap<String, String> = BTreeMap::new();
         query.insert("sort_by".into(), "relevancy".into());
         Self::build_news_query(&mut query, params);
 
@@ -87,7 +87,7 @@ impl Client {
         Ok(result)
     }
 
-    fn build_news_query(query: &mut HashMap<String, String>, params: &NewsQuery) {
+    fn build_news_query(query: &mut BTreeMap<String, String>, params: &NewsQuery) {
         query.insert("lang".to_string(), params.market.lang_code.clone());
         query.insert("countries".to_string(), params.market.country_code.clone());
         query.insert(
@@ -99,7 +99,7 @@ impl Client {
 
     /// Retrieve headlines from the remote API
     pub async fn headlines(&self, params: &HeadlinesQuery) -> Result<Vec<Article>, Error> {
-        let mut query: HashMap<String, String> = HashMap::new();
+        let mut query: BTreeMap<String, String> = BTreeMap::new();
         Self::build_headlines_query(&mut query, params);
 
         let c = reqwest::Client::new();
@@ -118,7 +118,7 @@ impl Client {
         Ok(result)
     }
 
-    fn build_headlines_query(query: &mut HashMap<String, String>, params: &HeadlinesQuery) {
+    fn build_headlines_query(query: &mut BTreeMap<String, String>, params: &HeadlinesQuery) {
         query.insert("lang".to_string(), params.market.lang_code.clone());
         query.insert("countries".to_string(), params.market.country_code.clone());
         query.insert(

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -140,7 +140,9 @@ mod tests {
     use crate::newscatcher::Topic;
     use wiremock::{
         matchers::{header, method, path, query_param},
-        Mock, MockServer, ResponseTemplate,
+        Mock,
+        MockServer,
+        ResponseTemplate,
     };
 
     #[tokio::test]

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -74,7 +74,7 @@ impl Client {
         let c = reqwest::Client::new();
         let response = c
             .get(format!("{}/_sn", self.url))
-            .header("Authorization", format!("Bearer {}", &self.token))
+            .bearer_auth(&self.token)
             .query(&query)
             .send()
             .await
@@ -105,7 +105,7 @@ impl Client {
         let c = reqwest::Client::new();
         let response = c
             .get(format!("{}/_lh", self.url))
-            .header("Authorization", format!("Bearer {}", &self.token))
+            .bearer_auth(&self.token)
             .query(&query)
             .send()
             .await

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -14,7 +14,7 @@
 
 //! Client to get new documents.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use displaydoc::Display as DisplayDoc;
 use thiserror::Error;
@@ -60,6 +60,8 @@ pub struct HeadlinesQuery {
 }
 
 impl Client {
+    const TIMEOUT: Duration = Duration::from_secs(15);
+
     /// Create a client.
     pub fn new(token: String, url: String) -> Self {
         Self { token, url }
@@ -74,6 +76,7 @@ impl Client {
         let c = reqwest::Client::new();
         let response = c
             .get(format!("{}/_sn", self.url))
+            .timeout(Self::TIMEOUT)
             .bearer_auth(&self.token)
             .query(&query)
             .send()
@@ -105,6 +108,7 @@ impl Client {
         let c = reqwest::Client::new();
         let response = c
             .get(format!("{}/_lh", self.url))
+            .timeout(Self::TIMEOUT)
             .bearer_auth(&self.token)
             .query(&query)
             .send()
@@ -136,9 +140,7 @@ mod tests {
     use crate::newscatcher::Topic;
     use wiremock::{
         matchers::{header, method, path, query_param},
-        Mock,
-        MockServer,
-        ResponseTemplate,
+        Mock, MockServer, ResponseTemplate,
     };
 
     #[tokio::test]


### PR DESCRIPTION
Do not do a query if there no keywords.
Use BTreeMap instead of HashMap to always have the same order of the parameters and be more cache friendly.
Use `bearer_token` instead of setting it manually.
Set timeout for requests.