### PR TITLE
[Merged by Bors] - TY-2486 non optional page size

### DIFF
--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -56,7 +56,7 @@ impl Ops for BreakingNews {
             let mut articles = Vec::new();
             let mut errors = Vec::new();
 
-            for market in markets.read().await.clone() {
+            for market in markets.read().await.iter() {
                 let query = HeadlinesQuery {
                     market,
                     page_size: self.page_size,

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -36,7 +36,7 @@ use super::Ops;
 pub(crate) struct BreakingNews {
     client: Client,
     markets: Option<Arc<RwLock<Vec<Market>>>>,
-    page_size: Option<usize>,
+    page_size: usize,
 }
 
 #[async_trait]
@@ -48,17 +48,19 @@ impl Ops for BreakingNews {
     fn configure(&mut self, config: &EndpointConfig) {
         self.client = Client::new(config.api_key.clone(), config.api_base_url.clone());
         self.markets.replace(Arc::clone(&config.markets));
-        self.page_size.replace(config.page_size);
+        self.page_size = config.page_size;
     }
 
     async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
         if let Some(markets) = self.markets.as_ref() {
             let mut articles = Vec::new();
             let mut errors = Vec::new();
-            let page_size = self.page_size;
 
             for market in markets.read().await.clone() {
-                let query = HeadlinesQuery { market, page_size };
+                let query = HeadlinesQuery {
+                    market,
+                    page_size: self.page_size,
+                };
                 match self.client.headlines(&query).await {
                     Ok(batch) => articles.extend(batch),
                     Err(err) => errors.push(err),

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -36,7 +36,7 @@ use super::Ops;
 pub(crate) struct PersonalizedNews {
     client: Client,
     markets: Option<Arc<RwLock<Vec<Market>>>>,
-    page_size: Option<usize>,
+    page_size: usize,
 }
 
 #[async_trait]
@@ -48,7 +48,7 @@ impl Ops for PersonalizedNews {
     fn configure(&mut self, config: &EndpointConfig) {
         self.client = Client::new(config.api_key.clone(), config.api_base_url.clone());
         self.markets.replace(Arc::clone(&config.markets));
-        self.page_size.replace(config.page_size);
+        self.page_size = config.page_size;
     }
 
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -58,14 +58,14 @@ impl Ops for PersonalizedNews {
         if let Some(markets) = self.markets.as_ref() {
             let mut articles = Vec::new();
             let mut errors = Vec::new();
-            let filter = key_phrases.iter().fold(Filter::default(), |filter, kp| {
+            let filter = &key_phrases.iter().fold(Filter::default(), |filter, kp| {
                 filter.add_keyword(kp.words())
             });
 
-            for market in markets.read().await.clone() {
+            for market in markets.read().await.iter() {
                 let query = NewsQuery {
                     market,
-                    filter: filter.clone(),
+                    filter,
                     page_size: self.page_size,
                     page: None,
                 };

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -42,11 +42,11 @@ pub struct Client {
 }
 
 /// Parameters determining which news to fetch
-pub struct NewsQuery {
+pub struct NewsQuery<'a> {
     /// Market of news.
-    pub market: Market,
+    pub market: &'a Market,
     /// News filter.
-    pub filter: Filter,
+    pub filter: &'a Filter,
     /// How many articles to return (per page).
     pub page_size: usize,
     /// Page number.
@@ -54,9 +54,9 @@ pub struct NewsQuery {
 }
 
 /// Parameters determining which headlines to fetch
-pub struct HeadlinesQuery {
+pub struct HeadlinesQuery<'a> {
     /// Market of headlines.
-    pub market: Market,
+    pub market: &'a Market,
     /// How many articles to return (per page).
     pub page_size: usize,
 }
@@ -70,7 +70,7 @@ impl Client {
     }
 
     /// Retrieve news from the remote API
-    pub async fn news(&self, params: &NewsQuery) -> Result<Vec<Article>, Error> {
+    pub async fn news(&self, params: &NewsQuery<'_>) -> Result<Vec<Article>, Error> {
         let mut query: BTreeMap<String, String> = BTreeMap::new();
         query.insert("sort_by".into(), "relevancy".into());
         Self::build_news_query(&mut query, params);
@@ -92,9 +92,12 @@ impl Client {
         Ok(result)
     }
 
-    fn build_news_query(query: &mut BTreeMap<String, String>, params: &NewsQuery) {
-        query.insert("lang".to_string(), params.market.lang_code.clone());
-        query.insert("countries".to_string(), params.market.country_code.clone());
+    fn build_news_query(query: &mut BTreeMap<String, String>, params: &NewsQuery<'_>) {
+        query.insert("lang".to_string(), params.market.lang_code.to_string());
+        query.insert(
+            "countries".to_string(),
+            params.market.country_code.to_string(),
+        );
         query.insert("page_size".to_string(), params.page_size.to_string());
         query.insert("q".to_string(), params.filter.build());
         if let Some(page) = params.page {
@@ -103,7 +106,7 @@ impl Client {
     }
 
     /// Retrieve headlines from the remote API
-    pub async fn headlines(&self, params: &HeadlinesQuery) -> Result<Vec<Article>, Error> {
+    pub async fn headlines(&self, params: &HeadlinesQuery<'_>) -> Result<Vec<Article>, Error> {
         let mut query: BTreeMap<String, String> = BTreeMap::new();
         Self::build_headlines_query(&mut query, params);
 
@@ -124,9 +127,12 @@ impl Client {
         Ok(result)
     }
 
-    fn build_headlines_query(query: &mut BTreeMap<String, String>, params: &HeadlinesQuery) {
-        query.insert("lang".to_string(), params.market.lang_code.clone());
-        query.insert("countries".to_string(), params.market.country_code.clone());
+    fn build_headlines_query(query: &mut BTreeMap<String, String>, params: &HeadlinesQuery<'_>) {
+        query.insert("lang".to_string(), params.market.lang_code.to_string());
+        query.insert(
+            "countries".to_string(),
+            params.market.country_code.to_string(),
+        );
         query.insert("page_size".to_string(), params.page_size.to_string());
     }
 }
@@ -169,13 +175,14 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let filter = Filter::default().add_keyword("Climate change");
+        let market = &Market {
+            lang_code: "en".to_string(),
+            country_code: "AU".to_string(),
+        };
+        let filter = &Filter::default().add_keyword("Climate change");
 
         let params = NewsQuery {
-            market: Market {
-                lang_code: "en".to_string(),
-                country_code: "AU".to_string(),
-            },
+            market,
             filter,
             page_size: 2,
             page: Some(1),
@@ -213,15 +220,16 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let filter = Filter::default()
+        let market = &Market {
+            lang_code: "de".to_string(),
+            country_code: "DE".to_string(),
+        };
+        let filter = &Filter::default()
             .add_keyword("Bill Gates")
             .add_keyword("Tim Cook");
 
         let params = NewsQuery {
-            market: Market {
-                lang_code: "de".to_string(),
-                country_code: "DE".to_string(),
-            },
+            market,
             filter,
             page_size: 2,
             page: None,
@@ -260,7 +268,7 @@ mod tests {
             .await;
 
         let params = HeadlinesQuery {
-            market: Market {
+            market: &Market {
                 lang_code: "en".to_string(),
                 country_code: "US".to_string(),
             },

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -48,7 +48,7 @@ pub struct NewsQuery {
     /// News filter.
     pub filter: Filter,
     /// How many articles to return (per page).
-    pub page_size: Option<usize>,
+    pub page_size: usize,
     /// Page number.
     pub page: Option<usize>,
 }
@@ -58,7 +58,7 @@ pub struct HeadlinesQuery {
     /// Market of headlines.
     pub market: Market,
     /// How many articles to return (per page).
-    pub page_size: Option<usize>,
+    pub page_size: usize,
 }
 
 impl Client {
@@ -95,10 +95,7 @@ impl Client {
     fn build_news_query(query: &mut BTreeMap<String, String>, params: &NewsQuery) {
         query.insert("lang".to_string(), params.market.lang_code.clone());
         query.insert("countries".to_string(), params.market.country_code.clone());
-        query.insert(
-            "page_size".to_string(),
-            params.page_size.unwrap_or(100).to_string(),
-        );
+        query.insert("page_size".to_string(), params.page_size.to_string());
         query.insert("q".to_string(), params.filter.build());
         if let Some(page) = params.page {
             query.insert("page".to_string(), page.to_string());
@@ -130,10 +127,7 @@ impl Client {
     fn build_headlines_query(query: &mut BTreeMap<String, String>, params: &HeadlinesQuery) {
         query.insert("lang".to_string(), params.market.lang_code.clone());
         query.insert("countries".to_string(), params.market.country_code.clone());
-        query.insert(
-            "page_size".to_string(),
-            params.page_size.unwrap_or(100).to_string(),
-        );
+        query.insert("page_size".to_string(), params.page_size.to_string());
     }
 }
 
@@ -183,7 +177,7 @@ mod tests {
                 country_code: "AU".to_string(),
             },
             filter,
-            page_size: Some(2),
+            page_size: 2,
             page: Some(1),
         };
 
@@ -229,7 +223,7 @@ mod tests {
                 country_code: "DE".to_string(),
             },
             filter,
-            page_size: Some(2),
+            page_size: 2,
             page: None,
         };
 
@@ -270,7 +264,7 @@ mod tests {
                 lang_code: "en".to_string(),
                 country_code: "US".to_string(),
             },
-            page_size: Some(2),
+            page_size: 2,
         };
 
         let docs = client.headlines(&params).await.unwrap();


### PR DESCRIPTION
**References**

- [TY-2486]

**Summary**

- make page size non optional in the queries
- don't clone markets and filters more than once while building a query


[TY-2486]: https://xainag.atlassian.net/browse/TY-2486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ