### PR TITLE
[Merged by Bors] - TY-2599	news provider do not support to_rank in headline queries.

### DIFF
--- a/discovery_engine/lib/src/ffi/types/feed_market.dart
+++ b/discovery_engine/lib/src/ffi/types/feed_market.dart
@@ -25,7 +25,6 @@ extension FeedMarketFfi on FeedMarket {
   void writeNative(Pointer<RustMarket> place) {
     countryCode.writeNative(ffi.market_place_of_country_code(place));
     langCode.writeNative(ffi.market_place_of_lang_code(place));
-    ffi.finish_market_initialization(place);
   }
 
   static FeedMarket readNative(Pointer<RustMarket> market) {

--- a/discovery_engine_core/bindings/src/types/market.rs
+++ b/discovery_engine_core/bindings/src/types/market.rs
@@ -40,28 +40,6 @@ pub unsafe extern "C" fn market_place_of_lang_code(place: *mut Market) -> *mut S
     unsafe { addr_of_mut!((*place).lang_code) }
 }
 
-/// Finish the initialization of a [`Market`] instance.
-///
-/// This sets defaults for fields not yet exposed to dart.
-///
-///
-/// # Safety
-///
-/// - The pointer must point to a valid [`Market`] memory object, it
-///   might be uninitialized.
-/// - Must be called after all exposed fields have been initialized and
-///   not before that.
-#[no_mangle]
-pub unsafe extern "C" fn finish_market_initialization(place: *mut Market) {
-    unsafe {
-        //Note: I'm not sure if `&*place.country_code` is guaranteed to not construct a
-        //      intermediate `&place` (which would be unsound).
-        #[allow(clippy::deref_addrof)]
-        let limit = Market::default_news_quality_rank_limit(&*addr_of_mut!((*place).country_code));
-        addr_of_mut!((*place).news_quality_rank_limit).write(limit);
-    };
-}
-
 /// Alloc an uninitialized `Box<Market>`, mainly used for testing.
 #[no_mangle]
 pub extern "C" fn alloc_uninitialized_market() -> *mut Market {

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -79,6 +79,10 @@ impl CommonQueryParts<'_> {
             // FIXME Consider cmp::min(self.page, 1) or explicit error variant
             .append_pair("page", &self.page.to_string());
 
+        if let Some(limit) = self.market.news_quality_rank_limit() {
+            query.append_pair("to_rank", &limit.to_string());
+        }
+
         Ok(())
     }
 }
@@ -102,10 +106,6 @@ where
         query
             .append_pair("sort_by", "relevancy")
             .append_pair("q", &self.filter.build());
-
-        if let Some(limit) = self.common.market.news_quality_rank_limit() {
-            query.append_pair("to_rank", &limit.to_string());
-        }
 
         Ok(())
     }

--- a/discovery_engine_core/providers/src/filter.rs
+++ b/discovery_engine_core/providers/src/filter.rs
@@ -46,17 +46,13 @@ pub struct Market {
     pub country_code: String,
     /// Language code as defined in ISO 639-1 — 2 letter code, e.g. 'de' or 'en'
     pub lang_code: String,
-    /// Up to which "quality rank" news articles should be included for this market.
-    ///
-    /// News with a quality rank higher (i.e. worse) than the limit will not be included.
-    pub news_quality_rank_limit: Option<usize>,
 }
 
 impl Market {
     /// Returns the default news quality rank limit for given country.
-    pub fn default_news_quality_rank_limit(country_code: &str) -> Option<usize> {
+    pub fn news_quality_rank_limit(&self) -> Option<usize> {
         #[allow(clippy::match_same_arms)]
-        Some(match country_code {
+        Some(match &*self.country_code {
             "AT" => 70_000,
             "BE" => 70_000,
             "CA" => 70_000,

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -31,7 +31,6 @@ async fn main() -> Result<()> {
     let market = Market {
         lang_code: "en".to_string(),
         country_code: "US".to_string(),
-        news_quality_rank_limit: None,
     };
 
     // This is updated every iteration, based on the response from Newscatcher. So in reality,


### PR DESCRIPTION
- newscatcher doesn't support `to_rank` in headline queries
- given the feedback from the previous PR it is unnecessary to store
  to limit anywhere (as it isn't meant to be configurable).

**References:**

- [TY-2599](https://xainag.atlassian.net/browse/TY-2599)
