### PR TITLE
TY-2499 consistent engine state naming.

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -63,7 +63,7 @@ class EngineInitializer with EquatableMixin {
   final SetupData setupData;
 
   /// The state to restore.
-  final Uint8List? state;
+  final Uint8List? engineState;
 
   /// The history to use for filtering initial results.
   final List<HistoricDocument> history;
@@ -74,11 +74,11 @@ class EngineInitializer with EquatableMixin {
   EngineInitializer({
     required this.config,
     required this.setupData,
-    required this.state,
+    required this.engineState,
     required this.history,
     required this.aiConfig,
   });
 
   @override
-  List<Object?> get props => [config, setupData, state, history];
+  List<Object?> get props => [config, setupData, engineState, history];
 }

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -197,7 +197,7 @@ class EventHandler {
       EngineInitializer(
         config: config,
         setupData: setupData,
-        state: engineState,
+        engineState: engineState,
         history: history,
         aiConfig: aiConfig,
       ),

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -78,7 +78,7 @@ class DiscoveryEngineFfi implements Engine {
         setupData,
         aiConfig: initializer.aiConfig,
       ).allocNative().move(),
-      initializer.state?.allocNative().move() ?? nullptr,
+      initializer.engineState?.allocNative().move() ?? nullptr,
       initializer.history.allocNative().move(),
     );
     final boxedEngine = resultSharedEngineStringFfiAdapter.moveNative(result);

--- a/discovery_engine/test/ffi/ffi_test.dart
+++ b/discovery_engine/test/ffi/ffi_test.dart
@@ -55,7 +55,7 @@ void main() {
         EngineInitializer(
           config: config,
           setupData: setupData,
-          state: null,
+          engineState: null,
           history: [],
           aiConfig: null,
         ),


### PR DESCRIPTION

**References:**

- [TY-2499](https://xainag.atlassian.net/browse/TY-2499)