### PR TITLE
[Merged by Bors] - TY-2591 Fix for restoring search

### DIFF
--- a/discovery_engine/lib/src/ffi/types/document/document.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document.dart
@@ -70,11 +70,16 @@ class DocumentFfi with EquatableMixin {
     resource.writeNative(ffi.document_place_of_resource(place));
   }
 
-  Document toDocument({required int batchIndex}) => Document(
+  Document toDocument({
+    required int batchIndex,
+    bool isSearched = false,
+  }) =>
+      Document(
         documentId: id,
         stackId: stackId,
         resource: resource,
         batchIndex: batchIndex,
+        isSearched: isSearched,
       );
 
   ActiveDocumentData toActiveDocumentData() =>

--- a/discovery_engine/lib/src/ffi/types/document/document_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document_vec.dart
@@ -70,13 +70,13 @@ extension DocumentSliceFfi on List<DocumentFfi> {
   }
 
   List<DocumentWithActiveData> toDocumentListWithActiveData({
-    bool searched = false,
+    bool isSearched = false,
   }) =>
       asMap()
           .entries
           .map(
             (e) => DocumentWithActiveData(
-              e.value.toDocument(batchIndex: e.key, isSearched: searched),
+              e.value.toDocument(batchIndex: e.key, isSearched: isSearched),
               e.value.toActiveDocumentData(),
             ),
           )

--- a/discovery_engine/lib/src/ffi/types/document/document_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document_vec.dart
@@ -69,13 +69,16 @@ extension DocumentSliceFfi on List<DocumentFfi> {
     return res;
   }
 
-  List<DocumentWithActiveData> toDocumentListWithActiveData() => asMap()
-      .entries
-      .map(
-        (e) => DocumentWithActiveData(
-          e.value.toDocument(batchIndex: e.key),
-          e.value.toActiveDocumentData(),
-        ),
-      )
-      .toList();
+  List<DocumentWithActiveData> toDocumentListWithActiveData({
+    bool searched = false,
+  }) =>
+      asMap()
+          .entries
+          .map(
+            (e) => DocumentWithActiveData(
+              e.value.toDocument(batchIndex: e.key, isSearched: searched),
+              e.value.toActiveDocumentData(),
+            ),
+          )
+          .toList();
 }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -170,7 +170,7 @@ class DiscoveryEngineFfi implements Engine {
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)
-        .toDocumentListWithActiveData();
+        .toDocumentListWithActiveData(searched: true);
   }
 
   /// Disposes the engine.

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -170,7 +170,7 @@ class DiscoveryEngineFfi implements Engine {
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)
-        .toDocumentListWithActiveData(searched: true);
+        .toDocumentListWithActiveData(isSearched: true);
   }
 
   /// Disposes the engine.


### PR DESCRIPTION
[ref](https://xainag.atlassian.net/browse/TY-2591)

When getting documents from active search we need to make sure that we save them as "searched" documents, by setting the `isSearched` flag to true.