### PR TITLE
[Merged by Bors] - TY-2524 fix potential 32bit problems

### DIFF
--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -19,12 +19,15 @@ import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustEmbedding;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show checkFfiUsize;
 
 extension EmbeddingFfi on Embedding {
   void writeNative(
     final Pointer<RustEmbedding> place,
   ) {
     final len = values.length;
+    checkFfiUsize(len, 'Embedding.length');
     final buffer = ffi.alloc_uninitialized_f32_slice(len);
     buffer.asTypedList(len).setAll(0, values);
     ffi.init_embedding_at(place, buffer, len);

--- a/discovery_engine/lib/src/ffi/types/list.dart
+++ b/discovery_engine/lib/src/ffi/types/list.dart
@@ -40,7 +40,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
 
   /// Allocates a slice of `RustType` containing all items of this list.
   Pointer<RustType> createSlice(List<Type> list) {
-    checkFfiUsize(list.length, 'list.length');
+    checkFfiUsize(list.length, 'List.length');
     final slice = alloc(list.length);
     list.fold<Pointer<RustType>>(slice, (nextElement, market) {
       writeNative(market, nextElement);
@@ -54,7 +54,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final Pointer<RustType> ptr,
     final int len,
   ) {
-    checkFfiUsize(len, 'list.length');
+    checkFfiUsize(len, 'List.length');
     final out = <Type>[];
     Iterable<int>.generate(len).fold<Pointer<RustType>>(ptr, (nextElement, _) {
       out.add(readNative(nextElement));
@@ -68,7 +68,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final List<Type> list,
     final Pointer<RustVecType> place,
   ) {
-    checkFfiUsize(list.length, 'list.length');
+    checkFfiUsize(list.length, 'List.length');
     final slice = createSlice(list);
     writeNativeVec(place, slice, list.length);
   }

--- a/discovery_engine/lib/src/ffi/types/list.dart
+++ b/discovery_engine/lib/src/ffi/types/list.dart
@@ -14,6 +14,9 @@
 
 import 'dart:ffi' show NativeType, Pointer;
 
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show checkFfiUsize;
+
 class ListFfiAdapter<Type, RustType extends NativeType,
     RustVecType extends NativeType> {
   final Pointer<RustType> Function(int) alloc;
@@ -37,6 +40,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
 
   /// Allocates a slice of `RustType` containing all items of this list.
   Pointer<RustType> createSlice(List<Type> list) {
+    checkFfiUsize(list.length, 'list.length');
     final slice = alloc(list.length);
     list.fold<Pointer<RustType>>(slice, (nextElement, market) {
       writeNative(market, nextElement);
@@ -50,6 +54,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final Pointer<RustType> ptr,
     final int len,
   ) {
+    checkFfiUsize(len, 'list.length');
     final out = <Type>[];
     Iterable<int>.generate(len).fold<Pointer<RustType>>(ptr, (nextElement, _) {
       out.add(readNative(nextElement));
@@ -63,6 +68,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final List<Type> list,
     final Pointer<RustVecType> place,
   ) {
+    checkFfiUsize(list.length, 'list.length');
     final slice = createSlice(list);
     writeNativeVec(place, slice, list.length);
   }

--- a/discovery_engine/lib/src/ffi/types/primitives.dart
+++ b/discovery_engine/lib/src/ffi/types/primitives.dart
@@ -44,6 +44,7 @@ class PrimitivesFfi {
 
 extension Uint8ListFfi on Uint8List {
   Boxed<RustVecU8> allocNative() {
+    checkFfiUsize(length, 'Uint8List.length');
     final ptr = ffi.alloc_uninitialized_bytes(length);
     ptr.asTypedList(length).setAll(0, this);
     final vec = ffi.alloc_vec_u8(ptr, length);
@@ -54,5 +55,12 @@ extension Uint8ListFfi on Uint8List {
     final len = ffi.get_vec_u8_len(vec);
     final buffer = ffi.get_vec_u8_buffer(vec);
     return Uint8List.fromList(buffer.asTypedList(len));
+  }
+}
+
+// FIXME[dart >1.16]: Use AbiSpecificInteger
+void checkFfiUsize(int val, String name) {
+  if (val > 0xFFFFFFFF) {
+    throw ArgumentError.value(val, name, 'only 32bit values are supported');
   }
 }

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -19,6 +19,8 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustOptionString, RustString;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show checkFfiUsize;
 
 extension StringFfi on String {
   void writeNative(final Pointer<RustString> place) {
@@ -65,12 +67,15 @@ class BoxedStr {
   final Pointer<Uint8> ptr;
   final int len;
 
-  BoxedStr.fromRawParts(this.ptr, this.len);
+  BoxedStr.fromRawParts(this.ptr, this.len) {
+    checkFfiUsize(len, 'BoxedStr.len');
+  }
 
   /// Creates a `Box<str>` based on given dart string.
   factory BoxedStr.create(String string) {
     final utf8Bytes = utf8.encode(string);
     final len = utf8Bytes.length;
+    checkFfiUsize(len, 'string.len');
     final ptr = ffi.alloc_uninitialized_bytes(len);
     ptr.asTypedList(len).setAll(0, utf8Bytes);
     return BoxedStr.fromRawParts(ptr, len);

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -75,7 +75,7 @@ class BoxedStr {
   factory BoxedStr.create(String string) {
     final utf8Bytes = utf8.encode(string);
     final len = utf8Bytes.length;
-    checkFfiUsize(len, 'string.len');
+    checkFfiUsize(len, 'String.len');
     final ptr = ffi.alloc_uninitialized_bytes(len);
     ptr.asTypedList(len).setAll(0, utf8Bytes);
     return BoxedStr.fromRawParts(ptr, len);

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -95,7 +95,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     pub async fn get_feed_documents(
         engine: &SharedEngine,
         history: Box<Vec<HistoricDocument>>,
-        max_documents: usize,
+        max_documents: u32,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine

--- a/discovery_engine_core/bindings/src/types/document/document_vec.rs
+++ b/discovery_engine_core/bindings/src/types/document/document_vec.rs
@@ -18,7 +18,7 @@ use xayn_discovery_engine_core::document::Document;
 
 use crate::types::{
     slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts, next_element},
-    vec::{get_vec_buffer, get_vec_len},
+    vec::{get_vec_buffer, get_vec_len}, primitives::FfiUsize,
 };
 
 /// Initializes a `Vec<Document>` at given place.
@@ -36,7 +36,7 @@ use crate::types::{
 pub unsafe extern "C" fn init_document_vec_at(
     place: *mut Vec<Document>,
     slice_ptr: *mut Document,
-    slice_len: usize,
+    slice_len: FfiUsize,
 ) {
     unsafe {
         place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn init_document_vec_at(
 
 /// Alloc an uninitialized `Box<[Document]>`.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_document_slice(len: usize) -> *mut Document {
+pub extern "C" fn alloc_uninitialized_document_slice(len: FfiUsize) -> *mut Document {
     alloc_uninitialized_slice(len)
 }
 
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn next_document(place: *mut Document) -> *mut Document {
 ///
 /// The pointer must represent a valid `Box<[Document]>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn drop_document_slice(documents: *mut Document, len: usize) {
+pub unsafe extern "C" fn drop_document_slice(documents: *mut Document, len: FfiUsize) {
     drop(unsafe { boxed_slice_from_raw_parts(documents, len) });
 }
 
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn drop_document_slice(documents: *mut Document, len: usiz
 ///
 /// The pointer must point to a valid `Vec<Document>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_document_vec_len(documents: *mut Vec<Document>) -> usize {
+pub unsafe extern "C" fn get_document_vec_len(documents: *mut Vec<Document>) -> FfiUsize {
     unsafe { get_vec_len(documents) }
 }
 

--- a/discovery_engine_core/bindings/src/types/document/document_vec.rs
+++ b/discovery_engine_core/bindings/src/types/document/document_vec.rs
@@ -17,8 +17,9 @@
 use xayn_discovery_engine_core::document::Document;
 
 use crate::types::{
+    primitives::FfiUsize,
     slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts, next_element},
-    vec::{get_vec_buffer, get_vec_len}, primitives::FfiUsize,
+    vec::{get_vec_buffer, get_vec_len},
 };
 
 /// Initializes a `Vec<Document>` at given place.

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn news_resource_place_of_image(
 /// The pointer must point to a valid [`NewsResource`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn news_resource_place_of_rank(place: *mut NewsResource) -> *mut usize {
+pub unsafe extern "C" fn news_resource_place_of_rank(place: *mut NewsResource) -> *mut u64 {
     unsafe { addr_of_mut!((*place).rank) }
 }
 

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -47,7 +47,9 @@ pub unsafe extern "C" fn init_historic_document_vec_at(
 
 /// Alloc an uninitialized `Box<[HistoricDocument]>`.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_historic_document_slice(len: FfiUsize) -> *mut HistoricDocument {
+pub extern "C" fn alloc_uninitialized_historic_document_slice(
+    len: FfiUsize,
+) -> *mut HistoricDocument {
     alloc_uninitialized_slice(len)
 }
 

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -21,7 +21,7 @@ use crate::types::{
     vec::{get_vec_buffer, get_vec_len},
 };
 
-use super::boxed::alloc_uninitialized;
+use super::{boxed::alloc_uninitialized, primitives::FfiUsize};
 
 /// Initializes a `Vec<HistoricDocument>` at given place.
 ///
@@ -38,7 +38,7 @@ use super::boxed::alloc_uninitialized;
 pub unsafe extern "C" fn init_historic_document_vec_at(
     place: *mut Vec<HistoricDocument>,
     slice_ptr: *mut HistoricDocument,
-    slice_len: usize,
+    slice_len: FfiUsize,
 ) {
     unsafe {
         place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn init_historic_document_vec_at(
 
 /// Alloc an uninitialized `Box<[HistoricDocument]>`.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_historic_document_slice(len: usize) -> *mut HistoricDocument {
+pub extern "C" fn alloc_uninitialized_historic_document_slice(len: FfiUsize) -> *mut HistoricDocument {
     alloc_uninitialized_slice(len)
 }
 
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn next_historic_document(
 #[no_mangle]
 pub unsafe extern "C" fn drop_historic_document_slice(
     documents: *mut HistoricDocument,
-    len: usize,
+    len: FfiUsize,
 ) {
     drop(unsafe { boxed_slice_from_raw_parts(documents, len) });
 }
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn drop_historic_document_slice(
 #[no_mangle]
 pub unsafe extern "C" fn get_historic_document_vec_len(
     documents: *mut Vec<HistoricDocument>,
-) -> usize {
+) -> FfiUsize {
     unsafe { get_vec_len(documents) }
 }
 

--- a/discovery_engine_core/bindings/src/types/market_vec.rs
+++ b/discovery_engine_core/bindings/src/types/market_vec.rs
@@ -21,7 +21,10 @@ use crate::types::{
     vec::{get_vec_buffer, get_vec_len},
 };
 
-use super::{boxed::{self, alloc_uninitialized}, primitives::FfiUsize};
+use super::{
+    boxed::{self, alloc_uninitialized},
+    primitives::FfiUsize,
+};
 
 /// Initializes a `Vec<Market>` at given place.
 ///

--- a/discovery_engine_core/bindings/src/types/market_vec.rs
+++ b/discovery_engine_core/bindings/src/types/market_vec.rs
@@ -21,7 +21,7 @@ use crate::types::{
     vec::{get_vec_buffer, get_vec_len},
 };
 
-use super::boxed::{self, alloc_uninitialized};
+use super::{boxed::{self, alloc_uninitialized}, primitives::FfiUsize};
 
 /// Initializes a `Vec<Market>` at given place.
 ///
@@ -38,7 +38,7 @@ use super::boxed::{self, alloc_uninitialized};
 pub unsafe extern "C" fn init_market_vec_at(
     place: *mut Vec<Market>,
     slice_ptr: *mut Market,
-    len: usize,
+    len: FfiUsize,
 ) {
     unsafe {
         place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, len)));
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn init_market_vec_at(
 
 /// Alloc an uninitialized `Box<[Market]>`.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_market_slice(len: usize) -> *mut Market {
+pub extern "C" fn alloc_uninitialized_market_slice(len: FfiUsize) -> *mut Market {
     alloc_uninitialized_slice(len)
 }
 
@@ -57,7 +57,7 @@ pub extern "C" fn alloc_uninitialized_market_slice(len: usize) -> *mut Market {
 ///
 /// The pointer must represent a valid `Box<[Market]>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn drop_market_slice(markets: *mut Market, len: usize) {
+pub unsafe extern "C" fn drop_market_slice(markets: *mut Market, len: FfiUsize) {
     drop(unsafe { boxed_slice_from_raw_parts(markets, len) });
 }
 
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn next_market(place: *mut Market) -> *mut Market {
 ///
 /// The pointer must point to a valid `Vec<Market>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_market_vec_len(markets: *mut Vec<Market>) -> usize {
+pub unsafe extern "C" fn get_market_vec_len(markets: *mut Vec<Market>) -> FfiUsize {
     unsafe { get_vec_len(markets) }
 }
 

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -29,7 +29,6 @@ use super::{
 /// to 2**32, e.g. for `Vec` the extern interface will
 /// only expose the first 2**32 elements of a
 /// `Vec`.
-///
 // FIXME[dart >1.16]: Use AbiSpecificInteger.
 #[derive(Clone, Copy)]
 #[repr(transparent)]

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -25,8 +25,8 @@ use super::{
 
 /// Type to represent "length" in FFI.
 ///
-/// Be aware that values returned are clamped
-/// to 2**32, e.g. for `Vec` the extern interface will
+/// Be aware that values returned are bounded
+/// by 2**32, e.g. for `Vec` the extern interface will
 /// only expose the first 2**32 elements of a
 /// `Vec`.
 // FIXME[dart >1.16]: Use AbiSpecificInteger.
@@ -42,9 +42,9 @@ impl FfiUsize {
         self.0 as usize
     }
 
-    /// Creates a instance from a `usize`.
+    /// Creates an instance from an `usize`.
     ///
-    /// The value is clamped to `2**32`.
+    /// The value is bounded by `2**32`.
     pub fn from_usize_lossy(v: usize) -> Self {
         Self(v.try_into().unwrap_or(u32::MAX))
     }

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -14,12 +14,42 @@
 
 //! Modules containing FFI glue for handling primitives (expect `str`/`slice`).
 
+use std::convert::TryInto;
+
 use super::{
     boxed,
     option::get_option_some,
     slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts},
     vec::{alloc_vec, get_vec_buffer, get_vec_len},
 };
+
+/// Type to represent "length" in FFI.
+///
+/// Be aware that values returned are clamped
+/// to 2**32, e.g. for `Vec` the extern interface will
+/// only expose the first 2**32 elements of a
+/// `Vec`.
+///
+// FIXME[dart >1.16]: Use AbiSpecificInteger.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct FfiUsize(u32);
+
+impl FfiUsize {
+    /// Returns the value as `usize`.
+    pub fn to_usize(self) -> usize {
+        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+        compile_error!("Only 32/64bit targets are supported");
+        self.0 as usize
+    }
+
+    /// Creates a instance from a `usize`.
+    ///
+    /// The value is clamped to `2**32`.
+    pub fn from_usize_lossy(v: usize) -> Self {
+        Self(v.try_into().unwrap_or(u32::MAX))
+    }
+}
 
 /// Initializes a rust `Option<f32>` to `Some(value)`.
 ///
@@ -61,7 +91,7 @@ pub unsafe extern "C" fn get_option_f32_some(option: *const Option<f32>) -> *con
 
 /// Allocates an uninitialized array of floats.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_f32_slice(len: usize) -> *mut f32 {
+pub extern "C" fn alloc_uninitialized_f32_slice(len: FfiUsize) -> *mut f32 {
     alloc_uninitialized_slice(len)
 }
 
@@ -71,13 +101,13 @@ pub extern "C" fn alloc_uninitialized_f32_slice(len: usize) -> *mut f32 {
 ///
 /// The pointer must represent a valid `Box<[f32]>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn drop_f32_slice(ptr: *mut f32, len: usize) {
+pub unsafe extern "C" fn drop_f32_slice(ptr: *mut f32, len: FfiUsize) {
     drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
 }
 
 /// Allocates an uninitialized array of bytes.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_bytes(len: usize) -> *mut u8 {
+pub extern "C" fn alloc_uninitialized_bytes(len: FfiUsize) -> *mut u8 {
     alloc_uninitialized_slice(len)
 }
 
@@ -87,7 +117,7 @@ pub extern "C" fn alloc_uninitialized_bytes(len: usize) -> *mut u8 {
 ///
 /// The pointer must represent a valid `Box<[u8]>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: usize) {
+pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: FfiUsize) {
     drop(unsafe { boxed_slice_from_raw_parts(ptr, len) });
 }
 
@@ -97,7 +127,7 @@ pub unsafe extern "C" fn drop_bytes(ptr: *mut u8, len: usize) {
 ///
 /// - Constructing a `Box<[u8]>` from given `slice_ptr`,`slice_len` must be sound.
 #[no_mangle]
-pub unsafe extern "C" fn alloc_vec_u8(slice_ptr: *mut u8, slice_len: usize) -> *mut Vec<u8> {
+pub unsafe extern "C" fn alloc_vec_u8(slice_ptr: *mut u8, slice_len: FfiUsize) -> *mut Vec<u8> {
     unsafe { alloc_vec(slice_ptr, slice_len) }
 }
 
@@ -117,7 +147,7 @@ pub unsafe extern "C" fn drop_vec_u8(ptr: *mut Vec<u8>) {
 ///
 /// The pointer must point to a valid `Vec<u8>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_vec_u8_len(vec: *mut Vec<u8>) -> usize {
+pub unsafe extern "C" fn get_vec_u8_len(vec: *mut Vec<u8>) -> FfiUsize {
     unsafe { get_vec_len(vec) }
 }
 

--- a/discovery_engine_core/bindings/src/types/slice.rs
+++ b/discovery_engine_core/bindings/src/types/slice.rs
@@ -16,8 +16,11 @@
 
 use std::{mem::MaybeUninit, slice};
 
+use super::primitives::FfiUsize;
+
 /// Allocates an array of (uninitialized) `T` memory objects of given length.
-pub(super) fn alloc_uninitialized_slice<T>(len: usize) -> *mut T {
+pub(super) fn alloc_uninitialized_slice<T>(len: FfiUsize) -> *mut T {
+    let len = len.to_usize();
     let mut vec = Vec::<MaybeUninit<T>>::with_capacity(len);
     //SAFE: MaybeUninit doesn't need initialization
     unsafe {
@@ -28,8 +31,12 @@ pub(super) fn alloc_uninitialized_slice<T>(len: usize) -> *mut T {
 }
 
 /// Creates a `Box<[T]>` from a pointer to the first element and the slice len.
-pub(super) unsafe fn boxed_slice_from_raw_parts<T>(ptr: *mut T, len: usize) -> Box<[T]> {
-    unsafe { Box::from_raw(slice::from_raw_parts_mut(ptr, len)) }
+///
+/// # Safety
+///
+/// - It must be sound to create a `Box<[T]>` from given `ptr` and `len`.
+pub(super) unsafe fn boxed_slice_from_raw_parts<T>(ptr: *mut T, len: FfiUsize) -> Box<[T]> {
+    unsafe { Box::from_raw(slice::from_raw_parts_mut(ptr, len.to_usize())) }
 }
 
 /// Given a pointer to an element in an array, returns a pointer to the next element.

--- a/discovery_engine_core/bindings/src/types/url.rs
+++ b/discovery_engine_core/bindings/src/types/url.rs
@@ -18,7 +18,7 @@ use std::ptr;
 
 use url::Url;
 
-use super::{option::get_option_some, string::str_from_raw_parts, primitives::FfiUsize};
+use super::{option::get_option_some, primitives::FfiUsize, string::str_from_raw_parts};
 
 /// Creates a rust `Url` based on given parsing given `&str` at given place.
 ///
@@ -71,7 +71,10 @@ pub unsafe extern "C" fn init_some_url_at(
 /// # Safety
 ///
 /// - The bytes `str_ptr..str_ptr+str_len` must be a sound rust `str`.
-unsafe fn parse_url_from_parts(str_ptr: *const u8, str_len: FfiUsize) -> Result<Url, url::ParseError> {
+unsafe fn parse_url_from_parts(
+    str_ptr: *const u8,
+    str_len: FfiUsize,
+) -> Result<Url, url::ParseError> {
     Url::parse(unsafe { str_from_raw_parts(str_ptr, str_len) })
 }
 
@@ -164,7 +167,11 @@ mod tests {
         let url = "https://foo.example/bar";
         let place = &mut MaybeUninit::<Url>::uninit();
         unsafe {
-            let ok = init_url_at(place.as_mut_ptr(), url.as_ptr(), FfiUsize::from_usize_lossy(url.len()));
+            let ok = init_url_at(
+                place.as_mut_ptr(),
+                url.as_ptr(),
+                FfiUsize::from_usize_lossy(url.len()),
+            );
             assert_eq!(ok, 1);
         }
         let place = unsafe { place.assume_init_mut() };
@@ -176,7 +183,11 @@ mod tests {
         let url = "not_an_url";
         let place = &mut MaybeUninit::<Url>::uninit();
         unsafe {
-            let ok = init_url_at(place.as_mut_ptr(), url.as_ptr(), FfiUsize::from_usize_lossy(url.len()));
+            let ok = init_url_at(
+                place.as_mut_ptr(),
+                url.as_ptr(),
+                FfiUsize::from_usize_lossy(url.len()),
+            );
             assert_eq!(ok, 0);
         }
     }

--- a/discovery_engine_core/bindings/src/types/vec.rs
+++ b/discovery_engine_core/bindings/src/types/vec.rs
@@ -14,11 +14,13 @@
 
 //! Modules containing FFI glue for `Vec<T>`.
 
-use super::slice::boxed_slice_from_raw_parts;
+use super::{slice::boxed_slice_from_raw_parts, primitives::FfiUsize};
 
 /// Get length of a `Box<Vec<T>>`.
-pub(super) unsafe fn get_vec_len<T>(vec: *mut Vec<T>) -> usize {
-    unsafe { &*vec }.len()
+///
+/// Be aware that the returned length is clamped to `FfiUnsignedSize::MAX` elements.
+pub(super) unsafe fn get_vec_len<T>(vec: *mut Vec<T>) -> FfiUsize {
+    FfiUsize::from_usize_lossy(unsafe { &*vec }.len())
 }
 
 /// Get a pointer to the beginning of a `Box<Vec<T>>`'s buffer.
@@ -31,7 +33,7 @@ pub(super) unsafe fn get_vec_buffer<T>(vec: *mut Vec<T>) -> *mut T {
 /// # Safety
 ///
 /// - Constructing a `Box<[T]>` from given `slice_ptr`,`slice_len` must be sound.
-pub(super) unsafe fn alloc_vec<T>(slice_ptr: *mut T, slice_len: usize) -> *mut Vec<T> {
+pub(super) unsafe fn alloc_vec<T>(slice_ptr: *mut T, slice_len: FfiUsize) -> *mut Vec<T> {
     let boxed_slice = unsafe { boxed_slice_from_raw_parts(slice_ptr, slice_len) };
     Box::into_raw(Box::new(Vec::from(boxed_slice)))
 }

--- a/discovery_engine_core/bindings/src/types/vec.rs
+++ b/discovery_engine_core/bindings/src/types/vec.rs
@@ -14,7 +14,7 @@
 
 //! Modules containing FFI glue for `Vec<T>`.
 
-use super::{slice::boxed_slice_from_raw_parts, primitives::FfiUsize};
+use super::{primitives::FfiUsize, slice::boxed_slice_from_raw_parts};
 
 /// Get length of a `Box<Vec<T>>`.
 ///

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -118,7 +118,7 @@ pub struct NewsResource {
     pub image: Option<Url>,
 
     /// The rank of the domain of the source,
-    pub rank: usize,
+    pub rank: u64,
 
     /// How much the article match the query.
     pub score: Option<f32>,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -27,19 +27,31 @@ use tracing::error;
 
 use xayn_ai::{
     ranker::{AveragePooler, Builder, CoiSystemConfig},
-    KpeConfig, SMBertConfig,
+    KpeConfig,
+    SMBertConfig,
 };
 use xayn_discovery_engine_providers::{Client, Filter, Market, NewsQuery};
 
 use crate::{
     document::{
-        self, document_from_article, Document, HistoricDocument, TimeSpent, UserReacted,
+        self,
+        document_from_article,
+        Document,
+        HistoricDocument,
+        TimeSpent,
+        UserReacted,
         UserReaction,
     },
     mab::{self, BetaSampler, SelectionIter},
     ranker::Ranker,
     stack::{
-        self, BoxedOps, BreakingNews, Data as StackData, Id as StackId, PersonalizedNews, Stack,
+        self,
+        BoxedOps,
+        BreakingNews,
+        Data as StackData,
+        Id as StackId,
+        PersonalizedNews,
+        Stack,
     },
 };
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -27,31 +27,19 @@ use tracing::error;
 
 use xayn_ai::{
     ranker::{AveragePooler, Builder, CoiSystemConfig},
-    KpeConfig,
-    SMBertConfig,
+    KpeConfig, SMBertConfig,
 };
 use xayn_discovery_engine_providers::{Client, Filter, Market, NewsQuery};
 
 use crate::{
     document::{
-        self,
-        document_from_article,
-        Document,
-        HistoricDocument,
-        TimeSpent,
-        UserReacted,
+        self, document_from_article, Document, HistoricDocument, TimeSpent, UserReacted,
         UserReaction,
     },
     mab::{self, BetaSampler, SelectionIter},
     ranker::Ranker,
     stack::{
-        self,
-        BoxedOps,
-        BreakingNews,
-        Data as StackData,
-        Id as StackId,
-        PersonalizedNews,
-        Stack,
+        self, BoxedOps, BreakingNews, Data as StackData, Id as StackId, PersonalizedNews, Stack,
     },
 };
 
@@ -305,11 +293,11 @@ where
     pub async fn get_feed_documents(
         &mut self,
         history: &[HistoricDocument],
-        max_documents: usize,
+        max_documents: u32,
     ) -> Result<Vec<Document>, Error> {
         let mut stacks = self.stacks.write().await;
         let documents =
-            SelectionIter::new(BetaSampler, stacks.values_mut()).select(max_documents)?;
+            SelectionIter::new(BetaSampler, stacks.values_mut()).select(max_documents as usize)?;
 
         let request_new = (self.request_after < self.core_config.request_after)
             .then(|| self.core_config.request_new)
@@ -642,7 +630,7 @@ struct State {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
+    use std::{error::Error, mem::size_of};
 
     use super::*;
 
@@ -684,5 +672,10 @@ mod tests {
                 .with_penalty(&[0.99, 0.66, 0.33])?,
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_usize_not_to_small() {
+        assert!(size_of::<usize>() >= size_of::<u32>());
     }
 }

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -64,7 +64,7 @@ pub struct Article {
 
     /// The page rank of the source website.
     #[serde(deserialize_with = "deserialize_rank")]
-    pub rank: usize,
+    pub rank: u64,
 
     /// The domain of the article's source, e.g. `xayn.com`. Not a valid URL.
     #[serde(
@@ -130,12 +130,12 @@ where
 }
 
 /// Null-value tolerant deserialization of rank
-fn deserialize_rank<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn deserialize_rank<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
     let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or(usize::MAX))
+    Ok(opt.unwrap_or(u64::MAX))
 }
 
 /// Null-value tolerant deserialization of topic


### PR DESCRIPTION
Does remove all usage of `usize`/`isize` in FFI.

Neither dart nor ffigen support that well when cross-compilation to 32bit targets is involved.

Once we have dart 1.16 we can replace this with a much better solutions using
`AbiSpecificInteger` and custom type-mapping options for `ffigen`.

**References:**

- [TY-2524](https://xainag.atlassian.net/browse/TY-2524)