### PR TITLE
[Merged by Bors] - Add value getter to Source

### DIFF
--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -36,6 +36,8 @@ class Source extends Equatable {
   @override
   String toString() => _repr;
 
+  String get value => _repr;
+
   /// Must only be created anew by the Engine.
   ///
   /// Through other places can (de-)serialize it, iff they do not


### PR DESCRIPTION
In dart `toString` should be used only to inspect the object for debug.
This PR add `value` to get the inner string value of the source.