### PR TITLE
[Merged by Bors] - Add default for 'articles'

### DIFF
--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -153,6 +153,7 @@ pub struct Response {
     /// Status message
     pub status: String,
     /// Main response content
+    #[serde(default)]
     pub articles: Vec<Article>,
     /// Total pages of content available
     pub total_pages: usize,


### PR DESCRIPTION
When the api has no articles to return does not insert the 'articles' field.