### PR TITLE
[Merged by Bors] - TY-2713 make market optional in endpoint query

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -424,7 +424,7 @@ where
         for market in markets.iter() {
             let news_query = NewsQuery {
                 common: CommonQueryParts {
-                    market,
+                    market: Some(market),
                     page_size: scaled_page_size,
                     page: page as usize,
                     excluded_sources: &excluded_sources,

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -129,7 +129,7 @@ fn spawn_headlines_request(
         let market = market;
         let query = HeadlinesQuery {
             common: CommonQueryParts {
-                market: &market,
+                market: Some(&market),
                 page_size,
                 page,
                 excluded_sources: &excluded_sources,

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -145,7 +145,7 @@ fn spawn_news_request(
         let market = market;
         let query = NewsQuery {
             common: CommonQueryParts {
-                market: &market,
+                market: Some(&market),
                 page_size,
                 page,
                 excluded_sources: &excluded_sources,

--- a/discovery_engine_core/tooling/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/bin/newscatcher.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         println!("Fetching page {} of {}", page, total_pages);
         let params = HeadlinesQuery {
             common: CommonQueryParts {
-                market: &market,
+                market: Some(&market),
                 page_size: 100,
                 page,
                 excluded_sources: &[],


### PR DESCRIPTION
related #281 #283 #292

**Summary**

allow `market` to be optional in queries to the newscatcher endpoint.