### PR TITLE
[Merged by Bors] - TY-2605 initialize trusted stack

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -52,6 +52,7 @@ use crate::{
         BoxedOps,
         BreakingNews,
         Data as StackData,
+        FavouriteNews,
         Id as StackId,
         PersonalizedNews,
         Stack,
@@ -660,6 +661,7 @@ impl XaynAiEngine {
         let stack_ops = vec![
             Box::new(BreakingNews::new(&endpoint_config, client.clone())) as BoxedOps,
             Box::new(PersonalizedNews::new(&endpoint_config, client.clone())) as BoxedOps,
+            Box::new(FavouriteNews::new(&endpoint_config, client.clone())) as BoxedOps,
         ];
 
         if let Some(state) = state {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -52,10 +52,10 @@ use crate::{
         BoxedOps,
         BreakingNews,
         Data as StackData,
-        FavouriteNews,
         Id as StackId,
         PersonalizedNews,
         Stack,
+        TrustedNews,
     },
 };
 
@@ -661,7 +661,7 @@ impl XaynAiEngine {
         let stack_ops = vec![
             Box::new(BreakingNews::new(&endpoint_config, client.clone())) as BoxedOps,
             Box::new(PersonalizedNews::new(&endpoint_config, client.clone())) as BoxedOps,
-            Box::new(FavouriteNews::new(&endpoint_config, client.clone())) as BoxedOps,
+            Box::new(TrustedNews::new(&endpoint_config, client.clone())) as BoxedOps,
         ];
 
         if let Some(state) = state {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -660,8 +660,8 @@ impl XaynAiEngine {
         let endpoint_config = config.into();
         let stack_ops = vec![
             Box::new(BreakingNews::new(&endpoint_config, client.clone())) as BoxedOps,
-            Box::new(PersonalizedNews::new(&endpoint_config, client.clone())) as BoxedOps,
             Box::new(TrustedNews::new(&endpoint_config, client.clone())) as BoxedOps,
+            Box::new(PersonalizedNews::new(&endpoint_config, client.clone())) as BoxedOps,
         ];
 
         if let Some(state) = state {

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -40,7 +40,7 @@ pub use self::ops::Ops;
 pub(crate) use self::{
     data::Data,
     filters::normalize,
-    ops::{breaking::BreakingNews, personalized::PersonalizedNews},
+    ops::{breaking::BreakingNews, favourite::FavouriteNews, personalized::PersonalizedNews},
 };
 
 /// Errors that could occur while manipulating a stack.

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -40,7 +40,7 @@ pub use self::ops::Ops;
 pub(crate) use self::{
     data::Data,
     filters::normalize,
-    ops::{breaking::BreakingNews, favourite::FavouriteNews, personalized::PersonalizedNews},
+    ops::{breaking::BreakingNews, personalized::PersonalizedNews, trusted::TrustedNews},
 };
 
 /// Errors that could occur while manipulating a stack.


### PR DESCRIPTION
previously related #281 #283 #292 #301 #304 #317

**Summary**

Initializes the trusted stack for engine initialization.

note: a dart integration test fails if the trusted stack is added as the last of the stacks.
the test should be fixed, perhaps separately.