### PR TITLE
[Merged by Bors] - TY-2719 smbert snippet

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -434,7 +434,13 @@ where
             .into_iter()
             .filter_map(|article| {
                 self.ranker
-                    .compute_smbert(&article.title)
+                    .compute_smbert(
+                        article
+                            .excerpt
+                            .is_empty()
+                            .then(|| &article.title)
+                            .unwrap_or(&article.excerpt),
+                    )
                     .map_err(Error::Ranker)
                     .and_then(|embedding| {
                         document_from_article(article, stack_id, embedding).map_err(Error::Document)

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -688,7 +688,7 @@ fn ai_config_from_json(json: &str) -> Figment {
     Figment::new()
         .merge(Serialized::defaults(CoiSystemConfig::default()))
         .merge(Serialized::default("kpe.token_size", 150))
-        .merge(Serialized::default("smbert.token_size", 52))
+        .merge(Serialized::default("smbert.token_size", 150))
         .merge(Json::string(json))
 }
 
@@ -720,7 +720,7 @@ mod tests {
     fn test_ai_config_from_json_default() -> Result<(), Box<dyn Error>> {
         let ai_config = ai_config_from_json("{}");
         assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
-        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 52);
+        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 150);
         assert_eq!(
             ai_config.extract::<CoiSystemConfig>()?,
             CoiSystemConfig::default(),

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -107,6 +107,15 @@ pub struct Article {
     pub published_date: NaiveDateTime,
 }
 
+impl Article {
+    /// Gets the excerpt or falls back to the title if the excerpt is empty.
+    pub fn excerpt_or_title(&self) -> &str {
+        (!self.excerpt.is_empty())
+            .then(|| &self.excerpt)
+            .unwrap_or(&self.title)
+    }
+}
+
 // Taken from https://github.com/serde-rs/serde/issues/1098#issuecomment-760711617
 fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where


### PR DESCRIPTION
**References**

- [TY-2719]

**Summary**

- use `Article`'s excerpt instead of title for smbert, fall back to title if excerpt is empty
- set smbert default token size to 150


[TY-2719]: https://xainag.atlassian.net/browse/TY-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ