### PR TITLE
[Merged by Bors] - TY-2492 Write tool to fetch lots of articles to verify our deserialization logic works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 
 cargo-installs/
+headlines_download/

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1168,6 +1168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1434,29 @@ name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "paste"
@@ -2022,6 +2054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7868ad3b8196a8a0aea99a8220b124278ee5320a55e4fde97794b6f85b1a377"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2122,15 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -2280,7 +2330,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -2329,6 +2382,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tooling"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "xayn-discovery-engine-providers",
 ]
 
 [[package]]
@@ -2829,6 +2893,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3088,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "thiserror",
  "tokio",
  "url",

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "bindings",
     "core",
     "providers",
+    "tooling",
 ]
 resolver = "2"
 

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -64,6 +64,7 @@ impl Ops for BreakingNews {
                 let query = HeadlinesQuery {
                     market,
                     page_size: self.page_size,
+                    page: 1,
                 };
                 match self.client.headlines(&query).await {
                     Ok(batch) => articles.extend(batch),

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -15,6 +15,7 @@ maplit = "1.0.2"
 reqwest = { version = "0.11.9", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+serde_path_to_error = "0.1.7"
 thiserror = "1.0.30"
 url = "2.2.2"
 

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -33,4 +33,4 @@ mod newscatcher;
 
 pub use client::{Client, HeadlinesQuery, NewsQuery};
 pub use filter::{Filter, Market};
-pub use newscatcher::{Article, Topic};
+pub use newscatcher::{Article, Response, Topic};

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -42,7 +42,7 @@ pub enum Topic {
 }
 
 /// A news article
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Article {
     /// Newscatcher API's unique identifier for each news article.
     #[serde(
@@ -147,8 +147,13 @@ where
     Ok(opt.unwrap_or(Topic::News))
 }
 
+/// Query response from the Newscatcher API
 #[derive(Deserialize, Debug)]
-pub(crate) struct Response {
-    pub(crate) status: String,
-    pub(crate) articles: Vec<Article>,
+pub struct Response {
+    /// Status message
+    pub status: String,
+    /// Main response content
+    pub articles: Vec<Article>,
+    /// Total pages of content available
+    pub total_pages: usize,
 }

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tooling"
+version = "0.1.0"
+edition = "2018"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "newscatcher"
+path = "bin/newscatcher.rs"
+
+[dependencies]
+anyhow = "1.0.55"
+serde_json = "1.0.79"
+serde_path_to_error = "0.1"
+tokio = { version = "1.17.0", features = ["full"] }
+xayn-discovery-engine-providers = { path = "../providers" }

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -1,0 +1,61 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anyhow::{Context, Result};
+use xayn_discovery_engine_providers::{Client, HeadlinesQuery, Market};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let url = "https://api-gw.xaynet.dev".to_string();
+    let token = std::env::var("NEWSCATCHER_DEV_BEARER_AUTH_TOKEN").context(
+        "Please provide the NEWSCATCHER_DEV_BEARER_AUTH_TOKEN environment variable for the dev environment. \
+                  The token can be found in 1Password",
+    )?;
+
+    tokio::fs::create_dir("./headlines_download")
+        .await
+        .context("Failed to create download directory. Does it already exist?")?;
+
+    let client = Client::new(token, url);
+    let market = Market {
+        lang_code: "en".to_string(),
+        country_code: "US".to_string(),
+    };
+
+    // This is updated every iteration, based on the response from Newscatcher. So in reality,
+    // we'll be fetching more than one page.
+    let mut total_pages = 1;
+    let mut page = 1;
+    while page <= total_pages {
+        println!("Fetching page {} of {}", page, total_pages);
+        let params = HeadlinesQuery {
+            market: &market,
+            page_size: 100,
+            page,
+        };
+        let raw_response = client.headlines_query(&params).await.unwrap();
+        total_pages = raw_response.total_pages;
+
+        let content = serde_json::to_string_pretty(&raw_response.articles)?;
+        tokio::fs::write(
+            format!("./headlines_download/page_{:03}.json", page),
+            content,
+        )
+        .await?;
+
+        page += 1;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
[TY-2492] 

The addition of `serde_path_to_error` seems worthwile, as it significantly improves the error messages in case something goes wrong when deserializing. With this change we'll get something like:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:
DecodingAtPath("articles[93].excerpt", Error { path: Path { segments: [Map { key: "articles" },
Seq { index: 93 }, Map { key: "excerpt" }] }, original: Error("invalid type: null, expected a string",
line: 1, column: 64906) })', tooling/src/newscatcher.rs:45:66
```

Indicating the place where the error occurred (`articles[93].excerpt` in this case).

[TY-2492]: https://xainag.atlassian.net/browse/TY-2492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ