### PR TITLE
[Merged by Bors] - TY-2589 Updated to tract 0.16.3 and use a patched tract-linalg. [1]

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -339,12 +339,9 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "winapi",
 ]
 
 [[package]]
@@ -1259,9 +1256,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "liquid"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e930310cf4334c4936ae18737500a57739c69442b5c42bae114d619af54b82"
+checksum = "cb6e6551b4c8a2045351f0853b54807b21080176a055b754dc0ad29428edf293"
 dependencies = [
  "doc-comment",
  "kstring",
@@ -1273,12 +1270,11 @@ dependencies = [
 
 [[package]]
 name = "liquid-core"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eae470f061bfc53607283906de925ab67ed57a341e827146e3b241699a1dcde"
+checksum = "8ea8f6c13e8ae36bce67fc1eaacf32c13b26d16576b7ee2ec9de33a3980cefd6"
 dependencies = [
  "anymap2",
- "chrono",
  "itertools",
  "kstring",
  "liquid-derive",
@@ -1286,13 +1282,14 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+ "time 0.3.9",
 ]
 
 [[package]]
 name = "liquid-derive"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510e456700da1afe07603913b0da5a2595f2482656ade07abf719aae7501f0a"
+checksum = "d82d81028aba7e869d0aa423ae926a7f15fd55ca576baac279ed38020b180a56"
 dependencies = [
  "proc-macro2",
  "proc-quote",
@@ -1301,17 +1298,17 @@ dependencies = [
 
 [[package]]
 name = "liquid-lib"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341259f779ff663bdf1fc478bddb2ca51fda25414006dc69395eddfac07e0a4"
+checksum = "8256326835eae262affdc6df8743d9e1b917354ba3c8c380e6238426a8097564"
 dependencies = [
- "chrono",
  "itertools",
  "kstring",
  "liquid-core",
  "once_cell",
  "percent-encoding",
  "regex",
+ "time 0.3.9",
  "unicode-segmentation",
 ]
 
@@ -1543,6 +1540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -2586,6 +2592,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dae90e816dea4439c86dc0b691d33f06b210c88db4a4f717b0576d8f06171e"
+checksum = "9594754f9e42e8e3118b48ebbd035afb647e2167c2fd63f0d8df704aa0dd2516"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -2786,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1241dc05ad240997e0106db8538efbbf7c03ce4f37060b3dac662acb9530fbba"
+checksum = "8f17b4f511942899e0caa8f50f3d41d37f142fcd5437e11230fe3da752e30aa4"
 dependencies = [
  "anyhow",
  "educe",
@@ -2805,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d49d3b0e441151f5fcdad555906061c7a2cfcb2500594eb00fbd5702848700"
+checksum = "bc2ed4817da3e2bd1847b999a9748cde5b34fc785a31ee5e589e51bf2a078dac"
 dependencies = [
  "derive-new",
  "educe",
@@ -2817,9 +2841,8 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3192f979d3130039a117a95f84cd23c8769569abb703da12cdc3d6d5e1f0a7b"
+version = "0.16.3"
+source = "git+https://github.com/xaynetwork/tract.git?branch=android-relocation-patch#78a1ce5425c6fbaf3ab75a2d10a0c56c999c0d4f"
 dependencies = [
  "cc",
  "derive-new",
@@ -2841,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933e8a261237086429684bc8c47cdadeaaebe644fe44b91eba8439dd9c868ed8"
+checksum = "1acdc9abc0bdee43d1fc43eddc30a47524324301e350d227f6f6751d9de477f1"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2856,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73af98ea69d0bd9a2b181acb71cda5a7917caf09a69c9cab882d38b281b6e25c"
+checksum = "16bbed3111395175353a0bbc2e47a4bb1ae7aa8aa269380623ad84609e7fce56"
 dependencies = [
  "bytes",
  "derive-new",
@@ -2876,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2b96c7cefa72342053445d03a1d465b1ea426302faba6d121dd544bc70294f"
+checksum = "99fdcfb4a5a7e521a90a09796cfb064a6a34ff2a8f1863f684b0e5df45f1f45d"
 dependencies = [
  "educe",
  "tract-nnef",
@@ -3425,5 +3448,5 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
+ "time 0.1.43",
 ]

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -24,5 +24,9 @@ branch = "main"
 git = "https://github.com/xaynetwork/xayn_dart_api_dl.git"
 branch = "main"
 
+[patch.crates-io.tract-linalg]
+git = "https://github.com/xaynetwork/tract.git"
+branch = "android-relocation-patch"
+
 [profile.dev.package.tract-core]
 opt-level = 3

--- a/justfile
+++ b/justfile
@@ -228,8 +228,7 @@ _compile-android target:
     cd "$RUST_WORKSPACE"; \
         cargo ndk --bindgen -t $(echo "{{target}}" | sed 's/[^ ]* */&/g') -p $ANDROID_PLATFORM_VERSION \
         -o "{{justfile_directory()}}/$FLUTTER_WORKSPACE/android/src/main/jniLibs" build \
-        --release \
-        -p xayn-discovery-engine-bindings --locked
+        --release -p xayn-discovery-engine-bindings --locked
 
 compile-android-local: _codegen-order-workaround
     #!/usr/bin/env sh

--- a/justfile
+++ b/justfile
@@ -228,7 +228,8 @@ _compile-android target:
     cd "$RUST_WORKSPACE"; \
         cargo ndk --bindgen -t $(echo "{{target}}" | sed 's/[^ ]* */&/g') -p $ANDROID_PLATFORM_VERSION \
         -o "{{justfile_directory()}}/$FLUTTER_WORKSPACE/android/src/main/jniLibs" build \
-        --release -p xayn-discovery-engine-bindings --locked
+        --release \
+        -p xayn-discovery-engine-bindings --locked
 
 compile-android-local: _codegen-order-workaround
     #!/usr/bin/env sh


### PR DESCRIPTION

Reviewers should probably also take a look at the patch branch: 

https://github.com/xaynetwork/tract/compare/v0.16.3...xaynetwork:android-relocation-patch

Be aware that the solution implemented by sonos/tract will likely be somewhat different
(i.e. only changing the asm for android, maybe also using different asm).

This was tested with `cross` for the non-neon implementation and with `cargo dinghy`
on the armv7a phone we have for the neon implementation.

**References:**

- [TY-2589](https://xainag.atlassian.net/browse/TY-2589)