### PR TITLE
[Merged by Bors] - TY-2497 - Fix errors when deserializing articles with null fields

### DIFF
--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -45,57 +45,106 @@ pub enum Topic {
 #[derive(Clone, Deserialize, Debug)]
 pub struct Article {
     /// Newscatcher API's unique identifier for each news article.
-    #[serde(rename(deserialize = "_id"))]
+    #[serde(
+        rename(deserialize = "_id"),
+        deserialize_with = "deserialize_null_default"
+    )]
     pub id: String,
 
     /// The title of the article.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub title: String,
 
     /// How well the article is matching your search criteria.
-    #[serde(rename(deserialize = "_score"))]
+    #[serde(
+        rename(deserialize = "_score"),
+        deserialize_with = "deserialize_null_default"
+    )]
     pub score: Option<f32>,
 
     /// The page rank of the source website.
+    #[serde(deserialize_with = "deserialize_rank")]
     pub rank: usize,
 
     /// The domain of the article's source, e.g. `xayn.com`. Not a valid URL.
-    #[serde(rename(deserialize = "clean_url"))]
+    #[serde(
+        rename(deserialize = "clean_url"),
+        deserialize_with = "deserialize_null_default"
+    )]
     pub source_domain: String,
 
     /// Short summary of the article provided by the publisher.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub excerpt: String,
 
     /// Full URL where the article was originally published.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub link: String,
 
     /// A link to a thumbnail image of the article.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub media: String,
 
     /// The main topic of the news publisher.
     /// Important: This parameter is not deducted on a per-article level:
     /// it is deducted on the per-publisher level.
+    #[serde(deserialize_with = "deserialize_topic")]
     pub topic: Topic,
 
     /// The country of the publisher.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub country: String,
 
     /// The language of the article.
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub language: String,
 
     /// While Newscatcher claims to have some sort of timezone support in their
     /// [API][<https://docs.newscatcherapi.com/api-docs/endpoints/search-news>] (via the
     /// `published_date_precision` attribute), in practice they do not seem to be supplying any
     /// sort of timezone information. As a result, we provide NaiveDateTime for now.
-    #[serde(deserialize_with = "naive_date_time_from_str")]
+    #[serde(deserialize_with = "deserialize_naive_date_time_from_str")]
     pub published_date: NaiveDateTime,
 }
 
-fn naive_date_time_from_str<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
+// Taken from https://github.com/serde-rs/serde/issues/1098#issuecomment-760711617
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
+/// Null-value tolerant deserialization of `NaiveDateTime`
+fn deserialize_naive_date_time_from_str<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
-    NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").map_err(de::Error::custom)
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    opt.map_or_else(
+        || Ok(NaiveDateTime::from_timestamp(0, 0)),
+        |s| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").map_err(de::Error::custom),
+    )
+}
+
+/// Null-value tolerant deserialization of rank
+fn deserialize_rank<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or(usize::MAX))
+}
+
+/// Null-value tolerant deserialization of topic
+fn deserialize_topic<'de, D>(deserializer: D) -> Result<Topic, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or(Topic::News))
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
[TY-2497]

We discovered that, contrary to their documentation, Newscatcher responses
sometimes contain articles which are missing non-optional fields, causing
our deserializing to fail. As a remedy, we're introducing defaults for all
fields which may potentially exhibit this behaviour. In a follow-up, we may
need to introduce additional filtering to discard deserialized articles which
are missing crucial information (such as the excerpt).

[TY-2497]: https://xainag.atlassian.net/browse/TY-2497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ