### PR TITLE
[Merged by Bors] - TY-2685 remove key phrases of removed markets

### DIFF
--- a/discovery_engine_core/ai/xayn-ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/system.rs
@@ -96,6 +96,11 @@ impl CoiSystem {
             self.config.gamma(),
         )
     }
+
+    /// Removes all key phrases associated to the markets.
+    pub(crate) fn remove_key_phrases(&self, markets: &[Market], key_phrases: &mut KeyPhrases) {
+        key_phrases.remove(markets);
+    }
 }
 
 /// Updates the positive coi closest to the embedding or creates a new one if it's too far away.

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/public.rs
@@ -82,6 +82,11 @@ impl Ranker {
         self.0.take_key_phrases(market, top)
     }
 
+    /// Removes all key phrases associated to the markets.
+    pub fn remove_key_phrases(&mut self, markets: &[Market]) {
+        self.0.remove_key_phrases(markets);
+    }
+
     /// Returns the positive cois.
     pub fn positive_cois(&self) -> &[PositiveCoi] {
         self.0.positive_cois()

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/system.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/system.rs
@@ -151,6 +151,12 @@ impl Ranker {
         )
     }
 
+    /// Removes all key phrases associated to the markets.
+    pub(crate) fn remove_key_phrases(&mut self, markets: &[Market]) {
+        self.coi
+            .remove_key_phrases(markets, &mut self.state.key_phrases);
+    }
+
     /// Returns the positive cois.
     pub(crate) fn positive_cois(&self) -> &[PositiveCoi] {
         self.state.user_interests.positive.as_slice()


### PR DESCRIPTION
**References**

- [TY-2685]
- story/feature branch `TY-2653-key_phrase_market`
- requires #326
- followed by #328

**Summary**

- add & expose `KeyPhrases::remove()` to remove key phrases for given markets


[TY-2685]: https://xainag.atlassian.net/browse/TY-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ