### PR TITLE
[Merged by Bors] - TY-2691 topic search events

### DIFF
--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
 import 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart';
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart';
@@ -149,11 +150,12 @@ class ClientEvent with _$ClientEvent {
     UserReaction userReaction,
   ) = UserReactionChanged;
 
-  /// Event created when the user starts a new active search.
-  /// `isTopic` indicates whether `queryTerm` is a topic.
+  /// Event created when the user starts a new active search. `searchBy`
+  /// determines what `term` is, e.g. [SearchBy.query] indicates that `term` is
+  /// a query term.
   @Implements<SearchClientEvent>()
-  @Assert('queryTerm != ""')
-  const factory ClientEvent.searchRequested(String queryTerm, bool isTopic) =
+  @Assert('term != ""')
+  const factory ClientEvent.searchRequested(String term, SearchBy searchBy) =
       SearchRequested;
 
   /// Event created when the client asks for a next batch of documents related

--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -151,8 +151,9 @@ class ClientEvent with _$ClientEvent {
 
   /// Event created when the user starts a new active search.
   @Implements<SearchClientEvent>()
-  @Assert('queryTerm != ""')
-  const factory ClientEvent.searchRequested(String queryTerm) = SearchRequested;
+  @Assert('(query != "" && topic == "") || (query == "" && topic != "")')
+  const factory ClientEvent.searchRequested(String query, String topic) =
+      SearchRequested;
 
   /// Event created when the client asks for a next batch of documents related
   /// to the current active search.

--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -150,9 +150,10 @@ class ClientEvent with _$ClientEvent {
   ) = UserReactionChanged;
 
   /// Event created when the user starts a new active search.
+  /// `isTopic` indicates whether `queryTerm` is a topic.
   @Implements<SearchClientEvent>()
-  @Assert('(query != "" && topic == "") || (query == "" && topic != "")')
-  const factory ClientEvent.searchRequested(String query, String topic) =
+  @Assert('queryTerm != ""')
+  const factory ClientEvent.searchRequested(String queryTerm, bool isTopic) =
       SearchRequested;
 
   /// Event created when the client asks for a next batch of documents related

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -347,7 +347,7 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestSearch(String queryTerm) {
     return _trySend(() async {
-      final event = ClientEvent.searchRequested(queryTerm, '');
+      final event = ClientEvent.searchRequested(queryTerm, false);
       final response = await _manager.send(event);
 
       return response.mapEvent(

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -347,6 +347,7 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestSearch(String queryTerm) {
     return _trySend(() async {
+      // TODO method for requesting by topic
       final event = ClientEvent.searchRequested(queryTerm, false);
       final response = await _manager.send(event);
 

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -46,6 +46,8 @@ import 'package:xayn_discovery_engine/src/discovery_engine_manager.dart'
     show DiscoveryEngineManager;
 import 'package:xayn_discovery_engine/src/discovery_engine_worker.dart'
     as entry_point show main;
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
+    show SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
@@ -347,7 +349,7 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestSearch(String queryTerm) {
     return _trySend(() async {
-      final event = ClientEvent.searchRequested(queryTerm, false);
+      final event = ClientEvent.searchRequested(queryTerm, SearchBy.query);
       final response = await _manager.send(event);
 
       return response.mapEvent(
@@ -368,7 +370,7 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestTopic(String topic) {
     return _trySend(() async {
-      final event = ClientEvent.searchRequested(topic, true);
+      final event = ClientEvent.searchRequested(topic, SearchBy.topic);
       final response = await _manager.send(event);
 
       return response.mapEvent(

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -347,7 +347,7 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestSearch(String queryTerm) {
     return _trySend(() async {
-      final event = ClientEvent.searchRequested(queryTerm);
+      final event = ClientEvent.searchRequested(queryTerm, '');
       final response = await _manager.send(event);
 
       return response.mapEvent(

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -347,8 +347,28 @@ class DiscoveryEngine {
   /// for such failure.
   Future<EngineEvent> requestSearch(String queryTerm) {
     return _trySend(() async {
-      // TODO method for requesting by topic
       final event = ClientEvent.searchRequested(queryTerm, false);
+      final response = await _manager.send(event);
+
+      return response.mapEvent(
+        searchRequestSucceeded: true,
+        searchRequestFailed: true,
+        engineExceptionRaised: true,
+      );
+    });
+  }
+
+  /// Requests for [Document]s of a specific `topic`.
+  ///
+  /// In response it can return:
+  /// - [SearchRequestSucceeded] for successful response, containing a list of
+  /// [Document]s
+  /// - [SearchRequestFailed] for failed response, with a reason for failure
+  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// for such failure.
+  Future<EngineEvent> requestTopic(String topic) {
+    return _trySend(() async {
+      final event = ClientEvent.searchRequested(topic, true);
       final response = await _manager.send(event);
 
       return response.mapEvent(

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -38,6 +38,8 @@ class ActiveSearch with _$ActiveSearch {
 
 @HiveType(typeId: searchByTypeId)
 enum SearchBy {
-  @HiveField(0) query,
-  @HiveField(1) topic,
+  @HiveField(0)
+  query,
+  @HiveField(1)
+  topic,
 }

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -29,6 +29,7 @@ class ActiveSearch with _$ActiveSearch {
     @HiveField(0) required String queryTerm,
     @HiveField(1) required int requestedPageNb,
     @HiveField(2) required int pageSize,
+    @HiveField(3) required bool isTopic,
   }) = _ActiveSearch;
 
   factory ActiveSearch.fromJson(Map<String, Object?> json) =>

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -16,7 +16,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hive/hive.dart'
     show HiveType, HiveField, TypeAdapter, BinaryReader, BinaryWriter;
 import 'package:xayn_discovery_engine/src/domain/repository/type_id.dart'
-    show searchTypeId;
+    show searchTypeId, searchByTypeId;
 
 part 'active_search.freezed.dart';
 part 'active_search.g.dart';
@@ -29,9 +29,15 @@ class ActiveSearch with _$ActiveSearch {
     @HiveField(0) required String queryTerm,
     @HiveField(1) required int requestedPageNb,
     @HiveField(2) required int pageSize,
-    @HiveField(3) required bool isTopic,
+    @HiveField(3) required SearchBy searchBy,
   }) = _ActiveSearch;
 
   factory ActiveSearch.fromJson(Map<String, Object?> json) =>
       _$ActiveSearchFromJson(json);
+}
+
+@HiveType(typeId: searchByTypeId)
+enum SearchBy {
+  @HiveField(0) query,
+  @HiveField(1) topic,
 }

--- a/discovery_engine/lib/src/domain/repository/type_id.dart
+++ b/discovery_engine/lib/src/domain/repository/type_id.dart
@@ -28,3 +28,4 @@ const setSourceTypeId = 12;
 const sourceTypeId = 13;
 const sourceFilterTypeId = 14;
 const sourceFilterModeTypeId = 15;
+const searchByTypeId = 16;

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -88,7 +88,7 @@ class SearchManager {
   }
 
   /// Obtain the first batch of search documents and persist to repositories.
-  Future<EngineEvent> searchRequested(String queryTerm) async {
+  Future<EngineEvent> searchRequested(String queryTerm, String _topic) async {
     await searchClosed();
 
     final search = ActiveSearch(

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -93,7 +93,8 @@ class SearchManager {
   }
 
   /// Obtain the first batch of search documents and persist to repositories.
-  Future<EngineEvent> searchRequested(String queryTerm, SearchBy searchBy) async {
+  Future<EngineEvent> searchRequested(
+      String queryTerm, SearchBy searchBy) async {
     await searchClosed();
 
     final search = ActiveSearch(

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -88,9 +88,10 @@ class SearchManager {
   }
 
   /// Obtain the first batch of search documents and persist to repositories.
-  Future<EngineEvent> searchRequested(String queryTerm, String _topic) async {
+  Future<EngineEvent> searchRequested(String queryTerm, bool isTopic) async {
     await searchClosed();
 
+    // TODO handle topic search
     final search = ActiveSearch(
       queryTerm: queryTerm,
       requestedPageNb: 1,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -22,7 +22,7 @@ import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
     show EventConfig;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch;
+    show ActiveSearch, SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document, UserReaction;
 import 'package:xayn_discovery_engine/src/domain/repository/active_document_repo.dart'
@@ -69,7 +69,7 @@ class SearchManager {
       );
 
   Future<List<api.Document>> _getSearchDocuments(ActiveSearch search) async {
-    if (search.isTopic) {
+    if (search.searchBy == SearchBy.topic) {
       // TODO handle topic searches
       throw UnimplementedError();
     }
@@ -93,14 +93,14 @@ class SearchManager {
   }
 
   /// Obtain the first batch of search documents and persist to repositories.
-  Future<EngineEvent> searchRequested(String queryTerm, bool isTopic) async {
+  Future<EngineEvent> searchRequested(String queryTerm, SearchBy searchBy) async {
     await searchClosed();
 
     final search = ActiveSearch(
       queryTerm: queryTerm,
       requestedPageNb: 1,
       pageSize: _config.maxSearchDocs,
-      isTopic: isTopic,
+      searchBy: searchBy,
     );
     final docs = await _getSearchDocuments(search);
     await _searchRepo.save(search);

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -94,7 +94,9 @@ class SearchManager {
 
   /// Obtain the first batch of search documents and persist to repositories.
   Future<EngineEvent> searchRequested(
-      String queryTerm, SearchBy searchBy) async {
+    String queryTerm,
+    SearchBy searchBy,
+  ) async {
     await searchClosed();
 
     final search = ActiveSearch(

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -69,6 +69,7 @@ class SearchManager {
       );
 
   Future<List<api.Document>> _getSearchDocuments(ActiveSearch search) async {
+    // TODO handle topic searches
     final searchDocs = await _engine.activeSearch(
       search.queryTerm,
       search.requestedPageNb,
@@ -91,11 +92,11 @@ class SearchManager {
   Future<EngineEvent> searchRequested(String queryTerm, bool isTopic) async {
     await searchClosed();
 
-    // TODO handle topic search
     final search = ActiveSearch(
       queryTerm: queryTerm,
       requestedPageNb: 1,
       pageSize: _config.maxSearchDocs,
+      isTopic: isTopic,
     );
     final docs = await _getSearchDocuments(search);
     await _searchRepo.save(search);

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -69,7 +69,11 @@ class SearchManager {
       );
 
   Future<List<api.Document>> _getSearchDocuments(ActiveSearch search) async {
-    // TODO handle topic searches
+    if (search.isTopic) {
+      // TODO handle topic searches
+      throw UnimplementedError();
+    }
+
     final searchDocs = await _engine.activeSearch(
       search.queryTerm,
       search.requestedPageNb,

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -23,7 +23,7 @@ import 'package:xayn_discovery_engine/src/discovery_engine_worker.dart'
 import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
     show Manifest;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch;
+    show ActiveSearch, SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
@@ -160,5 +160,5 @@ const mockActiveSearch = ActiveSearch(
   queryTerm: queryTerm,
   requestedPageNb: 1,
   pageSize: 20,
-  isTopic: false,
+  searchBy: SearchBy.query,
 );

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -160,4 +160,5 @@ const mockActiveSearch = ActiveSearch(
   queryTerm: queryTerm,
   requestedPageNb: 1,
   pageSize: 20,
+  isTopic: false,
 );

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -32,6 +32,7 @@ Future<void> main() async {
       queryTerm: 'example search query',
       requestedPageNb: 1,
       pageSize: 10,
+      isTopic: false,
     );
 
     setUpAll(() async {

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -17,7 +17,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:hive/hive.dart' show Box, Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch;
+    show ActiveSearch, SearchBy;
 import 'package:xayn_discovery_engine/src/infrastructure/box_name.dart'
     show searchBox;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_search_repo.dart'
@@ -32,7 +32,7 @@ Future<void> main() async {
       queryTerm: 'example search query',
       requestedPageNb: 1,
       pageSize: 10,
-      isTopic: false,
+      searchBy: SearchBy.query,
     );
 
     setUpAll(() async {

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -150,7 +150,7 @@ Future<void> main() async {
           pageSize: config.maxSearchDocs,
         );
 
-        final response = await mgr.searchRequested('example query');
+        final response = await mgr.searchRequested('example query', '');
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<SearchRequestSucceeded>());

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -148,6 +148,7 @@ Future<void> main() async {
           queryTerm: 'example query',
           requestedPageNb: 1,
           pageSize: config.maxSearchDocs,
+          isTopic: false,
         );
 
         final response = await mgr.searchRequested('example query', false);

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -150,7 +150,7 @@ Future<void> main() async {
           pageSize: config.maxSearchDocs,
         );
 
-        final response = await mgr.searchRequested('example query', '');
+        final response = await mgr.searchRequested('example query', false);
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<SearchRequestSucceeded>());

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -34,7 +34,7 @@ import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show ActiveDocumentData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch;
+    show ActiveSearch, SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document, UserReaction;
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
@@ -148,10 +148,10 @@ Future<void> main() async {
           queryTerm: 'example query',
           requestedPageNb: 1,
           pageSize: config.maxSearchDocs,
-          isTopic: false,
+          searchBy: SearchBy.query,
         );
 
-        final response = await mgr.searchRequested('example query', false);
+        final response = await mgr.searchRequested('example query', SearchBy.query);
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<SearchRequestSucceeded>());

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -151,7 +151,8 @@ Future<void> main() async {
           searchBy: SearchBy.query,
         );
 
-        final response = await mgr.searchRequested('example query', SearchBy.query);
+        final response =
+            await mgr.searchRequested('example query', SearchBy.query);
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<SearchRequestSucceeded>());


### PR DESCRIPTION
**Summary**

extends `ClientEvent.searchRequested` to be _either_ a search query term or a topic.
extends the `ActiveSearch` class accordingly.