### PR TITLE
[Merged by Bors] - Only return errors when there are some

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -602,10 +602,10 @@ async fn update_stacks<'a>(
     }
 
     // only return an error if all stacks failed
-    if errors.len() < stacks.len() {
-        Ok(())
-    } else {
+    if !errors.is_empty() && errors.len() >= stacks.len() {
         Err(Error::Errors(errors))
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
It could happen that we have no stacks and no errors, in that case an error with an empty list of error was returned.
This PR change the condition to make it a bit more explicit on the cases in which we want to return an error.