### PR TITLE
[Merged by Bors] - TY-2734 expose positive and negative cois in ranker trait

### DIFF
--- a/discovery_engine_core/ai/xayn-ai/src/coi/point.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/point.rs
@@ -32,7 +32,7 @@ use crate::{
 #[obake(version("0.3.0"))]
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(PartialEq)]
-pub(crate) struct PositiveCoi {
+pub struct PositiveCoi {
     #[obake(cfg(">=0.0"))]
     pub(super) id: CoiId,
     #[obake(cfg(">=0.0"))]
@@ -90,7 +90,7 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
 
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(PartialEq)]
-pub(crate) struct NegativeCoi {
+pub struct NegativeCoi {
     pub(super) id: CoiId,
     pub(super) point: Embedding,
     #[derivative(PartialEq = "ignore")]
@@ -107,7 +107,7 @@ impl NegativeCoi {
     }
 }
 
-pub(crate) trait CoiPoint {
+pub trait CoiPoint {
     /// Gets the coi id.
     fn id(&self) -> CoiId;
 

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/mod.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/mod.rs
@@ -25,6 +25,7 @@ pub use crate::{
     coi::{
         config::{Config as CoiSystemConfig, Error as CoiSystemConfigError},
         key_phrase::KeyPhrase,
+        point::{CoiPoint, NegativeCoi, PositiveCoi},
     },
     embedding::utils::{cosine_similarity, pairwise_cosine_similarity, Embedding},
     DocumentId,

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/public.rs
@@ -30,6 +30,8 @@ use crate::{
     UserFeedback,
 };
 
+use super::{NegativeCoi, PositiveCoi};
+
 pub struct Ranker(super::system::Ranker);
 
 impl Ranker {
@@ -78,6 +80,16 @@ impl Ranker {
     /// Takes the top key phrases from the positive cois, sorted in descending relevance.
     pub fn take_key_phrases(&mut self, top: usize) -> Vec<KeyPhrase> {
         self.0.take_key_phrases(top)
+    }
+
+    /// Returns the positive cois.
+    pub fn positive_cois(&self) -> &[PositiveCoi] {
+        self.0.positive_cois()
+    }
+
+    /// Returns the negative cois.
+    pub fn negative_cois(&self) -> &[NegativeCoi] {
+        self.0.negative_cois()
     }
 }
 

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/system.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/system.rs
@@ -26,7 +26,7 @@ use crate::{
     coi::{
         config::Config,
         key_phrase::{KeyPhrase, KeyPhrases},
-        point::UserInterests,
+        point::{NegativeCoi, PositiveCoi, UserInterests},
         CoiSystem,
     },
     data::document::UserFeedback,
@@ -148,6 +148,16 @@ impl Ranker {
             &mut self.state.key_phrases,
             top,
         )
+    }
+
+    /// Returns the positive cois.
+    pub(crate) fn positive_cois(&self) -> &[PositiveCoi] {
+        self.state.user_interests.positive.as_slice()
+    }
+
+    /// Returns the negative cois.
+    pub(crate) fn negative_cois(&self) -> &[NegativeCoi] {
+        self.state.user_interests.negative.as_slice()
     }
 }
 

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -16,7 +16,7 @@ use chrono::NaiveDateTime;
 use uuid::Uuid;
 
 use xayn_ai::{
-    ranker::{Embedding, KeyPhrase},
+    ranker::{Embedding, KeyPhrase, NegativeCoi, PositiveCoi},
     DocumentId,
     UserFeedback,
 };
@@ -45,6 +45,12 @@ pub trait Ranker {
 
     /// Computes the S-mBert embedding of the given `sequence`.
     fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError>;
+
+    /// Returns the positive cois.
+    fn positive_cois(&self) -> &[PositiveCoi];
+
+    /// Returns the negative cois.
+    fn negative_cois(&self) -> &[NegativeCoi];
 }
 
 impl Ranker for xayn_ai::ranker::Ranker {
@@ -81,6 +87,14 @@ impl Ranker for xayn_ai::ranker::Ranker {
 
     fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError> {
         self.compute_smbert(sequence).map_err(Into::into)
+    }
+
+    fn positive_cois(&self) -> &[PositiveCoi] {
+        self.positive_cois()
+    }
+
+    fn negative_cois(&self) -> &[NegativeCoi] {
+        self.negative_cois()
     }
 }
 


### PR DESCRIPTION
Ticket:
- [TY-2734]

Summary:
- Added two methods to have access to the `Vec<PositiveCois>` and `Vec<NegativeCois>` of the ranker.
- Alternatively both methods could also return `Vec<&dyn CoiPoint>`. However, we would have to create a new vector each time we call one of the methods.

[TY-2734]: https://xainag.atlassian.net/browse/TY-2734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ