### PR TITLE
[Merged by Bors] - Make sure release artifacts are copied to the right location, even if they already exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     timeout-minutes: 10
     needs: [build-ios-libs, build-android-libs]
     steps:
+      - name: Clean temp directory
+        working-directory: ${{ runner.temp }}
+        run: |
+          rm -rf ./artifacts
+      
       - name: Install SSH key gitlab
         uses: shimataro/ssh-key-action@3c9b0fc6f2d223b8450b02a0445f526350fc73e0 # v2.3.1
         with:


### PR DESCRIPTION
This can currently occur because, on our dedicated github runner, the working directory
is not cleaned after each run. A proper fix for this issue is tracked in TY-2664.