### PR TITLE
[Merged by Bors] - Handle stacks that are not ready to ask new data

### DIFF
--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -40,7 +40,12 @@ pub use self::ops::Ops;
 pub(crate) use self::{
     data::Data,
     filters::normalize,
-    ops::{breaking::BreakingNews, personalized::PersonalizedNews, trusted::TrustedNews},
+    ops::{
+        breaking::BreakingNews,
+        personalized::PersonalizedNews,
+        trusted::TrustedNews,
+        NewItemsError,
+    },
 };
 
 /// Errors that could occur while manipulating a stack.
@@ -63,7 +68,7 @@ pub enum Error {
     },
 
     /// Failed to get new items: {0}.
-    New(#[source] GenericError),
+    New(#[source] NewItemsError),
 
     /// Failed to filter: {0}.
     Filter(#[source] GenericError),

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -32,6 +32,7 @@ use crate::{
 
 use super::{
     common::{create_requests_for_markets, request_min_new_items},
+    NewItemsError,
     Ops,
 };
 
@@ -85,7 +86,7 @@ impl Ops for BreakingNews {
         _key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
-    ) -> Result<Vec<Article>, GenericError> {
+    ) -> Result<Vec<Article>, NewItemsError> {
         let markets = self.markets.read().await.clone();
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
 
@@ -107,6 +108,7 @@ impl Ops for BreakingNews {
             |articles| Self::filter_articles(history, stack, articles),
         )
         .await
+        .map_err(Into::into)
     }
 
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError> {

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -39,6 +39,7 @@ use crate::{
 
 use super::{
     common::{create_requests_for_markets, request_min_new_items},
+    NewItemsError,
     Ops,
 };
 
@@ -92,9 +93,9 @@ impl Ops for PersonalizedNews {
         key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
-    ) -> Result<Vec<Article>, GenericError> {
+    ) -> Result<Vec<Article>, NewItemsError> {
         if key_phrases.is_empty() {
-            return Ok(vec![]);
+            return Err(NewItemsError::NotReady);
         }
 
         let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
@@ -122,6 +123,7 @@ impl Ops for PersonalizedNews {
             |articles| Self::filter_articles(history, stack, articles),
         )
         .await
+        .map_err(Into::into)
     }
 
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError> {


### PR DESCRIPTION
If a stack is not ready to return data we don't count it as successful or failed stacks.

At the moment if `TrustedSources` has no  sources and is the only stack that required to be updated we are returning an error but we should not.

This PR allows a stack to return `NotReady` as a variant of the error, if a stack is not ready we exclude it from the count of stacks w.r.t. the return of errors.

Having `new_items` returning something like
```rust
enum NewItems {
  NotReady,
  Items(Vec<Article>),
  Err(GenericError),
}
```
would be nicer but for how we are handling errors in the stack and engine it will require more changes.