### PR TITLE
[Merged by Bors] - TY-2553 configure stack ops upon creation

### DIFF
--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -20,7 +20,7 @@ use xayn_discovery_engine_providers::Article;
 
 use crate::{
     document::{Document, HistoricDocument},
-    engine::{EndpointConfig, GenericError},
+    engine::GenericError,
     stack::Id,
 };
 use xayn_ai::ranker::KeyPhrase;
@@ -40,9 +40,6 @@ pub trait Ops {
     /// Only one stack with a given id can be added to [`Engine`](crate::engine::Engine).
     /// This method must always return the same value for a given implementation.
     fn id(&self) -> Id;
-
-    /// Configure the operations from endpoint settings.
-    fn configure(&mut self, config: &EndpointConfig);
 
     /// Returns new items that could be added to the stack.
     ///

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -34,7 +34,6 @@ use crate::{
 use super::Ops;
 
 /// Stack operations customized for breaking news items.
-#[derive(Default)]
 pub(crate) struct BreakingNews {
     client: Arc<Client>,
     markets: Option<Arc<RwLock<Vec<Market>>>>,
@@ -42,19 +41,22 @@ pub(crate) struct BreakingNews {
     semantic_filter_config: SemanticFilterConfig,
 }
 
+impl BreakingNews {
+    /// Creates a breaking news stack.
+    pub(crate) fn new(config: &EndpointConfig) -> Self {
+        Self {
+            client: Arc::new(Client::new(&config.api_key, &config.api_base_url)),
+            markets: Some(config.markets.clone()),
+            page_size: config.page_size,
+            semantic_filter_config: SemanticFilterConfig::default(),
+        }
+    }
+}
+
 #[async_trait]
 impl Ops for BreakingNews {
     fn id(&self) -> Id {
         Id(Uuid::parse_str("1ce442c8-8a96-433e-91db-c0bee37e5a83").unwrap(/* valid uuid */))
-    }
-
-    fn configure(&mut self, config: &EndpointConfig) {
-        self.client = Arc::new(Client::new(
-            config.api_key.clone(),
-            config.api_base_url.clone(),
-        ));
-        self.markets.replace(Arc::clone(&config.markets));
-        self.page_size = config.page_size;
     }
 
     fn needs_key_phrases(&self) -> bool {

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -43,7 +43,7 @@ use super::Ops;
 /// Stack operations customized for personalized news items.
 pub(crate) struct PersonalizedNews {
     client: Arc<Client>,
-    markets: Option<Arc<RwLock<Vec<Market>>>>,
+    markets: Arc<RwLock<Vec<Market>>>,
     page_size: usize,
     semantic_filter_config: SemanticFilterConfig,
 }
@@ -53,7 +53,7 @@ impl PersonalizedNews {
     pub(crate) fn new(config: &EndpointConfig) -> Self {
         Self {
             client: Arc::new(Client::new(&config.api_key, &config.api_base_url)),
-            markets: Some(config.markets.clone()),
+            markets: config.markets.clone(),
             page_size: config.page_size,
             semantic_filter_config: SemanticFilterConfig::default(),
         }
@@ -74,40 +74,38 @@ impl Ops for PersonalizedNews {
         if key_phrases.is_empty() {
             return Ok(vec![]);
         }
-        if let Some(markets) = self.markets.as_ref() {
-            let mut articles = Vec::new();
-            let mut errors = Vec::new();
-            let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
-                filter.add_keyword(kp.words())
-            }));
 
-            let mut requests = markets
-                .read()
-                .await
-                .iter()
-                .cloned()
-                .map(|market| {
-                    spawn_news_request(self.client.clone(), market, filter.clone(), self.page_size)
-                })
-                .collect::<FuturesUnordered<_>>();
+        let mut articles = Vec::new();
+        let mut errors = Vec::new();
+        let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
+            filter.add_keyword(kp.words())
+        }));
 
-            while let Some(handle) = requests.next().await {
-                // should we also push handle errors?
-                if let Ok(result) = handle {
-                    match result {
-                        Ok(batch) => articles.extend(batch),
-                        Err(err) => errors.push(err),
-                    }
+        let mut requests = self
+            .markets
+            .read()
+            .await
+            .iter()
+            .cloned()
+            .map(|market| {
+                spawn_news_request(self.client.clone(), market, filter.clone(), self.page_size)
+            })
+            .collect::<FuturesUnordered<_>>();
+
+        while let Some(handle) = requests.next().await {
+            // should we also push handle errors?
+            if let Ok(result) = handle {
+                match result {
+                    Ok(batch) => articles.extend(batch),
+                    Err(err) => errors.push(err),
                 }
             }
+        }
 
-            if articles.is_empty() && !errors.is_empty() {
-                Err(errors.pop().unwrap(/* nonempty errors */).into())
-            } else {
-                Ok(articles)
-            }
+        if articles.is_empty() && !errors.is_empty() {
+            Err(errors.pop().unwrap(/* nonempty errors */).into())
         } else {
-            Ok(vec![])
+            Ok(articles)
         }
     }
 

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -41,7 +41,6 @@ use crate::{
 use super::Ops;
 
 /// Stack operations customized for personalized news items.
-#[derive(Default)]
 pub(crate) struct PersonalizedNews {
     client: Arc<Client>,
     markets: Option<Arc<RwLock<Vec<Market>>>>,
@@ -49,19 +48,22 @@ pub(crate) struct PersonalizedNews {
     semantic_filter_config: SemanticFilterConfig,
 }
 
+impl PersonalizedNews {
+    /// Creates a personalized news stack.
+    pub(crate) fn new(config: &EndpointConfig) -> Self {
+        Self {
+            client: Arc::new(Client::new(&config.api_key, &config.api_base_url)),
+            markets: Some(config.markets.clone()),
+            page_size: config.page_size,
+            semantic_filter_config: SemanticFilterConfig::default(),
+        }
+    }
+}
+
 #[async_trait]
 impl Ops for PersonalizedNews {
     fn id(&self) -> Id {
         Id(Uuid::parse_str("311dc7eb-5fc7-4aa4-8232-e119f7e80e76").unwrap(/* valid uuid */))
-    }
-
-    fn configure(&mut self, config: &EndpointConfig) {
-        self.client = Arc::new(Client::new(
-            config.api_key.clone(),
-            config.api_base_url.clone(),
-        ));
-        self.markets.replace(Arc::clone(&config.markets));
-        self.page_size = config.page_size;
     }
 
     fn needs_key_phrases(&self) -> bool {

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -127,7 +127,6 @@ impl Query for HeadlinesQuery<'_> {
 impl Seal for HeadlinesQuery<'_> {}
 
 /// Client that can provide documents.
-#[derive(Default)]
 pub struct Client {
     token: String,
     url: String,


### PR DESCRIPTION
**References**

- [TY-2553]

**Summary**

- remove `configure()` method from stack `Ops`
- configure `BreakingNews` and `PersonalizedNews` upon creation


[TY-2553]: https://xainag.atlassian.net/browse/TY-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ