### PR TITLE
[Merged by Bors] - Switch CI docker container from hard-coded tag to `v1` tag

### DIFF
--- a/.github/workflows/ci_build_android.yml
+++ b/.github/workflows/ci_build_android.yml
@@ -17,7 +17,7 @@ jobs:
   build-android-libs:
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 45
     strategy:
       matrix:

--- a/.github/workflows/ci_flutter_example.yml
+++ b/.github/workflows/ci_flutter_example.yml
@@ -44,7 +44,7 @@ jobs:
     # that needs to exist during the linking process.
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   selection:
     runs-on: ubuntu-20.04
-
     # Set job outputs to values from filter step
     outputs:
       dart: ${{ steps.filter.outputs.dart }}
@@ -48,7 +47,7 @@ jobs:
     if: ${{ needs.selection.outputs.dart == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -67,7 +66,7 @@ jobs:
     if: ${{ needs.selection.outputs.dart == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -87,7 +86,7 @@ jobs:
     if: ${{ always()}}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 20
     steps:
       - name: Check cargo-test
@@ -114,7 +113,7 @@ jobs:
     if: ${{ needs.selection.outputs.dart == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -159,7 +158,7 @@ jobs:
     if: ${{ needs.selection.outputs.dart == 'true' || needs.selection.outputs.flutter == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -178,7 +177,7 @@ jobs:
     if: ${{ needs.selection.outputs.dart == 'true' || needs.selection.outputs.flutter == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -215,7 +214,7 @@ jobs:
     if: ${{ needs.selection.outputs.rust == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
@@ -233,7 +232,7 @@ jobs:
     if: ${{ needs.selection.outputs.rust == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
@@ -252,7 +251,7 @@ jobs:
     if: ${{ needs.selection.outputs.rust == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
@@ -271,7 +270,7 @@ jobs:
     if: ${{ needs.selection.outputs.rust == 'true' }}
     runs-on: ubuntu-20.04
     container:
-      image: xaynetci/yellow:9135de0
+      image: xaynetci/yellow:v1
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
 
   release:
     runs-on: ubuntu-20.04
-    #container:
-      #image: xaynetci/yellow:9135de0
+    container:
+      image: xaynetci/yellow:v1
     timeout-minutes: 10
     needs: [build-ios-libs, build-android-libs]
     steps:
@@ -34,11 +34,10 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: Setup job
-        uses: ./.github/actions/setup-job
+        uses: ./.github/actions/setup-job-docker
         with:
           dart: true
           rust: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts
         id: artifacts

--- a/justfile
+++ b/justfile
@@ -226,7 +226,7 @@ dry-run-release:
 _compile-android target:
     # See also: https://developer.android.com/studio/projects/gradle-external-native-builds#jniLibs
     cd "$RUST_WORKSPACE"; \
-        cargo ndk -t $(echo "{{target}}" | sed 's/[^ ]* */&/g') -p $ANDROID_PLATFORM_VERSION \
+        cargo ndk --bindgen -t $(echo "{{target}}" | sed 's/[^ ]* */&/g') -p $ANDROID_PLATFORM_VERSION \
         -o "{{justfile_directory()}}/$FLUTTER_WORKSPACE/android/src/main/jniLibs" build \
         --release -p xayn-discovery-engine-bindings --locked
 


### PR DESCRIPTION
[This commit](https://github.com/xaynetwork/xayn_docker/commit/f3bcb13d6ec3bdb0d14178106443caf3c6ca244b) from the `xayn_docker` repo adds rsync and allows the `release` tag to be created.