### PR TITLE
[Merged by Bors] - TY-2523 do more requests

### DIFF
--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pub(crate) mod breaking;
+mod common;
 pub(crate) mod personalized;
 
 use async_trait::async_trait;

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 use super::{
-    common::{request_min_new_items, spawn_requests_for_markets},
+    common::{create_requests_for_markets, request_min_new_items},
     Ops,
 };
 
@@ -93,7 +93,7 @@ impl Ops for BreakingNews {
             self.max_requests,
             self.min_articles,
             |request_num| {
-                spawn_requests_for_markets(markets.clone(), |market| {
+                create_requests_for_markets(markets.clone(), |market| {
                     let page = request_num as usize + 1;
                     spawn_headlines_request(
                         self.client.clone(),

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -19,14 +19,7 @@ use itertools::chain;
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::Uuid;
 use xayn_ai::ranker::KeyPhrase;
-use xayn_discovery_engine_providers::{
-    Article,
-    Client,
-    CommonQueryParts,
-    Error,
-    HeadlinesQuery,
-    Market,
-};
+use xayn_discovery_engine_providers::{Article, Client, CommonQueryParts, HeadlinesQuery, Market};
 
 use crate::{
     document::{Document, HistoricDocument},
@@ -130,7 +123,7 @@ fn spawn_headlines_request(
     page_size: usize,
     page: usize,
     excluded_sources: Arc<Vec<String>>,
-) -> JoinHandle<Result<Vec<Article>, Error>> {
+) -> JoinHandle<Result<Vec<Article>, GenericError>> {
     tokio::spawn(async move {
         let market = market;
         let query = HeadlinesQuery {
@@ -141,6 +134,6 @@ fn spawn_headlines_request(
                 excluded_sources: &excluded_sources,
             },
         };
-        client.query_articles(&query).await
+        client.query_articles(&query).await.map_err(Into::into)
     })
 }

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -99,8 +99,9 @@ impl Ops for BreakingNews {
         request_min_new_items(
             self.max_requests,
             self.min_articles,
-            |page| {
+            |request_num| {
                 spawn_requests_for_markets(markets.clone(), |market| {
+                    let page = request_num as usize + 1;
                     spawn_headlines_request(
                         self.client.clone(),
                         market,

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -18,16 +18,13 @@ use xayn_discovery_engine_providers::{Article, Error, Market};
 
 use crate::engine::GenericError;
 
+type Requests = FuturesUnordered<JoinHandle<Result<Vec<Article>, Error>>>;
+
 async fn request_new_items(
-    markets: Vec<Market>,
-    request_fn: impl Fn(Market) -> JoinHandle<Result<Vec<Article>, Error>> + Send,
+    requests_fn: impl Fn() -> Requests + Send,
     filter_fn: impl FnOnce(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send,
 ) -> Result<Vec<Article>, GenericError> {
-    let mut requests = markets
-        .into_iter()
-        .map(|market| request_fn(market))
-        .collect::<FuturesUnordered<_>>();
-
+    let mut requests = requests_fn();
     let mut articles = Vec::new();
     let mut error = None;
 
@@ -55,23 +52,16 @@ async fn request_new_items(
 }
 
 pub(super) async fn request_min_new_items(
-    markets: Vec<Market>,
     max_requests: u32,
     min_articles: usize,
-    request_fn: impl Fn(Market, usize) -> JoinHandle<Result<Vec<Article>, Error>> + Send + Sync,
+    requests_fn: impl Fn(usize) -> Requests + Send + Sync,
     filter_fn: impl Fn(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send + Sync,
 ) -> Result<Vec<Article>, GenericError> {
     let mut articles = Vec::new();
     let mut error = None;
 
     for page in 1..=max_requests as usize {
-        match request_new_items(
-            markets.clone(),
-            |market| request_fn(market, page),
-            |articles| filter_fn(articles),
-        )
-        .await
-        {
+        match request_new_items(|| requests_fn(page), |articles| filter_fn(articles)).await {
             Ok(batch) => articles.extend(batch),
             Err(err) => {
                 error.replace(err);
@@ -89,3 +79,31 @@ pub(super) async fn request_min_new_items(
         Ok(articles)
     }
 }
+
+pub(super) fn spawn_requests_for_markets(
+    markets: Vec<Market>,
+    request_fn: impl Fn(Market) -> JoinHandle<Result<Vec<Article>, Error>> + Send,
+) -> FuturesUnordered<JoinHandle<Result<Vec<Article>, Error>>> {
+    markets
+        .into_iter()
+        .map(|market| request_fn(market))
+        .collect::<FuturesUnordered<_>>()
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     fn request_fn(market: Market, page: usize, sender: ) -> JoinHandle<Result<Vec<Article>, Error>> {
+
+//     }
+
+//     #[tokio::test]
+//     async fn test_request_min_new_items() {
+//         let markets = vec![Market{ country_code: "DE".into(), lang_code: "de".into() }];
+
+//         request_min_new_items(markets, 5, 20, |market, page| {
+
+//         })
+//     }
+// }

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -54,14 +54,14 @@ async fn request_new_items(
 pub(super) async fn request_min_new_items(
     max_requests: u32,
     min_articles: usize,
-    requests_fn: impl Fn(usize) -> Requests + Send + Sync,
+    requests_fn: impl Fn(u32) -> Requests + Send + Sync,
     filter_fn: impl Fn(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send + Sync,
 ) -> Result<Vec<Article>, GenericError> {
     let mut articles = Vec::new();
     let mut error = None;
 
-    for page in 1..=max_requests as usize {
-        match request_new_items(|| requests_fn(page), |articles| filter_fn(articles)).await {
+    for request_num in 0..max_requests {
+        match request_new_items(|| requests_fn(request_num), |articles| filter_fn(articles)).await {
             Ok(batch) => articles.extend(batch),
             Err(err) => {
                 error.replace(err);

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -14,96 +14,270 @@
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::task::JoinHandle;
-use xayn_discovery_engine_providers::{Article, Error, Market};
+use xayn_discovery_engine_providers::Market;
 
 use crate::engine::GenericError;
 
-type Requests = FuturesUnordered<JoinHandle<Result<Vec<Article>, Error>>>;
+type ItemsResult<I> = Result<Vec<I>, GenericError>;
+type Requests<I> = FuturesUnordered<JoinHandle<ItemsResult<I>>>;
 
-async fn request_new_items(
-    requests_fn: impl Fn() -> Requests + Send,
-    filter_fn: impl FnOnce(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send,
-) -> Result<Vec<Article>, GenericError> {
+async fn request_new_items<I: Send>(
+    requests_fn: impl FnOnce() -> Requests<I> + Send,
+    filter_fn: impl FnOnce(Vec<I>) -> ItemsResult<I> + Send,
+) -> ItemsResult<I> {
     let mut requests = requests_fn();
-    let mut articles = Vec::new();
+    let mut items = Vec::new();
     let mut error = None;
 
     while let Some(handle) = requests.next().await {
         // should we also push handle errors?
         if let Ok(result) = handle {
             match result {
-                Ok(batch) => articles.extend(batch),
+                Ok(batch) => items.extend(batch),
                 Err(err) => {
-                    error.replace(err.into());
+                    error.replace(err);
                 }
             }
         }
     }
 
-    let articles = filter_fn(articles)
+    let items = filter_fn(items)
         .map_err(|err| error.replace(err))
         .unwrap_or_default();
 
-    if articles.is_empty() && error.is_some() {
+    if items.is_empty() && error.is_some() {
         Err(error.unwrap(/* nonempty error */))
     } else {
-        Ok(articles)
+        Ok(items)
     }
 }
 
-pub(super) async fn request_min_new_items(
+pub(super) async fn request_min_new_items<I: Send>(
     max_requests: u32,
     min_articles: usize,
-    requests_fn: impl Fn(u32) -> Requests + Send + Sync,
-    filter_fn: impl Fn(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send + Sync,
-) -> Result<Vec<Article>, GenericError> {
-    let mut articles = Vec::new();
+    requests_fn: impl Fn(u32) -> Requests<I> + Send + Sync,
+    filter_fn: impl Fn(Vec<I>) -> ItemsResult<I> + Send + Sync,
+) -> ItemsResult<I> {
+    let mut items = Vec::new();
     let mut error = None;
 
     for request_num in 0..max_requests {
-        match request_new_items(|| requests_fn(request_num), |articles| filter_fn(articles)).await {
-            Ok(batch) => articles.extend(batch),
+        match request_new_items(|| requests_fn(request_num), |items| filter_fn(items)).await {
+            Ok(batch) => items.extend(batch),
             Err(err) => {
                 error.replace(err);
             }
         };
 
-        if articles.len() >= min_articles {
+        if items.len() >= min_articles {
             break;
         }
     }
 
-    if articles.is_empty() && error.is_some() {
+    if items.is_empty() && error.is_some() {
         Err(error.unwrap(/* nonempty error */))
     } else {
-        Ok(articles)
+        Ok(items)
     }
 }
 
-pub(super) fn spawn_requests_for_markets(
+pub(super) fn spawn_requests_for_markets<I>(
     markets: Vec<Market>,
-    request_fn: impl Fn(Market) -> JoinHandle<Result<Vec<Article>, Error>> + Send,
-) -> FuturesUnordered<JoinHandle<Result<Vec<Article>, Error>>> {
+    request_fn: impl Fn(Market) -> JoinHandle<ItemsResult<I>> + Send,
+) -> Requests<I> {
     markets
         .into_iter()
         .map(|market| request_fn(market))
         .collect::<FuturesUnordered<_>>()
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     fn request_fn(market: Market, page: usize, sender: ) -> JoinHandle<Result<Vec<Article>, Error>> {
+    struct Resp(Result<Vec<u32>, GenericError>);
 
-//     }
+    impl Resp {
+        fn ok(items: &[u32]) -> Self {
+            Self(Ok(items.to_owned()))
+        }
 
-//     #[tokio::test]
-//     async fn test_request_min_new_items() {
-//         let markets = vec![Market{ country_code: "DE".into(), lang_code: "de".into() }];
+        fn err(msg: &str) -> Self {
+            Self(Err(GenericError::from(msg)))
+        }
+    }
 
-//         request_min_new_items(markets, 5, 20, |market, page| {
+    fn client(responses: Vec<Resp>) -> Requests<u32> {
+        responses
+            .into_iter()
+            .map(|response| tokio::spawn(async move { response.0 }))
+            .collect::<FuturesUnordered<_>>()
+    }
 
-//         })
-//     }
-// }
+    #[tokio::test]
+    async fn test_request_new_items() {
+        let items = request_new_items(
+            || {
+                let responses = vec![Resp::ok(&[1]), Resp::ok(&[2, 3])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_request_new_items_only_errors() {
+        let res = request_new_items(
+            || {
+                let responses = vec![Resp::err("0"), Resp::err("1")];
+                client(responses)
+            },
+            Ok,
+        )
+        .await;
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "1");
+    }
+
+    #[tokio::test]
+    async fn test_request_new_items_mixed() {
+        let items = request_new_items(
+            || {
+                let responses = vec![Resp::err("0"), Resp::ok(&[1])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_request_new_items_filter() {
+        let items = request_new_items(
+            || {
+                let responses = vec![Resp::ok(&[1]), Resp::ok(&[2, 3])];
+                client(responses)
+            },
+            |items| Ok(items.into_iter().filter(|item| *item != 2).collect()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_request_new_items_filter_error() {
+        let res: Result<Vec<u32>, GenericError> =
+            request_new_items(FuturesUnordered::new, |_| Err(GenericError::from("filter"))).await;
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "filter");
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items() {
+        let items = request_min_new_items(
+            2,
+            2,
+            |i| {
+                let responses = vec![Resp::ok(&[i])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items_only() {
+        let res = request_min_new_items(
+            2,
+            2,
+            |i| {
+                let responses = vec![Resp::err(&format!("{}", i))];
+                client(responses)
+            },
+            Ok,
+        )
+        .await;
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "1");
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items_mixed() {
+        let items = request_min_new_items(
+            2,
+            2,
+            |i| {
+                let responses = vec![Resp::err(&format!("{}", i)), Resp::ok(&[i])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items_less_than_min() {
+        let items = request_min_new_items(
+            3,
+            10,
+            |i| {
+                if i == 2 {
+                    // only the second request returns an item
+                    let responses = vec![Resp::ok(&[i])];
+                    client(responses)
+                } else {
+                    FuturesUnordered::new()
+                }
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0], 2);
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items_more_than_min() {
+        let items = request_min_new_items(
+            3,
+            1,
+            |i| {
+                let responses = vec![Resp::ok(&[i]), Resp::ok(&[i])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], 0);
+    }
+
+    #[tokio::test]
+    async fn test_request_min_new_items_no_requests() {
+        let items = request_min_new_items(
+            0,
+            0,
+            |i| {
+                let responses = vec![Resp::ok(&[i]), Resp::ok(&[i])];
+                client(responses)
+            },
+            Ok,
+        )
+        .await
+        .unwrap();
+        assert!(items.is_empty());
+    }
+}

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -1,0 +1,91 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use tokio::task::JoinHandle;
+use xayn_discovery_engine_providers::{Article, Error, Market};
+
+use crate::engine::GenericError;
+
+async fn request_new_items(
+    markets: Vec<Market>,
+    request_fn: impl Fn(Market) -> JoinHandle<Result<Vec<Article>, Error>> + Send,
+    filter_fn: impl FnOnce(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send,
+) -> Result<Vec<Article>, GenericError> {
+    let mut requests = markets
+        .into_iter()
+        .map(|market| request_fn(market))
+        .collect::<FuturesUnordered<_>>();
+
+    let mut articles = Vec::new();
+    let mut error = None;
+
+    while let Some(handle) = requests.next().await {
+        // should we also push handle errors?
+        if let Ok(result) = handle {
+            match result {
+                Ok(batch) => articles.extend(batch),
+                Err(err) => {
+                    error.replace(err.into());
+                }
+            }
+        }
+    }
+
+    let articles = filter_fn(articles)
+        .map_err(|err| error.replace(err))
+        .unwrap_or_default();
+
+    if articles.is_empty() && error.is_some() {
+        Err(error.unwrap(/* nonempty error */))
+    } else {
+        Ok(articles)
+    }
+}
+
+pub(super) async fn request_min_new_items(
+    markets: Vec<Market>,
+    max_requests: u32,
+    min_articles: usize,
+    request_fn: impl Fn(Market, usize) -> JoinHandle<Result<Vec<Article>, Error>> + Send + Sync,
+    filter_fn: impl Fn(Vec<Article>) -> Result<Vec<Article>, GenericError> + Send + Sync,
+) -> Result<Vec<Article>, GenericError> {
+    let mut articles = Vec::new();
+    let mut error = None;
+
+    for page in 1..=max_requests as usize {
+        match request_new_items(
+            markets.clone(),
+            |market| request_fn(market, page),
+            |articles| filter_fn(articles),
+        )
+        .await
+        {
+            Ok(batch) => articles.extend(batch),
+            Err(err) => {
+                error.replace(err);
+            }
+        };
+
+        if articles.len() >= min_articles {
+            break;
+        }
+    }
+
+    if articles.is_empty() && error.is_some() {
+        Err(error.unwrap(/* nonempty error */))
+    } else {
+        Ok(articles)
+    }
+}

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -110,7 +110,7 @@ mod tests {
     fn client(responses: Vec<Resp>) -> Requests<u32> {
         responses
             .into_iter()
-            .map(|response| tokio::spawn(async move { response.0 }))
+            .map(|response| tokio::spawn(async { response.0 }))
             .collect::<FuturesUnordered<_>>()
     }
 
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_request_min_new_items_only() {
+    async fn test_request_min_new_items_only_errors() {
         let res = request_min_new_items(
             2,
             2,

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 use super::{
-    common::{request_min_new_items, spawn_requests_for_markets},
+    common::{create_requests_for_markets, request_min_new_items},
     Ops,
 };
 
@@ -107,7 +107,7 @@ impl Ops for PersonalizedNews {
             self.max_requests,
             self.min_articles,
             |request_num| {
-                spawn_requests_for_markets(markets.clone(), |market| {
+                create_requests_for_markets(markets.clone(), |market| {
                     let page = request_num as usize + 1;
                     spawn_news_request(
                         self.client.clone(),

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::chain;
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::Uuid;
@@ -24,6 +23,7 @@ use xayn_discovery_engine_providers::{
     Article,
     Client,
     CommonQueryParts,
+    Error,
     Filter,
     Market,
     NewsQuery,
@@ -38,7 +38,7 @@ use crate::{
     },
 };
 
-use super::Ops;
+use super::{common::request_min_new_items, Ops};
 
 /// Stack operations customized for personalized news items.
 pub(crate) struct PersonalizedNews {
@@ -47,8 +47,8 @@ pub(crate) struct PersonalizedNews {
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
     semantic_filter_config: SemanticFilterConfig,
-    _max_requests: u32,
-    _min_articles: usize,
+    max_requests: u32,
+    min_articles: usize,
 }
 
 impl PersonalizedNews {
@@ -60,8 +60,8 @@ impl PersonalizedNews {
             page_size: config.page_size,
             semantic_filter_config: SemanticFilterConfig::default(),
             excluded_sources: config.excluded_sources.clone(),
-            _max_requests: config.max_requests,
-            _min_articles: config.min_articles,
+            max_requests: config.max_requests,
+            min_articles: config.min_articles,
         }
     }
 
@@ -95,49 +95,29 @@ impl Ops for PersonalizedNews {
             return Ok(vec![]);
         }
 
-        let mut articles = Vec::new();
-        let mut errors = Vec::new();
         let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
             filter.add_keyword(kp.words())
         }));
-
+        let markets = self.markets.read().await.clone();
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
-        let mut requests = self
-            .markets
-            .read()
-            .await
-            .iter()
-            .cloned()
-            .map(|market| {
+
+        request_min_new_items(
+            markets,
+            self.max_requests,
+            self.min_articles,
+            |market, page| {
                 spawn_news_request(
                     self.client.clone(),
                     market,
                     filter.clone(),
                     self.page_size,
+                    page,
                     excluded_sources.clone(),
                 )
-            })
-            .collect::<FuturesUnordered<_>>();
-
-        while let Some(handle) = requests.next().await {
-            // should we also push handle errors?
-            if let Ok(result) = handle {
-                match result {
-                    Ok(batch) => articles.extend(batch),
-                    Err(err) => errors.push(err.into()),
-                }
-            }
-        }
-
-        let articles = Self::filter_articles(history, stack, articles)
-            .map_err(|err| errors.push(err))
-            .unwrap_or_default();
-
-        if articles.is_empty() && !errors.is_empty() {
-            Err(errors.pop().unwrap(/* nonempty errors */))
-        } else {
-            Ok(articles)
-        }
+            },
+            |articles| Self::filter_articles(history, stack, articles),
+        )
+        .await
     }
 
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError> {
@@ -153,15 +133,16 @@ fn spawn_news_request(
     market: Market,
     filter: Arc<Filter>,
     page_size: usize,
+    page: usize,
     excluded_sources: Arc<Vec<String>>,
-) -> JoinHandle<Result<Vec<Article>, xayn_discovery_engine_providers::Error>> {
+) -> JoinHandle<Result<Vec<Article>, Error>> {
     tokio::spawn(async move {
         let market = market;
         let query = NewsQuery {
             common: CommonQueryParts {
                 market: &market,
                 page_size,
-                page: 1,
+                page,
                 excluded_sources: &excluded_sources,
             },
             filter,

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -23,7 +23,6 @@ use xayn_discovery_engine_providers::{
     Article,
     Client,
     CommonQueryParts,
-    Error,
     Filter,
     Market,
     NewsQuery,
@@ -140,7 +139,7 @@ fn spawn_news_request(
     page_size: usize,
     page: usize,
     excluded_sources: Arc<Vec<String>>,
-) -> JoinHandle<Result<Vec<Article>, Error>> {
+) -> JoinHandle<Result<Vec<Article>, GenericError>> {
     tokio::spawn(async move {
         let market = market;
         let query = NewsQuery {
@@ -152,7 +151,6 @@ fn spawn_news_request(
             },
             filter,
         };
-
-        client.query_articles(&query).await
+        client.query_articles(&query).await.map_err(Into::into)
     })
 }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -107,8 +107,9 @@ impl Ops for PersonalizedNews {
         request_min_new_items(
             self.max_requests,
             self.min_articles,
-            |page| {
+            |request_num| {
                 spawn_requests_for_markets(markets.clone(), |market| {
+                    let page = request_num as usize + 1;
                     spawn_news_request(
                         self.client.clone(),
                         market,


### PR DESCRIPTION
Ticket:
- [TY-2523]

Summary:
- make more requests if we don't have `min_articles` of articles. the number of requests is limited by `max_requests`
- added tests

During the implementation, I thought about whether the whole thing could also be implemented with `tower`. Writing the layers will require some thinking but long term I think we would benefit from it as it is more flexible. I saw that `kube` rebuild their client code with tower so there is a good reference that we can use. It would be nice if we could do a small poc that implements this pr in form of a tower service.
 


[TY-2523]: https://xainag.atlassian.net/browse/TY-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ