### PR TITLE
[Merged by Bors] - TY-2509 Get keyphrases only when needed

### DIFF
--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -50,6 +50,9 @@ pub trait Ops {
     /// tailored to the user's interests.
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError>;
 
+    /// Returns if `[new_items]` needs the key phrases to work.
+    fn needs_key_phrases(&self) -> bool;
+
     /// Filter `articles` based on `stack` documents.
     fn filter_articles(
         &self,

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -51,6 +51,10 @@ impl Ops for BreakingNews {
         self.page_size = config.page_size;
     }
 
+    fn needs_key_phrases(&self) -> bool {
+        false
+    }
+
     async fn new_items(&self, _key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
         if let Some(markets) = self.markets.as_ref() {
             let mut articles = Vec::new();

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -51,6 +51,10 @@ impl Ops for PersonalizedNews {
         self.page_size = config.page_size;
     }
 
+    fn needs_key_phrases(&self) -> bool {
+        true
+    }
+
     async fn new_items(&self, key_phrases: &[KeyPhrase]) -> Result<Vec<Article>, GenericError> {
         if key_phrases.is_empty() {
             return Ok(vec![]);


### PR DESCRIPTION
We are consuming key phrases every time the app ask for documents. 
With this PR we only ask for key phrases when a stack that needs key phrases needs to be updated.