### PR TITLE
[Merged by Bors] - TY-2540 default to hard coded market specific news quality rank limits

### DIFF
--- a/discovery_engine/lib/src/ffi/types/feed_market.dart
+++ b/discovery_engine/lib/src/ffi/types/feed_market.dart
@@ -25,8 +25,7 @@ extension FeedMarketFfi on FeedMarket {
   void writeNative(Pointer<RustMarket> place) {
     countryCode.writeNative(ffi.market_place_of_country_code(place));
     langCode.writeNative(ffi.market_place_of_lang_code(place));
-    //FIXME properly set it
-    ffi.init_market_news_quality_rank_limit(place);
+    ffi.finish_market_initialization(place);
   }
 
   static FeedMarket readNative(Pointer<RustMarket> market) {

--- a/discovery_engine_core/bindings/src/types/market.rs
+++ b/discovery_engine_core/bindings/src/types/market.rs
@@ -40,17 +40,26 @@ pub unsafe extern "C" fn market_place_of_lang_code(place: *mut Market) -> *mut S
     unsafe { addr_of_mut!((*place).lang_code) }
 }
 
-/// Sets the `news_quality_rank_limit` field of a [`Market`] to `None`.
+/// Finish the initialization of a [`Market`] instance.
+///
+/// This sets defaults for fields not yet exposed to dart.
+///
 ///
 /// # Safety
 ///
-/// The pointer must point to a valid [`Market`] memory object, it
-/// might be uninitialized.
+/// - The pointer must point to a valid [`Market`] memory object, it
+///   might be uninitialized.
+/// - Must be called after all exposed fields have been initialized and
+///   not before that.
 #[no_mangle]
-pub unsafe extern "C" fn init_market_news_quality_rank_limit(place: *mut Market) {
+pub unsafe extern "C" fn finish_market_initialization(place: *mut Market) {
     unsafe {
-        addr_of_mut!((*place).news_quality_rank_limit).write(None);
-    }
+        //Note: I'm not sure if `&*place.country_code` is guaranteed to not construct a
+        //      intermediate `&place` (which would be unsound).
+        #[allow(clippy::deref_addrof)]
+        let limit = Market::default_news_quality_rank_limit(&*addr_of_mut!((*place).country_code));
+        addr_of_mut!((*place).news_quality_rank_limit).write(limit);
+    };
 }
 
 /// Alloc an uninitialized `Box<Market>`, mainly used for testing.

--- a/discovery_engine_core/providers/src/filter.rs
+++ b/discovery_engine_core/providers/src/filter.rs
@@ -51,6 +51,27 @@ pub struct Market {
     pub news_quality_rank_limit: Option<usize>,
 }
 
+impl Market {
+    /// Returns the default news quality rank limit for given country.
+    pub fn default_news_quality_rank_limit(country_code: &str) -> Option<usize> {
+        #[allow(clippy::match_same_arms)]
+        Some(match country_code {
+            "AT" => 70_000,
+            "BE" => 70_000,
+            "CA" => 70_000,
+            "CH" => 50_000,
+            "DE" => 12_000,
+            "ES" => 40_000,
+            "GB" => 14_000,
+            "IE" => 70_000,
+            "NL" => 60_000,
+            "PL" => 50_000,
+            "US" => 10_000,
+            _ => return None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Based on:**

- #251
- #244 

**References:**

- [story TY-2528](https://xainag.atlassian.net/browse/TY-2528)
- [ticket TY-2540](https://xainag.atlassian.net/browse/TY-2540)