### PR TITLE
Investigate what is needed to make discovery engine more robust to errors

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -90,6 +90,9 @@ class DocumentManager {
         reaction: userReaction,
       ),
     );
+    //TODO do we want to try to save the engine state even if userReacted failes
+    //TODO If we can't save the engine state we might want to log report error,
+    //     but we still can continue with `notifyChanged()`
     await _engineStateRepo.save(await _engine.serialize());
     _changedDocsReporter.notifyChanged([doc]);
   }
@@ -100,6 +103,7 @@ class DocumentManager {
   Future<void> addActiveDocumentTime(
     DocumentId id,
     DocumentViewMode mode,
+    //TODO this should be `Duration time`
     int sec,
   ) async {
     if (sec < 0) {
@@ -130,6 +134,7 @@ class DocumentManager {
       ),
     );
 
+    //TODO do we want to try to save the engine state even if timeSpent failes
     await _engineStateRepo.save(await _engine.serialize());
   }
 }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -88,6 +88,8 @@ class FeedManager {
   Future<EngineEvent> nextFeedBatch() async {
     final history = await _docRepo.fetchHistory();
     final feedDocs = await _engine.getFeedDocuments(history, _maxDocs);
+    // TODO do not fail if save fails (?)
+    // TODO even save if getFeedDocuments fails (?)
     await _engineStateRepo.save(await _engine.serialize());
 
     await _docRepo.updateMany(feedDocs.map((e) => e.document));

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -42,6 +42,8 @@ use xayn_discovery_engine_core::Engine;
 )]
 impl XaynDiscoveryEngineAsyncFfi {
     /// Initializes the engine.
+    //TODO do we retry on failure, can we differentiate temporary and permanent failure?
+    //      do we even have temporary failure?
     #[allow(clippy::box_vec)]
     pub async fn initialize(
         config: Box<InitConfig>,

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -143,6 +143,7 @@ impl TryFrom<Article> for NewsResource {
             date_published: article.published_date,
             url: Url::parse(&article.link)?,
             source_domain: article.source_domain,
+            // TODO if ut's not an url, we can just skip it (default to None)
             image: (!media.is_empty())
                 .then(|| Url::parse(&media))
                 .transpose()?,

--- a/discovery_engine_core/core/src/mab.rs
+++ b/discovery_engine_core/core/src/mab.rs
@@ -38,6 +38,8 @@ pub(crate) trait BetaSample {
 pub(crate) struct BetaSampler;
 
 impl BetaSample for BetaSampler {
+    // TODO we could consider making this non fallible by clamping alpha and beta,
+    //      (and probably log an error)
     fn sample(&self, alpha: f32, beta: f32) -> Result<f32, Error> {
         Ok(Beta::new(alpha, beta)?.sample(&mut rand::thread_rng()))
     }

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -28,6 +28,7 @@ use crate::{
 /// Provides a method for ranking a slice of [`Document`] items.
 pub trait Ranker {
     /// Performs the ranking of [`Document`] items.
+    //TODO check exactly how/when ranking fails.
     fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError>;
 
     /// Logs the time a user spent on a document.
@@ -43,14 +44,22 @@ pub trait Ranker {
     fn serialize(&self) -> Result<Vec<u8>, GenericError>;
 
     /// Computes the S-mBert embedding of the given `sequence`.
+    //TODO check exactly how/when ranking fails.
     fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError>;
 }
 
 impl Ranker for xayn_ai::ranker::Ranker {
+    // TODO the ranking implementation we currently use can't fail as it will
+    //      fallback to sort by score on error. We could make `Ranker.rank` non
+    //      erroring for now, if we combine it with a few similar changes we can
+    //      remove most error cases in `update_stack`, especially if we indicate
+    //      but not return an error if fetching new documents fails, in which case
+    //      we could make it error less.
     fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError> {
         self.rank(items).map_err(Into::into)
     }
 
+    // TODO this can't fail, it should not return a result
     fn log_document_view_time(&mut self, time_spent: &TimeSpent) -> Result<(), GenericError> {
         self.log_document_view_time(
             time_spent.reaction.into(),
@@ -60,6 +69,7 @@ impl Ranker for xayn_ai::ranker::Ranker {
         Ok(())
     }
 
+    // TODO this can't fail, it should not return a result
     fn log_user_reaction(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
         self.log_user_reaction(
             reaction.reaction.into(),

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -88,6 +88,7 @@ pub(crate) struct Stack {
 impl Stack {
     /// Create a new `Stack` with the given [`Data`] and customized [`Ops`].
     pub(crate) fn new(data: Data, ops: BoxedOps) -> Result<Self, Error> {
+        // TODO we could just indicate errors and filter
         Self::validate_documents_stack_id(&data.documents, ops.id())?;
 
         Ok(Self { data, ops })
@@ -104,6 +105,7 @@ impl Stack {
         new_documents: &[Document],
         ranker: &mut impl Ranker,
     ) -> Result<(), Error> {
+        // TODO we could just indicate errors and filter
         Self::validate_documents_stack_id(new_documents, self.ops.id())?;
 
         let mut items = self

--- a/discovery_engine_core/core/src/stack/data.rs
+++ b/discovery_engine_core/core/src/stack/data.rs
@@ -43,7 +43,12 @@ pub(crate) struct Data {
 }
 
 impl Data {
-    #[allow(dead_code)]
+    // TODO this is only used by tests, and many tests which use it test itself;
+    //      Also outside of tests the only place where we do create new `Data` always
+    //      uses default values. We also don't enforce this constraints when modifying
+    //      `alpha`, `beta` (currently we only add `1` so ok). Maybe remove `new`, add a
+    //      `modify_alpha/beta` function which clamps the values to `>0.0`??
+    #[cfg(test)]
     /// Create a `Data`.
     pub(crate) fn new(alpha: f32, beta: f32, documents: Vec<Document>) -> Result<Self, Error> {
         if alpha <= 0.0 {

--- a/discovery_engine_core/core/src/stack/filters.rs
+++ b/discovery_engine_core/core/src/stack/filters.rs
@@ -18,6 +18,7 @@ use url::Url;
 use xayn_discovery_engine_providers::Article;
 
 pub(crate) trait ArticleFilter {
+    //TODO like mentioned on StackOps we seem to have no use for making this fallible.
     fn apply(current: &[Document], articles: Vec<Article>) -> Result<Vec<Article>, GenericError>;
 }
 

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -51,6 +51,9 @@ pub trait Ops {
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError>;
 
     /// Filter `articles` based on `stack` documents.
+    // TODO as far as I can tell there is no reason for filter to be fallible
+    //      even if future implementations are, we probably want to just log/indicate
+    //      it as a side effect and continue on.
     fn filter_articles(
         &self,
         history: &[HistoricDocument],
@@ -59,6 +62,9 @@ pub trait Ops {
     ) -> Result<Vec<Article>, GenericError>;
 
     /// Merge stacked and new items.
+    // TODO as far as I can tell there is no reason for merge to be fallible
+    //      even if future implementations are, we probably want to just log/indicate
+    //      it as a side effect and continue on.
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;
 }
 

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -32,6 +32,8 @@ use crate::{
 use super::Ops;
 
 /// Stack operations customized for breaking news items.
+//TODO configure on creation, only have `.configure` for reconfiguring, there is no
+//      semantic consistent default implementation as far as I can tell
 #[derive(Default)]
 pub(crate) struct BreakingNews {
     client: Client,
@@ -52,6 +54,7 @@ impl Ops for BreakingNews {
     }
 
     async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
+        // TODO there is a log of code duplication between this and the one in `personalized.rs`.
         if let Some(markets) = self.markets.as_ref() {
             let mut articles = Vec::new();
             let mut errors = Vec::new();
@@ -67,6 +70,7 @@ impl Ops for BreakingNews {
                 }
             }
             if articles.is_empty() && !errors.is_empty() {
+                // TODO we can return all errors, it's at most one per-market
                 Err(errors.pop().unwrap(/* nonempty errors */).into())
             } else {
                 Ok(articles)


### PR DESCRIPTION
This PR commits a number of TODO mostly about how we could make the discovery engine more robust to errors, but also miscellaneous other things I noticed while going through the code.

I noticed that there are 3 kinds of errors:

- fatal ones (like initialization failed)
- expected non-fatal ones (like  network down)
- unexpected maybe-fatal ones (like some broken invariants)

Except for the first category in most other cases we still could "go one" and proceed running the discovery engine.

Sure in some cases we need to notify dart (e.g. so that it can display  that there are network problems to the user, or so that it can log a error/bug message which is somehow transmitted to us).

And sure in some cases it might degrade the usability of the app, but we still can go on.

For example:

- if de-serializing the state fails we can just not do so and pretend there was no state. (and report a bug)
- if serializing the state fails we also can go-on just every time the native context is recreated it forgets everything learned, but otherwise still works
- if some Url in an Article is unreadable we can skip that article, but keep the rest of the stack (or even just set the Url to `None` in some cases)
- for getting the next feed we already have documents before we update the stacks, so even if it fails we could return the current documents.
- if fetching fails we still can return a empty vec, until the stack runs out of documents that would work (and even after it would just be "useless" for the user but not "fail".
- in the sampler we can clamp alpha/beta instead of failing

Additional to that there are a bunch of "impossible" errors, where the used interfaces still return a result, but the error case is unreachable. Like ranking can't fail anymore as it will fallback to sorting by score. 

I believe it could make sense/be valuable to add a side-channel to report bugs, network errors and maybe later some stats and prune most error cases out of most use-cases. Always reporting them appropriately to the side-channel but then "going on" anyway.

I believe we can easily end up with a `update_stacks` not returning a `Result`  as well as less results in FFI.

With out question this is a bit of an unusual approach, especially for rust. But for our application might be the right choice. And by making the side-channel not just a logger we can still test everything properly.
