### PR TITLE
[Merged by Bors] - TY-2581 Code deduplication in providers client.

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -408,7 +408,7 @@ where
                 page_size: scaled_page_size,
                 page: Some(page as usize),
             };
-            match client.news(&news_query).await {
+            match client.query_articles(&news_query).await {
                 Ok(batch) => articles.extend(batch),
                 Err(err) => errors.push(Error::Client(err.into())),
             };

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -30,7 +30,7 @@ use xayn_ai::{
     KpeConfig,
     SMBertConfig,
 };
-use xayn_discovery_engine_providers::{Client, Filter, Market, NewsQuery};
+use xayn_discovery_engine_providers::{Client, CommonQueryParts, Filter, Market, NewsQuery};
 
 use crate::{
     document::{
@@ -403,9 +403,11 @@ where
         let scaled_page_size = page_size as usize / markets.len() + 1;
         for market in markets.iter() {
             let news_query = NewsQuery {
-                market,
+                common: CommonQueryParts {
+                    market,
+                    page_size: scaled_page_size,
+                },
                 filter,
-                page_size: scaled_page_size,
                 page: Some(page as usize),
             };
             match client.query_articles(&news_query).await {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -406,9 +406,9 @@ where
                 common: CommonQueryParts {
                     market,
                     page_size: scaled_page_size,
+                    page: page as usize,
                 },
                 filter,
-                page: Some(page as usize),
             };
             match client.query_articles(&news_query).await {
                 Ok(batch) => articles.extend(batch),

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -120,6 +120,6 @@ fn spawn_headlines_request(
             page_size,
             page: 1,
         };
-        client.headlines(&query).await
+        client.query_articles(&query).await
     })
 }

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -19,7 +19,7 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::Uuid;
 use xayn_ai::ranker::KeyPhrase;
-use xayn_discovery_engine_providers::{Article, Client, HeadlinesQuery, Market};
+use xayn_discovery_engine_providers::{Article, Client, CommonQueryParts, HeadlinesQuery, Market};
 
 use crate::{
     document::{Document, HistoricDocument},
@@ -116,8 +116,10 @@ fn spawn_headlines_request(
     tokio::spawn(async move {
         let market = market;
         let query = HeadlinesQuery {
-            market: &market,
-            page_size,
+            common: CommonQueryParts {
+                market: &market,
+                page_size,
+            },
             page: 1,
         };
         client.query_articles(&query).await

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -119,8 +119,8 @@ fn spawn_headlines_request(
             common: CommonQueryParts {
                 market: &market,
                 page_size,
+                page: 1,
             },
-            page: 1,
         };
         client.query_articles(&query).await
     })

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -19,7 +19,14 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::Uuid;
 use xayn_ai::ranker::KeyPhrase;
-use xayn_discovery_engine_providers::{Article, Client, Filter, Market, NewsQuery};
+use xayn_discovery_engine_providers::{
+    Article,
+    Client,
+    CommonQueryParts,
+    Filter,
+    Market,
+    NewsQuery,
+};
 
 use crate::{
     document::{Document, HistoricDocument},
@@ -125,9 +132,11 @@ fn spawn_news_request(
     tokio::spawn(async move {
         let market = market;
         let query = NewsQuery {
-            market: &market,
+            common: CommonQueryParts {
+                market: &market,
+                page_size,
+            },
             filter,
-            page_size,
             page: None,
         };
 

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -135,9 +135,9 @@ fn spawn_news_request(
             common: CommonQueryParts {
                 market: &market,
                 page_size,
+                page: 1,
             },
             filter,
-            page: None,
         };
 
         client.query_articles(&query).await

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -131,6 +131,6 @@ fn spawn_news_request(
             page: None,
         };
 
-        client.news(&query).await
+        client.query_articles(&query).await
     })
 }

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -23,6 +23,7 @@ use url::Url;
 use crate::{
     filter::{Filter, Market},
     newscatcher::{Article, Response as NewscatcherResponse},
+    seal::Seal,
 };
 
 /// Client errors.
@@ -46,9 +47,7 @@ pub enum Error {
 }
 
 /// Represents a Query to Newscatcher.
-///
-/// Should not be implemented outside of this module.
-pub trait Query: Sync {
+pub trait Query: Seal + Sync {
     fn setup_url(&self, url: &mut Url) -> Result<(), Error>;
 }
 
@@ -89,6 +88,8 @@ where
     }
 }
 
+impl<T> Seal for NewsQuery<'_, T> {}
+
 /// Parameters determining which headlines to fetch
 pub struct HeadlinesQuery<'a> {
     /// Market of headlines.
@@ -112,6 +113,8 @@ impl Query for HeadlinesQuery<'_> {
         Ok(())
     }
 }
+
+impl Seal for HeadlinesQuery<'_> {}
 
 /// Client that can provide documents.
 #[derive(Default)]

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -48,6 +48,7 @@ pub enum Error {
 
 /// Represents a Query to Newscatcher.
 pub trait Query: Seal + Sync {
+    /// Sets query specific parameters on given Newscatcher base URL.
     fn setup_url(&self, url: &mut Url) -> Result<(), Error>;
 }
 

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -31,7 +31,7 @@ mod expression;
 mod filter;
 mod newscatcher;
 
-pub use client::{Client, Error, HeadlinesQuery, NewsQuery, Query};
+pub use client::{Client, CommonQueryParts, Error, HeadlinesQuery, NewsQuery, Query};
 pub use filter::{Filter, Market};
 pub use newscatcher::{Article, Response, Topic};
 

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -31,7 +31,7 @@ mod expression;
 mod filter;
 mod newscatcher;
 
-pub use client::{Client, Error, HeadlinesQuery, NewsQuery};
+pub use client::{Client, Error, HeadlinesQuery, NewsQuery, Query};
 pub use filter::{Filter, Market};
 pub use newscatcher::{Article, Response, Topic};
 

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -34,3 +34,7 @@ mod newscatcher;
 pub use client::{Client, Error, HeadlinesQuery, NewsQuery};
 pub use filter::{Filter, Market};
 pub use newscatcher::{Article, Response, Topic};
+
+mod seal {
+    pub trait Seal {}
+}

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
             page_size: 100,
             page,
         };
-        let raw_response = client.headlines_query(&params).await.unwrap();
+        let raw_response = client.query_newscatcher(&params).await.unwrap();
         total_pages = raw_response.total_pages;
 
         let content = serde_json::to_string_pretty(&raw_response.articles)?;

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -43,8 +43,8 @@ async fn main() -> Result<()> {
             common: CommonQueryParts {
                 market: &market,
                 page_size: 100,
+                page,
             },
-            page,
         };
         let raw_response = client.query_newscatcher(&params).await.unwrap();
         total_pages = raw_response.total_pages;

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use anyhow::{Context, Result};
-use xayn_discovery_engine_providers::{Client, HeadlinesQuery, Market};
+use xayn_discovery_engine_providers::{Client, CommonQueryParts, HeadlinesQuery, Market};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -40,8 +40,10 @@ async fn main() -> Result<()> {
     while page <= total_pages {
         println!("Fetching page {} of {}", page, total_pages);
         let params = HeadlinesQuery {
-            market: &market,
-            page_size: 100,
+            common: CommonQueryParts {
+                market: &market,
+                page_size: 100,
+            },
             page,
         };
         let raw_response = client.query_newscatcher(&params).await.unwrap();


### PR DESCRIPTION
Removes  code duplication between `news` and `headlines` in providers `Client`.

**References:**

- [TY-2581](https://xainag.atlassian.net/browse/TY-2581)