### PR TITLE
[Merged by Bors] - TY-2726 key phrase selection tests

### DIFF
--- a/discovery_engine_core/ai/rubert/src/pooler.rs
+++ b/discovery_engine_core/ai/rubert/src/pooler.rs
@@ -35,6 +35,12 @@ where
 /// The embedding is of shape `(embedding_size,)`.
 pub type Embedding1 = Embedding<Ix1>;
 
+impl<const N: usize> From<[f32; N]> for Embedding<Ix1> {
+    fn from(array: [f32; N]) -> Self {
+        Array::from_vec(array.into()).into()
+    }
+}
+
 /// A 2-dimensional sequence embedding.
 ///
 /// The embedding is of shape `(token_size, embedding_size)`.

--- a/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
@@ -258,7 +258,7 @@ where
                 .filter_map(|(j, element)| (i != j).then(|| prepare(*element)))
                 .reduce(|x, y| reduce(x, y))
                 .map(|reduced| finalize(reduced, i < lane.len()))
-                .unwrap_or_default()
+                .unwrap_or(f32::NAN)
         })
         .collect::<Array1<_>>()
         .insert_axis(axis)
@@ -508,7 +508,7 @@ mod tests {
             |_, _| unreachable!(),
             |_, _| unreachable!(),
         );
-        assert!(reduced.is_empty());
+        assert_eq!(reduced.shape(), [1, 0]);
 
         let reduced = reduce_without_diag(
             ArrayView2::from_shape((0, 4), &[]).unwrap(),
@@ -517,7 +517,7 @@ mod tests {
             |_, _| unreachable!(),
             |_, _| unreachable!(),
         );
-        assert_approx_eq!(f32, reduced, [[0., 0., 0., 0.]]);
+        assert_approx_eq!(f32, reduced, [[f32::NAN, f32::NAN, f32::NAN, f32::NAN]]);
     }
 
     #[test]
@@ -529,7 +529,7 @@ mod tests {
             |reduced, _| reduced,
             |reduced, _| reduced,
         );
-        assert_approx_eq!(f32, reduced, [[0.]]);
+        assert_approx_eq!(f32, reduced, [[f32::NAN]]);
 
         let reduced = reduce_without_diag(
             Array1::range(1., 5., 1.).into_shape((2, 2)).unwrap(),

--- a/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
@@ -591,6 +591,14 @@ mod tests {
     }
 
     #[test]
+    fn test_argmax() {
+        assert!(argmax([] as [f32; 0]).is_none());
+        assert_eq!(argmax([2., 0., 1.]).unwrap(), 0);
+        assert_eq!(argmax([1., 2., 0.]).unwrap(), 1);
+        assert_eq!(argmax([0., 1., 2.]).unwrap(), 2);
+    }
+
+    #[test]
     fn test_update_key_phrases_empty() {
         let mut key_phrases = KeyPhrases::default();
         let cois = create_pos_cois(&[[1., 0., 0.]]);

--- a/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unify_key_phrases_empty() {
+    fn test_unify_empty() {
         let key_phrases = vec![];
         let candidates = [];
         let market = ("AA", "aa").into();
@@ -452,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unify_key_phrases_no_candidates() {
+    fn test_unify_no_candidates() {
         let key_phrases = vec![
             KeyPhrase::new("key", [1., 0., 0.], ("AA", "aa")).unwrap(),
             KeyPhrase::new("phrase", [1., 1., 0.], ("AA", "aa")).unwrap(),
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unify_key_phrases_only_candidates() {
+    fn test_unify_only_candidates() {
         let key_phrases = vec![];
         let candidates = ["key".into(), "phrase".into()];
         let market = ("AA", "aa").into();
@@ -482,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unify_key_phrases_duplicate() {
+    fn test_unify_duplicate() {
         let key_phrases = vec![
             KeyPhrase::new("key", [1., 0., 0.], ("AA", "aa")).unwrap(),
             KeyPhrase::new("phrase", [1., 1., 0.], ("AA", "aa")).unwrap(),
@@ -604,6 +604,14 @@ mod tests {
     }
 
     #[test]
+    fn test_argmax() {
+        assert!(argmax([] as [f32; 0]).is_none());
+        assert_eq!(argmax([2., 0., 1.]).unwrap(), 0);
+        assert_eq!(argmax([1., 2., 0.]).unwrap(), 1);
+        assert_eq!(argmax([0., 1., 2.]).unwrap(), 2);
+    }
+
+    #[test]
     fn test_similarities_empty() {
         let key_phrases = [];
         let coi_point = [1., 0., 0.].into();
@@ -650,14 +658,6 @@ mod tests {
             ],
             epsilon = 1e-5,
         );
-    }
-
-    #[test]
-    fn test_argmax() {
-        assert!(argmax([] as [f32; 0]).is_none());
-        assert_eq!(argmax([2., 0., 1.]).unwrap(), 0);
-        assert_eq!(argmax([1., 2., 0.]).unwrap(), 1);
-        assert_eq!(argmax([0., 1., 2.]).unwrap(), 2);
     }
 
     #[test]


### PR DESCRIPTION
**References**

- [TY-2726]
- #299, #302

**Summary**

- simplify test setup
- add tests for the remaining uncovered key phrase selection subfunctionality
- make `reduce_without_diag()` more robust in edge cases
- simplify `reduce_without_diag()` and `argmax()` function signatures
- generalize `is_selected()` and `select()` function signatures


[TY-2726]: https://xainag.atlassian.net/browse/TY-2726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ