### PR TITLE
[Merged by Bors] - TY-2682 update key phrases for the relevant market

### DIFF
--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -66,7 +66,7 @@ impl Ranker for xayn_ai::ranker::Ranker {
             reaction.reaction.into(),
             &reaction.snippet,
             &reaction.smbert_embedding,
-            &("", "").into(), // TODO: TY-2682
+            &reaction.market,
         );
         Ok(())
     }


### PR DESCRIPTION
**References**

- [TY-2682]
- requires #302, #307
- followed by #310

**Summary**

- since #307 made the market available to the user reaction we can just use it here


[TY-2682]: https://xainag.atlassian.net/browse/TY-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ