### PR TITLE
[Merged by Bors] - TY-2433 Extended the `Document` model for active search

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -80,7 +80,7 @@ class DocumentManager {
       throw StateError('id $id does not have active data attached');
     }
 
-    await _documentRepo.update(doc..registerReaction(userReaction));
+    await _documentRepo.update(doc..userReaction = userReaction);
     await _engine.userReacted(
       UserReacted(
         id: id,

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -74,25 +74,23 @@ class DocumentManager {
     if (doc == null || !doc.isActive) {
       throw ArgumentError('id $id does not identify an active document');
     }
-    await _documentRepo.update(doc..userReaction = userReaction);
+
     final smbertEmbedding = await _activeRepo.smbertEmbeddingById(id);
     if (smbertEmbedding == null) {
       throw StateError('id $id does not have active data attached');
     }
-    final snippet = doc.resource.snippet.isNotEmpty
-        ? doc.resource.snippet
-        : doc.resource.title;
+
+    await _documentRepo.update(doc..registerReaction(userReaction));
     await _engine.userReacted(
       UserReacted(
         id: id,
         stackId: doc.stackId,
-        snippet: snippet,
+        snippet: doc.snippet,
         smbertEmbedding: smbertEmbedding,
         reaction: userReaction,
       ),
     );
     await _engineStateRepo.save(await _engine.serialize());
-
     _changedDocsReporter.notifyChanged([doc]);
   }
 
@@ -107,10 +105,12 @@ class DocumentManager {
     if (sec < 0) {
       throw RangeError.range(sec, 0, null);
     }
+
     final activeData = await _activeRepo.fetchById(id);
     if (activeData == null) {
       throw ArgumentError('id $id does not identify an active document');
     }
+
     final doc = await _documentRepo.fetchById(id);
     if (doc == null || !doc.isActive) {
       throw ArgumentError('id $id does not identify an active document');
@@ -119,16 +119,13 @@ class DocumentManager {
     activeData.addViewTime(mode, Duration(seconds: sec));
     await _activeRepo.update(id, activeData);
 
-    // As we don't have a `DocumentViewMode` on the Rust side at the moment,
-    // we need to decide which value to use or to aggregate all view modes.
-    final sumDuration = activeData.viewTime.values
-        .reduce((aggregate, duration) => aggregate + duration);
-
     await _engine.timeSpent(
       TimeSpent(
         id: id,
         smbertEmbedding: activeData.smbertEmbedding,
-        time: sumDuration,
+        // As we don't have a `DocumentViewMode` on the Rust side at the moment,
+        // we are aggregating Duration from all view modes.
+        time: activeData.sumDuration,
         reaction: doc.userReaction,
       ),
     );

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -27,7 +27,7 @@ import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
-    show StackId;
+    show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 
@@ -58,11 +58,13 @@ class MockEngine implements Engine {
     final stackId = StackId();
 
     doc0 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 0,
       resource: resource,
     );
     doc1 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 1,
       resource: resource,

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -80,11 +80,6 @@ class FeedManager {
             });
 
           final feed = sortedActives.map((doc) => doc.toApiDocument()).toList();
-
-          if (feed.isEmpty) {
-            const reason = FeedFailureReason.noNewsForMarket;
-            return const EngineEvent.feedRequestFailed(reason);
-          }
           return EngineEvent.feedRequestSucceeded(feed);
         },
       );

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -15,7 +15,7 @@
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show FeedClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
-    show EngineEvent;
+    show EngineEvent, FeedFailureReason;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
@@ -65,7 +65,13 @@ class FeedManager {
   Future<EngineEvent> restoreFeed() => _docRepo.fetchAll().then(
         (docs) {
           final sortedActives = docs
-            ..retainWhere((doc) => doc.isActive)
+            ..retainWhere(
+              (doc) =>
+                  // we only want active documents
+                  doc.isActive &&
+                  // we only want feed documents (isSearched == false)
+                  doc.isSearched == false,
+            )
             ..sort((doc1, doc2) {
               final timeOrd = doc1.timestamp.compareTo(doc2.timestamp);
               return timeOrd == 0
@@ -74,6 +80,11 @@ class FeedManager {
             });
 
           final feed = sortedActives.map((doc) => doc.toApiDocument()).toList();
+
+          if (feed.isEmpty) {
+            const reason = FeedFailureReason.noNewsForMarket;
+            return const EngineEvent.feedRequestFailed(reason);
+          }
           return EngineEvent.feedRequestSucceeded(feed);
         },
       );
@@ -89,10 +100,15 @@ class FeedManager {
       await _activeRepo.update(id, docWithData.data);
     }
 
-    final docs = feedDocs
+    final feed = feedDocs
         .map((docWithData) => docWithData.document.toApiDocument())
         .toList();
-    return EngineEvent.nextFeedBatchRequestSucceeded(docs);
+
+    if (feed.isEmpty) {
+      const reason = FeedFailureReason.noNewsForMarket;
+      return const EngineEvent.nextFeedBatchRequestFailed(reason);
+    }
+    return EngineEvent.nextFeedBatchRequestSucceeded(feed);
   }
 
   /// Deactivate the given documents.

--- a/discovery_engine/lib/src/domain/models/active_data.dart
+++ b/discovery_engine/lib/src/domain/models/active_data.dart
@@ -45,6 +45,10 @@ class ActiveDocumentData with EquatableMixin {
 
   ActiveDocumentData(this.smbertEmbedding) : viewTime = {};
 
+  /// Returns sum of [Duration] from all the registered [DocumentViewMode] times.
+  Duration get sumDuration =>
+      viewTime.values.reduce((aggregate, duration) => aggregate + duration);
+
   /// Add a time interval to the running total for the given view mode.
   void addViewTime(DocumentViewMode mode, Duration time) {
     viewTime.update(mode, (total) => total + time, ifAbsent: () => time);

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -47,19 +47,32 @@ class Document {
   @HiveField(6)
   DateTime timestamp;
 
+  /// Indicates if this [Document] was returned in response to active search.
+  @HiveField(7)
+  bool isSearched;
+
   bool get isRelevant => userReaction == UserReaction.positive;
   bool get isNotRelevant => userReaction == UserReaction.negative;
   bool get isNeutral => userReaction == UserReaction.neutral;
+
+  /// Returns [NewsResource] snippet, or title if snippet is an empty String.
+  String get snippet =>
+      resource.snippet.isNotEmpty ? resource.snippet : resource.title;
 
   Document({
     required this.stackId,
     required this.resource,
     required this.batchIndex,
-    DocumentId? documentId,
+    required this.documentId,
     this.userReaction = UserReaction.neutral,
     this.isActive = true,
-  })  : documentId = documentId ?? DocumentId(),
-        timestamp = DateTime.now().toUtc();
+    this.isSearched = false,
+  }) : timestamp = DateTime.now().toUtc();
+
+  /// Register a [UserReaction]
+  void registerReaction(UserReaction reaction) {
+    userReaction = reaction;
+  }
 
   api.Document toApiDocument() => api.Document(
         documentId: documentId,

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -69,11 +69,6 @@ class Document {
     this.isSearched = false,
   }) : timestamp = DateTime.now().toUtc();
 
-  /// Register a [UserReaction]
-  void registerReaction(UserReaction reaction) {
-    userReaction = reaction;
-  }
-
   api.Document toApiDocument() => api.Document(
         documentId: documentId,
         resource: resource,

--- a/discovery_engine/lib/src/domain/repository/document_repo.dart
+++ b/discovery_engine/lib/src/domain/repository/document_repo.dart
@@ -38,4 +38,7 @@ abstract class DocumentRepository {
   /// If [docs] contains multiple documents with the same id, the last
   /// occurrence with that id will overwrite previous occurrences.
   Future<void> updateMany(Iterable<Document> docs);
+
+  /// Remove documents by ids from the repository.
+  Future<void> removeByIds(Set<DocumentId> ids);
 }

--- a/discovery_engine/lib/src/infrastructure/repository/hive_document_repo.dart
+++ b/discovery_engine/lib/src/infrastructure/repository/hive_document_repo.dart
@@ -46,4 +46,10 @@ class HiveDocumentRepository implements DocumentRepository {
       box.putAll(<String, Document>{
         for (final doc in docs) doc.documentId.toString(): doc
       });
+
+  @override
+  Future<void> removeByIds(Set<DocumentId> ids) {
+    // TODO: implement removeByIds
+    throw UnimplementedError();
+  }
 }

--- a/discovery_engine/lib/src/infrastructure/repository/hive_document_repo.dart
+++ b/discovery_engine/lib/src/infrastructure/repository/hive_document_repo.dart
@@ -48,8 +48,8 @@ class HiveDocumentRepository implements DocumentRepository {
       });
 
   @override
-  Future<void> removeByIds(Set<DocumentId> ids) {
-    // TODO: implement removeByIds
-    throw UnimplementedError();
+  Future<void> removeByIds(Set<DocumentId> ids) async {
+    final keys = ids.map((id) => id.toString());
+    await box.deleteAll(keys);
   }
 }

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -76,12 +76,14 @@ Future<void> main() async {
     final data = ActiveDocumentData(Embedding.fromList([4, 1]));
     final stackId = StackId();
     final doc1 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 0,
       resource: mockNewsResource,
       isActive: true,
     );
     final doc2 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 1,
       resource: mockNewsResource,

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -89,12 +89,14 @@ Future<void> main() async {
       data = ActiveDocumentData(Embedding.fromList([44]));
       final stackId = StackId();
       doc2 = Document(
+        documentId: DocumentId(),
         stackId: stackId,
         batchIndex: 2,
         resource: mockNewsResource,
         isActive: true,
       );
       doc3 = Document(
+        documentId: DocumentId(),
         stackId: stackId,
         batchIndex: 3,
         resource: mockNewsResource,

--- a/discovery_engine/test/repository/hive_document_repo_test.dart
+++ b/discovery_engine/test/repository/hive_document_repo_test.dart
@@ -148,6 +148,22 @@ Future<void> main() async {
         expect(box, hasLength(2));
         expect(box.values, containsAll(<Document>[doc1, doc2]));
       });
+
+      test('remove documents by ids, keep rest', () async {
+        final doc3 = Document(
+          documentId: DocumentId(),
+          stackId: stackId,
+          batchIndex: 2,
+          resource: mockNewsResource,
+        );
+
+        await repo.updateMany([doc1, doc2, doc3]);
+        expect(box, hasLength(3));
+
+        await repo.removeByIds({doc1.documentId, doc3.documentId});
+        expect(box, hasLength(1));
+        expect(box.values, containsAll(<Document>[doc2]));
+      });
     });
   });
 }

--- a/discovery_engine/test/repository/hive_document_repo_test.dart
+++ b/discovery_engine/test/repository/hive_document_repo_test.dart
@@ -19,7 +19,7 @@ import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document, UserReaction;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
-    show StackId;
+    show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
     show documentBox;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_document_repo.dart'
@@ -36,11 +36,13 @@ Future<void> main() async {
     late HiveDocumentRepository repo;
     final stackId = StackId();
     final doc1 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 0,
       resource: mockNewsResource,
     );
     final doc2 = Document(
+      documentId: DocumentId(),
       stackId: stackId,
       batchIndex: 1,
       resource: mockNewsResource,


### PR DESCRIPTION
[Prepare repo for searched `Documents`](https://xainag.atlassian.net/browse/TY-2433)
[Adapt feed manager](https://xainag.atlassian.net/browse/TY-2442)

This PR adds a new attribute to the `Document` model to differentiate between documents that belong to a feed, and those which belong to active search.

- In feed manager we filter out the documents that belong to an active search
- `removeByIds` method was added to `DocumentRepository` to prepare for removing unneeded documents from the repo when a search is closed
- some smaller changes were made to the document manager, to clean it up a bit