### PR TITLE
[Merged by Bors] - Use http connection for public external dependencies

### DIFF
--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   xayn_discovery_engine:
     git:
-      url: git@gitlab.com:xayn/xayn_discovery_engine_release.git
+      url: https://gitlab.com/xayn/xayn_discovery_engine_release
       ref: change_me_to_commit_ref
       path: discovery_engine
 


### PR DESCRIPTION
This avoids the import of the known hosts and the export of your
ssh key to gitlab. 

