### PR TITLE
[Merged by Bors] - TY-2777 port test-utils crate to DE conventions

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1192,9 +1192,9 @@ dependencies = [
  "layer",
  "ndarray",
  "rubert-tokenizer",
- "test-utils",
  "thiserror",
  "tract-onnx",
+ "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -1216,8 +1216,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "serde",
- "test-utils",
  "thiserror",
+ "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -2178,9 +2178,9 @@ dependencies = [
  "rayon",
  "rubert-tokenizer",
  "serde",
- "test-utils",
  "thiserror",
  "tract-onnx",
+ "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -2532,16 +2532,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "test-utils"
-version = "0.1.0"
-dependencies = [
- "float-cmp",
- "ndarray",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "textwrap"
@@ -3335,10 +3325,10 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "smallvec",
- "test-utils",
  "thiserror",
  "uuid",
  "xayn-discovery-engine-providers",
+ "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -3409,7 +3399,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "test-utils",
  "thiserror",
  "tokio",
  "tracing",
@@ -3417,6 +3406,7 @@ dependencies = [
  "uuid",
  "xayn-ai",
  "xayn-discovery-engine-providers",
+ "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -3438,6 +3428,16 @@ dependencies = [
  "tokio",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "xayn-discovery-engine-test-utils"
+version = "0.1.0"
+dependencies = [
+ "float-cmp",
+ "ndarray",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/discovery_engine_core/ai/kpe/Cargo.toml
+++ b/discovery_engine_core/ai/kpe/Cargo.toml
@@ -16,7 +16,7 @@ tract-onnx = "0.16.1"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }
-test-utils = { path = "../test-utils" }
+xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[bench]]
 name = "kpe"

--- a/discovery_engine_core/ai/kpe/examples/kpe.rs
+++ b/discovery_engine_core/ai/kpe/examples/kpe.rs
@@ -14,7 +14,7 @@
 
 use kpe::{Config, Pipeline};
 
-use test_utils::kpe::*;
+use xayn_discovery_engine_test_utils::kpe::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config =

--- a/discovery_engine_core/ai/kpe/src/model/bert.rs
+++ b/discovery_engine_core/ai/kpe/src/model/bert.rs
@@ -139,7 +139,7 @@ mod tests {
     use tract_onnx::prelude::IntoArcTensor;
 
     use super::*;
-    use test_utils::kpe::bert;
+    use xayn_discovery_engine_test_utils::kpe::bert;
 
     #[test]
     fn test_embeddings_collect_full() {

--- a/discovery_engine_core/ai/kpe/src/model/classifier.rs
+++ b/discovery_engine_core/ai/kpe/src/model/classifier.rs
@@ -97,7 +97,7 @@ mod tests {
     use ndarray::Array2;
 
     use super::*;
-    use test_utils::kpe::classifier;
+    use xayn_discovery_engine_test_utils::kpe::classifier;
 
     #[test]
     fn test_model_empty() {

--- a/discovery_engine_core/ai/kpe/src/model/cnn.rs
+++ b/discovery_engine_core/ai/kpe/src/model/cnn.rs
@@ -141,7 +141,7 @@ mod tests {
     use tract_onnx::prelude::IntoArcTensor;
 
     use super::*;
-    use test_utils::kpe::cnn;
+    use xayn_discovery_engine_test_utils::kpe::cnn;
 
     #[test]
     fn test_model_shapes() {

--- a/discovery_engine_core/ai/kpe/src/pipeline.rs
+++ b/discovery_engine_core/ai/kpe/src/pipeline.rs
@@ -84,7 +84,7 @@ impl Pipeline {
 mod tests {
     use std::{collections::HashSet, error::Error};
 
-    use test_utils::kpe::{bert, classifier, cnn, vocab};
+    use xayn_discovery_engine_test_utils::kpe::{bert, classifier, cnn, vocab};
 
     use super::*;
 

--- a/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
+++ b/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
@@ -209,7 +209,7 @@ mod tests {
     use ndarray::ArrayView2;
 
     use super::*;
-    use test_utils::smbert::vocab;
+    use xayn_discovery_engine_test_utils::smbert::vocab;
 
     /// Tokens: This embedd ##ing fit ##s perfect ##ly .
     const EXACT_SEQUENCE: &str = "This embedding fits perfectly.";

--- a/discovery_engine_core/ai/layer/Cargo.toml
+++ b/discovery_engine_core/ai/layer/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 
 [dev-dependencies]
-test-utils = { path = "../test-utils" }
+xayn-discovery-engine-test-utils = { path = "../test-utils" }

--- a/discovery_engine_core/ai/layer/src/activation.rs
+++ b/discovery_engine_core/ai/layer/src/activation.rs
@@ -147,7 +147,7 @@ mod tests {
     use ndarray::{arr3, Axis};
 
     use super::*;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_relu_activation_function_works() {

--- a/discovery_engine_core/ai/layer/src/conv.rs
+++ b/discovery_engine_core/ai/layer/src/conv.rs
@@ -275,7 +275,7 @@ mod tests {
 
     use super::*;
     use crate::activation::Linear;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_conv1d_nonsingleton_kernel() {

--- a/discovery_engine_core/ai/layer/src/dense.rs
+++ b/discovery_engine_core/ai/layer/src/dense.rs
@@ -291,7 +291,7 @@ mod tests {
     use ndarray::{arr1, arr2, Array1, Array2, IntoDimension};
 
     use crate::activation::{Linear, Relu};
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/discovery_engine_core/ai/layer/src/io.rs
+++ b/discovery_engine_core/ai/layer/src/io.rs
@@ -333,7 +333,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use crate::utils::he_normal_weights_init;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/discovery_engine_core/ai/layer/src/utils.rs
+++ b/discovery_engine_core/ai/layer/src/utils.rs
@@ -158,7 +158,7 @@ mod tests {
     use ndarray::{arr1, arr2, arr3};
 
     use super::*;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_softmax_1d() {

--- a/discovery_engine_core/ai/rubert/Cargo.toml
+++ b/discovery_engine_core/ai/rubert/Cargo.toml
@@ -23,7 +23,7 @@ onnxruntime = { version = "0.0.13", optional = true }
 rayon = { version = "1.5.1", optional = true }
 
 [dev-dependencies]
-test-utils = { path = "../test-utils" }
+xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [features]
 bench = ["criterion", "onnxruntime", "rayon"]

--- a/discovery_engine_core/ai/rubert/examples/mbert.rs
+++ b/discovery_engine_core/ai/rubert/examples/mbert.rs
@@ -17,7 +17,7 @@
 //! - `qa` for QAMBert
 
 use rubert::{Config, FirstPooler, Pipeline, SMBertConfig};
-use test_utils::smbert;
+use xayn_discovery_engine_test_utils::smbert;
 
 fn main() {
     let (embedding, size) = match std::env::args().nth(1).unwrap().as_str() {

--- a/discovery_engine_core/ai/rubert/examples/validate.rs
+++ b/discovery_engine_core/ai/rubert/examples/validate.rs
@@ -35,7 +35,7 @@ use rubert::{
     NonePooler,
 };
 use rubert_tokenizer::{Builder as TokenizerBuilder, Padding, Tokenizer, Truncation};
-use test_utils::{example::validate::transcripts, smbert};
+use xayn_discovery_engine_test_utils::{example::validate::transcripts, smbert};
 
 fn main() {
     ValidatorConfig {

--- a/discovery_engine_core/ai/rubert/src/model.rs
+++ b/discovery_engine_core/ai/rubert/src/model.rs
@@ -161,7 +161,7 @@ mod tests {
     use ndarray::Array2;
     use std::{fs::File, io::BufReader};
 
-    use test_utils::smbert::model;
+    use xayn_discovery_engine_test_utils::smbert::model;
 
     use super::*;
 

--- a/discovery_engine_core/ai/rubert/src/pipeline.rs
+++ b/discovery_engine_core/ai/rubert/src/pipeline.rs
@@ -131,7 +131,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use test_utils::smbert::{model, vocab};
+    use xayn_discovery_engine_test_utils::smbert::{model, vocab};
 
     use super::*;
     use crate::{

--- a/discovery_engine_core/ai/rubert/src/tokenizer.rs
+++ b/discovery_engine_core/ai/rubert/src/tokenizer.rs
@@ -108,7 +108,7 @@ mod tests {
     use std::{fs::File, io::BufReader};
 
     use rubert_tokenizer::{ModelError, PaddingError, PostTokenizerError};
-    use test_utils::smbert::vocab;
+    use xayn_discovery_engine_test_utils::smbert::vocab;
 
     use super::*;
 

--- a/discovery_engine_core/ai/test-utils/Cargo.toml
+++ b/discovery_engine_core/ai/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "test-utils"
+name = "xayn-discovery-engine-test-utils"
 version = "0.1.0"
-authors = ["Xayn Engineering <engineering@xaynet.dev>"]
+license = "AGPL-3.0-only"
 edition = "2018"
 publish = false
 

--- a/discovery_engine_core/ai/test-utils/src/approx_eq.rs
+++ b/discovery_engine_core/ai/test-utils/src/approx_eq.rs
@@ -276,8 +276,8 @@ mod tests {
 
     #[test]
     fn test_assert_approx_eq_float() {
-        assert_approx_eq!(f32, 0.15039155, 0.1503916, ulps = 3);
-        catch_unwind(|| assert_approx_eq!(f32, 0.15039155, 0.1503916, ulps = 2)).unwrap_err();
+        assert_approx_eq!(f32, 0.150_391_55, 0.150_391_6, ulps = 3);
+        catch_unwind(|| assert_approx_eq!(f32, 0.150_391_55, 0.150_391_6, ulps = 2)).unwrap_err();
     }
 
     #[test]
@@ -346,12 +346,12 @@ mod tests {
 
     #[test]
     fn test_equality_using_epsilon() {
-        assert_approx_eq!(f32, 0.125, 0.625, epsilon = 0.5)
+        assert_approx_eq!(f32, 0.125, 0.625, epsilon = 0.5);
     }
 
     #[test]
     #[should_panic(expected = "[]")]
     fn test_equality_using_epsilon_with_panic() {
-        assert_approx_eq!(f32, 0.125, 0.625, epsilon = 0.49)
+        assert_approx_eq!(f32, 0.125, 0.625, epsilon = 0.49);
     }
 }

--- a/discovery_engine_core/ai/test-utils/src/approx_eq.rs
+++ b/discovery_engine_core/ai/test-utils/src/approx_eq.rs
@@ -86,7 +86,7 @@ macro_rules! assert_approx_eq {
             $crate::ApproxEqIter::<$t>::indexed_iter_logical_order(right, Vec::new());
         loop {
             match (left_iter.next(), right_iter.next()) {
-                (std::option::Option::Some((lidx, lv)), std::option::Option::Some((ridx, rv))) => {
+                (Some((lidx, lv)), Some((ridx, rv))) => {
                     std::assert_eq!(
                         lidx, ridx,
                         "Dimensionality mismatch when iterating in logical order: {:?} != {:?}",
@@ -100,13 +100,13 @@ macro_rules! assert_approx_eq {
                         );
                     }
                 }
-                (std::option::Option::Some(pair), std::option::Option::None) => {
+                (Some(pair), None) => {
                     std::panic!("Left input is longer starting from index {:?}", pair);
                 }
-                (std::option::Option::None, std::option::Option::Some(pair)) => {
+                (None, Some(pair)) => {
                     std::panic!("Right input is longer starting from index {:?}", pair);
                 }
-                (std::option::Option::None, std::option::Option::None) => break,
+                (None, None) => break,
             }
         }
     }};

--- a/discovery_engine_core/ai/test-utils/src/approx_eq.rs
+++ b/discovery_engine_core/ai/test-utils/src/approx_eq.rs
@@ -24,14 +24,14 @@ use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix};
 /// This can be used to compare two floating point numbers:
 ///
 /// ```
-/// use test_utils::assert_approx_eq;
-/// assert_approx_eq!(f32, 0.15039155, 0.1503916, ulps = 3);
+/// use xayn_discovery_engine_test_utils::assert_approx_eq;
+/// assert_approx_eq!(f32, 0.150_391_55, 0.150_391_6, ulps = 3);
 /// ```
 ///
 /// Or containers of such:
 ///
 /// ```
-/// use test_utils::assert_approx_eq;
+/// use xayn_discovery_engine_test_utils::assert_approx_eq;
 /// assert_approx_eq!(f32, &[[1., 2.], [3., 4.]], vec![[1., 2.], [3., 4.]])
 /// ```
 ///
@@ -39,7 +39,7 @@ use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix};
 ///
 /// ```
 /// use ndarray::arr2;
-/// use test_utils::assert_approx_eq;
+/// use xayn_discovery_engine_test_utils::assert_approx_eq;
 /// assert_approx_eq!(
 ///     f32,
 ///     arr2(&[[1., 2.], [3., 4.]]),

--- a/discovery_engine_core/ai/test-utils/src/asset.rs
+++ b/discovery_engine_core/ai/test-utils/src/asset.rs
@@ -23,11 +23,11 @@ use std::{
 use serde::Deserialize;
 use serde_json::from_reader;
 
-pub const DATA_DIR: &str = "../discovery_engine_flutter/example/assets/";
-pub const ASSET_MANIFEST: &str = "../discovery_engine/lib/assets/asset_manifest.json";
+pub(crate) const DATA_DIR: &str = "../discovery_engine_flutter/example/assets/";
+const ASSET_MANIFEST: &str = "../discovery_engine/lib/assets/asset_manifest.json";
 
 /// Resolves the path to the requested data relative to the workspace directory.
-pub fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
+pub(crate) fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
     let manifest = var_os("CARGO_MANIFEST_DIR")
         .ok_or_else(|| Error::new(ErrorKind::NotFound, "missing CARGO_MANIFEST_DIR"))?;
 
@@ -70,7 +70,7 @@ fn read_assets() -> Result<HashMap<String, PathBuf>> {
 }
 
 /// Resolves the path to the requested asset relative to the workspace directory.
-pub fn resolve_asset(asset: &str) -> Result<PathBuf> {
+pub(crate) fn resolve_asset(asset: &str) -> Result<PathBuf> {
     resolve_path(&[read_assets()?
         .get(asset)
         .ok_or_else(|| Error::new(ErrorKind::NotFound, format!("missing asset '{}'", asset)))?])

--- a/discovery_engine_core/ai/test-utils/src/example/mod.rs
+++ b/discovery_engine_core/ai/test-utils/src/example/mod.rs
@@ -12,4 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Path resolvers for example assets.
+
 pub mod validate;

--- a/discovery_engine_core/ai/test-utils/src/example/validate.rs
+++ b/discovery_engine_core/ai/test-utils/src/example/validate.rs
@@ -18,7 +18,7 @@ use crate::asset::{resolve_path, DATA_DIR};
 
 const ASSET: &str = "ted_talk_transcripts.csv";
 
-/// Resolves the path to the MBert validation transcripts.
+/// Resolves the path to the `MBert` validation transcripts.
 pub fn transcripts() -> Result<PathBuf> {
     resolve_path(&[DATA_DIR, ASSET])
 }

--- a/discovery_engine_core/ai/test-utils/src/example/validate.rs
+++ b/discovery_engine_core/ai/test-utils/src/example/validate.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Path resolvers for validation example assets.
+
 use std::{io::Result, path::PathBuf};
 
 use crate::asset::{resolve_path, DATA_DIR};

--- a/discovery_engine_core/ai/test-utils/src/kpe.rs
+++ b/discovery_engine_core/ai/test-utils/src/kpe.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Path resolvers for the `KPE` assets.
+
 use std::{io::Result, path::PathBuf};
 
 use crate::asset::{resolve_path, DATA_DIR};

--- a/discovery_engine_core/ai/test-utils/src/lib.rs
+++ b/discovery_engine_core/ai/test-utils/src/lib.rs
@@ -23,7 +23,7 @@
     rust_2021_compatibility,
     unused_qualifications
 )]
-#![warn(missing_docs)]
+#![warn(missing_docs, unreachable_pub)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/test-utils/src/lib.rs
+++ b/discovery_engine_core/ai/test-utils/src/lib.rs
@@ -13,7 +13,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! The single source of truth for all data paths and other test utilities.
-#![forbid(unsafe_op_in_unsafe_fn)]
+
+#![forbid(unsafe_code, unsafe_op_in_unsafe_fn)]
+#![deny(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions,
+    clippy::items_after_statements
+)]
 
 mod approx_eq;
 mod asset;

--- a/discovery_engine_core/ai/test-utils/src/lib.rs
+++ b/discovery_engine_core/ai/test-utils/src/lib.rs
@@ -15,7 +15,14 @@
 //! The single source of truth for all data paths and other test utilities.
 
 #![forbid(unsafe_code, unsafe_op_in_unsafe_fn)]
-#![deny(clippy::pedantic)]
+#![deny(
+    clippy::pedantic,
+    clippy::future_not_send,
+    noop_method_call,
+    rust_2018_idioms,
+    rust_2021_compatibility,
+    unused_qualifications
+)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/test-utils/src/lib.rs
+++ b/discovery_engine_core/ai/test-utils/src/lib.rs
@@ -23,6 +23,7 @@
     rust_2021_compatibility,
     unused_qualifications
 )]
+#![warn(missing_docs)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/test-utils/src/smbert.rs
+++ b/discovery_engine_core/ai/test-utils/src/smbert.rs
@@ -16,12 +16,12 @@ use std::{io::Result, path::PathBuf};
 
 use crate::asset::resolve_asset;
 
-/// Resolves the path to the SMBert vocabulary.
+/// Resolves the path to the `SMBert` vocabulary.
 pub fn vocab() -> Result<PathBuf> {
     resolve_asset("smbertVocab")
 }
 
-/// Resolves the path to the SMBert model.
+/// Resolves the path to the `SMBert` model.
 pub fn model() -> Result<PathBuf> {
     resolve_asset("smbertModel")
 }

--- a/discovery_engine_core/ai/test-utils/src/smbert.rs
+++ b/discovery_engine_core/ai/test-utils/src/smbert.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Path resolvers for the `SMBert` assets.
+
 use std::{io::Result, path::PathBuf};
 
 use crate::asset::resolve_asset;

--- a/discovery_engine_core/ai/xayn-ai/Cargo.toml
+++ b/discovery_engine_core/ai/xayn-ai/Cargo.toml
@@ -43,7 +43,7 @@ paste = "1.0.7"
 rstest = "0.12.0"
 rstest_reuse = "0.3.0"
 serde_json = "1.0.79"
-test-utils = { path = "../test-utils" }
+xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [features]
 multithreaded = ["rayon"]

--- a/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/key_phrase.rs
@@ -423,7 +423,7 @@ mod tests {
     use std::time::Duration;
 
     use ndarray::arr2;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use crate::coi::{config::Config, utils::tests::create_pos_cois};
 

--- a/discovery_engine_core/ai/xayn-ai/src/coi/point.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/point.rs
@@ -246,7 +246,7 @@ pub(crate) mod tests {
     use ndarray::arr1;
 
     use crate::coi::utils::tests::create_pos_cois;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/discovery_engine_core/ai/xayn-ai/src/coi/stats.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/coi/stats.rs
@@ -124,7 +124,7 @@ pub(crate) fn compute_coi_decay_factor(
 #[cfg(test)]
 mod tests {
     use crate::coi::{config::Config, utils::tests::create_pos_cois};
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/discovery_engine_core/ai/xayn-ai/src/embedding/utils.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/embedding/utils.rs
@@ -98,7 +98,7 @@ mod tests {
     use ndarray::{arr1, arr2};
 
     use super::*;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_l2_norm() {

--- a/discovery_engine_core/ai/xayn-ai/src/ranker/context.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/ranker/context.rs
@@ -145,7 +145,7 @@ pub(super) fn compute_score_for_docs(
 #[cfg(test)]
 mod tests {
     use ndarray::arr1;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use crate::{
         coi::{create_neg_cois, create_pos_cois},

--- a/discovery_engine_core/ai/xayn-ai/src/utils.rs
+++ b/discovery_engine_core/ai/xayn-ai/src/utils.rs
@@ -111,7 +111,7 @@ mod tests {
     use serde_json::{from_str, to_string};
 
     use super::*;
-    use test_utils::assert_approx_eq;
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_nan_safe_f32_cmp_sorts_in_the_right_order() {

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -34,5 +34,5 @@ float-cmp = "0.9.0"
 mockall = "0.11.0"
 rubert = { path = "../ai/rubert" }
 serde_json = "1.0.79"
-test-utils = { path = "../ai/test-utils" }
+xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt", "sync"] }

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -34,5 +34,5 @@ float-cmp = "0.9.0"
 mockall = "0.11.0"
 rubert = { path = "../ai/rubert" }
 serde_json = "1.0.79"
-xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt", "sync"] }
+xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }

--- a/discovery_engine_core/core/src/stack/filters/semantic.rs
+++ b/discovery_engine_core/core/src/stack/filters/semantic.rs
@@ -189,11 +189,11 @@ mod tests {
 
     use chrono::NaiveDateTime;
     use rubert::SMBert;
-    use test_utils::{assert_approx_eq, smbert};
     use xayn_ai::{
         ranker::{AveragePooler, Embedding},
         SMBertConfig,
     };
+    use xayn_discovery_engine_test_utils::{assert_approx_eq, smbert};
 
     use crate::document::NewsResource;
 


### PR DESCRIPTION
**References**

- [TY-2777]

**Summary**

- rename the crate in the first commit
- fix one lint at a time in the following commits


[TY-2777]: https://xainag.atlassian.net/browse/TY-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ