### PR TITLE
[Merged by Bors] - TY-2773 port layer crate to DE conventions

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1189,11 +1189,11 @@ dependencies = [
  "criterion",
  "derive_more",
  "displaydoc",
- "layer",
  "ndarray",
  "rubert-tokenizer",
  "thiserror",
  "tract-onnx",
+ "xayn-discovery-engine-layer",
  "xayn-discovery-engine-test-utils",
 ]
 
@@ -1204,20 +1204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "layer"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "displaydoc",
- "ndarray",
- "rand 0.8.5",
- "rand_distr",
- "serde",
- "thiserror",
- "xayn-discovery-engine-test-utils",
 ]
 
 [[package]]
@@ -3308,7 +3294,6 @@ dependencies = [
  "itertools",
  "js-sys",
  "kpe",
- "layer",
  "lazy_static",
  "mockall",
  "ndarray",
@@ -3327,6 +3312,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "uuid",
+ "xayn-discovery-engine-layer",
  "xayn-discovery-engine-providers",
  "xayn-discovery-engine-test-utils",
 ]
@@ -3406,6 +3392,20 @@ dependencies = [
  "uuid",
  "xayn-ai",
  "xayn-discovery-engine-providers",
+ "xayn-discovery-engine-test-utils",
+]
+
+[[package]]
+name = "xayn-discovery-engine-layer"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "displaydoc",
+ "ndarray",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "thiserror",
  "xayn-discovery-engine-test-utils",
 ]
 

--- a/discovery_engine_core/ai/kpe/Cargo.toml
+++ b/discovery_engine_core/ai/kpe/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["deref", "from"] }
 displaydoc = "0.2.3"
-layer = { path = "../layer" }
 # to be kept in sync with tract-core
 ndarray = "=0.15.3"
 rubert-tokenizer = { path = "../rubert-tokenizer" }
 thiserror = "1.0.29"
 tract-onnx = "0.16.1"
+xayn-discovery-engine-layer = { path = "../layer" }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/discovery_engine_core/ai/kpe/src/model/classifier.rs
+++ b/discovery_engine_core/ai/kpe/src/model/classifier.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     tokenizer::encoding::ActiveMask,
 };
-use layer::{activation::Linear, dense::Dense, io::BinParams};
+use xayn_discovery_engine_layer::{activation::Linear, dense::Dense, io::BinParams};
 
 /// A Classifier model.
 #[derive(Debug)]

--- a/discovery_engine_core/ai/kpe/src/model/classifier.rs
+++ b/discovery_engine_core/ai/kpe/src/model/classifier.rs
@@ -66,7 +66,7 @@ impl Classifier {
         debug_assert_eq!(features.shape()[1], active_mask.shape()[1]);
         debug_assert!(features.is_valid());
         debug_assert!(active_mask.is_valid());
-        let (scores, _) = self.layer.run(features.t(), false);
+        let (scores, _) = self.layer.run(&features.t(), false);
         debug_assert_eq!(scores.shape(), [features.shape()[1], 1]);
         debug_assert!(scores.iter().copied().all(f32::is_finite));
 

--- a/discovery_engine_core/ai/kpe/src/model/cnn.rs
+++ b/discovery_engine_core/ai/kpe/src/model/cnn.rs
@@ -104,7 +104,7 @@ impl Cnn {
         debug_assert!(valid_embeddings.iter().copied().all(f32::is_finite));
 
         let run_layer =
-            |idx: usize| self.layers[idx].run(valid_embeddings.t().slice(s![NewAxis, .., ..]));
+            |idx: usize| self.layers[idx].run(&valid_embeddings.t().slice(s![NewAxis, .., ..]));
         let features = Features(concatenate(
             Axis(1),
             &[

--- a/discovery_engine_core/ai/kpe/src/model/cnn.rs
+++ b/discovery_engine_core/ai/kpe/src/model/cnn.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     tokenizer::encoding::ValidMask,
 };
-use layer::{activation::Relu, conv::Conv1D, io::BinParams};
+use xayn_discovery_engine_layer::{activation::Relu, conv::Conv1D, io::BinParams};
 
 /// A CNN model.
 #[derive(Debug)]

--- a/discovery_engine_core/ai/kpe/src/model/mod.rs
+++ b/discovery_engine_core/ai/kpe/src/model/mod.rs
@@ -23,7 +23,7 @@ use ndarray::ShapeError;
 use thiserror::Error;
 use tract_onnx::prelude::TractError;
 
-use layer::{conv::ConvError, io::LoadingLayerFailed};
+use xayn_discovery_engine_layer::{conv::ConvError, io::LoadingLayerFailed};
 
 /// The potential errors of the models.
 #[derive(Debug, Display, Error)]

--- a/discovery_engine_core/ai/kpe/src/pipeline.rs
+++ b/discovery_engine_core/ai/kpe/src/pipeline.rs
@@ -13,8 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use displaydoc::Display;
-use layer::io::{BinParams, LoadingBinParamsFailed};
 use thiserror::Error;
+use xayn_discovery_engine_layer::io::{BinParams, LoadingBinParamsFailed};
 
 use crate::{
     config::Config,

--- a/discovery_engine_core/ai/layer/Cargo.toml
+++ b/discovery_engine_core/ai/layer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "layer"
+name = "xayn-discovery-engine-layer"
 version = "0.1.0"
-authors = ["Xayn Engineering <engineering@xaynet.dev>"]
+license = "AGPL-3.0-only"
 edition = "2018"
 
 [dependencies]

--- a/discovery_engine_core/ai/layer/src/activation.rs
+++ b/discovery_engine_core/ai/layer/src/activation.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Activation layers.
+
 use ndarray::{Array, ArrayBase, Axis, Data, DataMut, DataOwned, Dimension, NdFloat, RemoveAxis};
 
 use crate::utils::softmax;

--- a/discovery_engine_core/ai/layer/src/activation.rs
+++ b/discovery_engine_core/ai/layer/src/activation.rs
@@ -59,11 +59,11 @@ where
 }
 
 impl Relu {
-    /// Calculates the partial derivatives of reLU at given input.
+    /// Calculates the partial derivatives of relu at given input.
     ///
     /// I.e. it returns an array where for all values in the input an 1 is included
     /// if the value is positive or a 0 is included else wise.
-    pub fn partial_derivatives_at<S, D>(input: ArrayBase<S, D>) -> Array<f32, D>
+    pub fn partial_derivatives_at<S, D>(input: &ArrayBase<S, D>) -> Array<f32, D>
     where
         S: Data<Elem = f32>,
         D: Dimension,
@@ -108,6 +108,7 @@ where
     /// with an relative axis index of 10 on an array which
     /// is 2-dimensional (and as such only has support the
     /// relative axis indices 0,1,-1,-2).
+    #[allow(clippy::cast_sign_loss)] // negative case is handled before the cast
     fn apply_to<S, D>(&self, input: ArrayBase<S, D>) -> ArrayBase<S, D>
     where
         S: DataOwned<Elem = A> + DataMut<Elem = A>,
@@ -153,14 +154,14 @@ mod tests {
     fn test_relu_activation_function_works() {
         let relu = Relu;
         let array = arr3(&[
-            [[-1.0f32, 2.], [3.5, -4.0]],
-            [[3.0, 2.4], [-3.0, -1.2]],
-            [[-12.0, -2.0], [2.0, 12.0]],
+            [[-1., 2.], [3.5, -4.]],
+            [[3., 2.4], [-3., -1.2]],
+            [[-12., -2.], [2., 12.]],
         ]);
         let expected = arr3(&[
-            [[0.0f32, 2.], [3.5, 0.0]],
-            [[3.0, 2.4], [0.0, 0.0]],
-            [[0.0, 0.0], [2.0, 12.0]],
+            [[0., 2.], [3.5, 0.]],
+            [[3., 2.4], [0., 0.]],
+            [[0., 0.], [2., 12.]],
         ]);
         let output = relu.apply_to(array);
         assert_approx_eq!(f32, output, expected);
@@ -170,9 +171,9 @@ mod tests {
     fn test_linear_activation_function_works() {
         let relu = Linear;
         let array = arr3(&[
-            [[-1.0f32, 2.], [3.5, -4.0]],
-            [[3.0, 2.4], [-3.0, -1.2]],
-            [[-12.0, -2.0], [2.0, 12.0]],
+            [[-1., 2.], [3.5, -4.]],
+            [[3., 2.4], [-3., -1.2]],
+            [[-12., -2.], [2., 12.]],
         ]);
         let expected = array.clone();
         let output = relu.apply_to(array);
@@ -183,9 +184,9 @@ mod tests {
     fn test_softmax_activation_function_works() {
         let relu = Softmax::new(-2);
         let array = arr3(&[
-            [[-1.0f32, 2.], [3.5, -4.0]],
-            [[3.0, 2.4], [-3.0, -1.2]],
-            [[-12.0, -2.0], [2.0, 12.0]],
+            [[-1., 2.], [3.5, -4.]],
+            [[3., 2.4], [-3., -1.2]],
+            [[-12., -2.], [2., 12.]],
         ]);
         let expected = softmax(array.clone(), Axis(1));
         let output = relu.apply_to(array);

--- a/discovery_engine_core/ai/layer/src/conv.rs
+++ b/discovery_engine_core/ai/layer/src/conv.rs
@@ -211,9 +211,12 @@ where
     ///
     /// The input is of shape `(batch_size, channel_in_size, input_size)` and the output is of shape
     /// `(batch_size, channel_out_size, output_size)`.
+    ///
+    /// # Panics
+    /// Panics if certain unimplemented edge cases are encountered.
     pub fn run(
         &self,
-        input: ArrayBase<impl Data<Elem = f32>, Ix3>,
+        input: &ArrayBase<impl Data<Elem = f32>, Ix3>,
     ) -> Result<Array3<f32>, ConvError> {
         let input_shape = input.shape();
         let batch_size = input_shape[0];
@@ -241,7 +244,7 @@ where
 
         let mut output = Array3::default([batch_size, self.channel_out_size, output_size]);
         azip!((mut output in output.outer_iter_mut(), input in input.outer_iter()) {
-            let input = self.unfold(input, output_size);
+            let input = self.unfold(&input, output_size);
             output.assign(&self.weights.dot(&input));
         });
         let output = self.activation.apply_to(output + &self.bias);
@@ -255,7 +258,7 @@ where
     /// `(channel_in_size * kernel_size, output_size)`.
     fn unfold(
         &self,
-        input: ArrayBase<impl Data<Elem = f32>, Ix2>,
+        input: &ArrayBase<impl Data<Elem = f32>, Ix2>,
         output_size: usize,
     ) -> Array2<f32> {
         if self.padding > 0 {
@@ -284,7 +287,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[312., 348., 384.], [798., 915., 1032.]],
@@ -300,7 +303,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[25., 28., 31., 34., 37.], [70., 82., 94., 106., 118.]],
@@ -316,7 +319,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[312., 348., 384.], [799., 916., 1033.]],
@@ -332,7 +335,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 2, 0, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[312., 384.], [798., 1032.]],
@@ -348,7 +351,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 2, 0, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[25., 31., 37.], [70., 94., 118.]],
@@ -365,7 +368,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 1, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [
@@ -388,7 +391,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 1, 1, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [
@@ -411,7 +414,7 @@ mod tests {
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 2, 1)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[[[354.], [921.]], [[894.], [2676.]]]);
         assert_approx_eq!(f32, output, expected);
@@ -425,7 +428,7 @@ mod tests {
         let input = Array1::range(0., 80., 1.).into_shape((2, 8, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 2)
             .unwrap()
-            .run(input)
+            .run(&input)
             .unwrap();
         let expected = arr3(&[
             [[794., 860., 926.], [6218., 6428., 6638.]],

--- a/discovery_engine_core/ai/layer/src/conv.rs
+++ b/discovery_engine_core/ai/layer/src/conv.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Convolutional layers.
+
 use displaydoc::Display;
 use ndarray::{
     azip,

--- a/discovery_engine_core/ai/layer/src/conv.rs
+++ b/discovery_engine_core/ai/layer/src/conv.rs
@@ -161,7 +161,7 @@ where
 
     /// Loads a 1-dimensional convolutional layer from a binary.
     pub fn load(
-        mut params: BinParamsWithScope,
+        mut params: BinParamsWithScope<'_>,
         activation: AF,
         stride: usize,
         padding: usize,
@@ -181,14 +181,14 @@ where
     /// Gets the weights.
     ///
     /// The weights are of shape `(channel_out_size, channel_grouped_size * kernel_size)`.
-    pub fn weights(&self) -> ArrayView2<f32> {
+    pub fn weights(&self) -> ArrayView2<'_, f32> {
         self.weights.view()
     }
 
     /// Gets the bias.
     ///
     /// The bias is of shape `(1, bias_size, 1)`.
-    pub fn bias(&self) -> ArrayView3<f32> {
+    pub fn bias(&self) -> ArrayView3<'_, f32> {
         self.bias.view()
     }
 

--- a/discovery_engine_core/ai/layer/src/dense.rs
+++ b/discovery_engine_core/ai/layer/src/dense.rs
@@ -79,7 +79,7 @@ where
     }
 
     pub fn load(
-        mut params: BinParamsWithScope,
+        mut params: BinParamsWithScope<'_>,
         activation_function: AF,
     ) -> Result<Self, LoadingLayerFailed> {
         Self::new(
@@ -90,15 +90,15 @@ where
         .map_err(Into::into)
     }
 
-    pub fn weights(&self) -> ArrayView2<f32> {
+    pub fn weights(&self) -> ArrayView2<'_, f32> {
         self.weights.view()
     }
 
-    pub fn bias(&self) -> ArrayView1<f32> {
+    pub fn bias(&self) -> ArrayView1<'_, f32> {
         self.bias.view()
     }
 
-    pub fn store_params(self, mut params: BinParamsWithScope) {
+    pub fn store_params(self, mut params: BinParamsWithScope<'_>) {
         params.insert("weights", self.weights);
         params.insert("bias", self.bias);
     }
@@ -165,8 +165,8 @@ where
     /// The `input` and `partials` arrays are expected to be c- or f-contiguous.
     pub fn gradients_from_partials_1d(
         &self,
-        input: ArrayView1<f32>,
-        partials: ArrayView1<f32>,
+        input: ArrayView1<'_, f32>,
+        partials: ArrayView1<'_, f32>,
     ) -> DenseGradientSet {
         let weights_nr_rows = self.weights.shape()[0];
         let weights_nr_columns = self.weights.shape()[1];

--- a/discovery_engine_core/ai/layer/src/dense.rs
+++ b/discovery_engine_core/ai/layer/src/dense.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Dense layers.
+
 use std::ops::{AddAssign, DivAssign, MulAssign};
 
 use ndarray::{
@@ -51,6 +53,7 @@ impl<AF> Dense<AF>
 where
     AF: ActivationFunction<f32>,
 {
+    /// Creates a dense layer.
     pub fn new(
         weights: Array2<f32>,
         bias: Array1<f32>,
@@ -78,6 +81,7 @@ where
         })
     }
 
+    /// Loads a dense layer.
     pub fn load(
         mut params: BinParamsWithScope<'_>,
         activation_function: AF,
@@ -90,19 +94,23 @@ where
         .map_err(Into::into)
     }
 
+    /// Gets the weights.
     pub fn weights(&self) -> ArrayView2<'_, f32> {
         self.weights.view()
     }
 
+    /// Gets the bias.
     pub fn bias(&self) -> ArrayView1<'_, f32> {
         self.bias.view()
     }
 
+    /// Stores all parameters.
     pub fn store_params(self, mut params: BinParamsWithScope<'_>) {
         params.insert("weights", self.weights);
         params.insert("bias", self.bias);
     }
 
+    /// Checks the shapes against an expectation.
     pub fn check_in_out_shapes<D>(&self, mut shape: D) -> Result<D, IncompatibleMatrices>
     where
         D: Dimension,
@@ -233,6 +241,7 @@ pub struct DenseGradientSet {
 }
 
 impl DenseGradientSet {
+    /// Creates a gradient set of a dense layer.
     pub fn new(weight_gradients: Array2<f32>, bias_gradients: Array1<f32>) -> Self {
         Self {
             weight_gradients,
@@ -240,10 +249,12 @@ impl DenseGradientSet {
         }
     }
 
+    /// Gets the weight gradients.
     pub fn weight_gradients(&self) -> &Array2<f32> {
         &self.weight_gradients
     }
 
+    /// Gets the bias gradients.
     pub fn bias_gradients(&self) -> &Array1<f32> {
         &self.bias_gradients
     }

--- a/discovery_engine_core/ai/layer/src/dense.rs
+++ b/discovery_engine_core/ai/layer/src/dense.rs
@@ -142,7 +142,7 @@ where
     /// was applied. If not then `None` is returned instead.
     pub fn run<S, D>(
         &self,
-        input: ArrayBase<S, D>,
+        input: &ArrayBase<S, D>,
         for_back_propagation: bool,
     ) -> (Array<f32, D>, Option<Array<f32, D>>)
     where
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn test_dense_matrix_for_2d_input() {
         // (features, units) = (3, 2)
-        let weights = arr2(&[[1.0f32, 2.], [4., 8.], [3., 0.]]);
+        let weights = arr2(&[[1., 2.], [4., 8.], [3., 0.]]);
         // (units,) = (2,)
         let bias = arr1(&[0.5, 2.0]);
         let dense = Dense::new(weights, bias, Linear).unwrap();
@@ -317,25 +317,25 @@ mod tests {
         // (..., features) = (2, 3);
         let inputs = arr2(&[[10., 1., -10.], [0., 10., 0.]]);
         let expected = arr2(&[[-15.5, 30.], [40.5, 82.]]);
-        let (res, _) = dense.run(inputs, false);
+        let (res, _) = dense.run(&inputs, false);
         assert_approx_eq!(f32, res, expected);
 
         // (..., features) = (1, 3);
         let inputs = arr2(&[[0.5, 1.0, -0.5]]);
         let expected = arr2(&[[3.5, 11.]]);
-        let (res, _) = dense.run(inputs, false);
+        let (res, _) = dense.run(&inputs, false);
         assert_approx_eq!(f32, res, expected);
     }
 
     #[test]
     fn test_activation_function_is_called() {
-        let weights = arr2(&[[1.0f32, 2.], [4., 8.], [3., 0.]]);
+        let weights = arr2(&[[1., 2.], [4., 8.], [3., 0.]]);
         let bias = arr1(&[0.5, 2.0]);
         let dense = Dense::new(weights, bias, Relu).unwrap();
 
         let inputs = arr2(&[[10., 1., -10.], [0., 10., 0.]]);
         let expected = arr2(&[[0.0, 30.], [40.5, 82.]]);
-        let (res, _) = dense.run(inputs, false);
+        let (res, _) = dense.run(&inputs, false);
         assert_approx_eq!(f32, res, expected);
     }
 
@@ -349,7 +349,7 @@ mod tests {
     #[test]
     fn test_dense_matrix_for_1d_input() {
         // (features, units) = (3, 2)
-        let weights = arr2(&[[1.0f32, 2.], [4., 8.], [3., 0.]]);
+        let weights = arr2(&[[1., 2.], [4., 8.], [3., 0.]]);
         // (units,) = (2,)
         let bias = arr1(&[0.5, 2.0]);
         let dense = Dense::new(weights, bias, Linear).unwrap();
@@ -357,13 +357,13 @@ mod tests {
         // (..., features) = (2, 3);
         let inputs = arr1(&[10., 1., -10.]);
         let expected = arr1(&[-15.5, 30.]);
-        let (res, _) = dense.run(inputs, false);
+        let (res, _) = dense.run(&inputs, false);
         assert_approx_eq!(f32, res, expected);
 
         // (..., features) = (1, 3);
         let inputs = arr1(&[0.5, 1.0, -0.5]);
         let expected = arr1(&[3.5, 11.]);
-        let (res, _) = dense.run(inputs, false);
+        let (res, _) = dense.run(&inputs, false);
         assert_approx_eq!(f32, res, expected);
     }
 
@@ -393,13 +393,13 @@ mod tests {
 
     #[test]
     fn returns_z_out_if_needed() {
-        let weights = arr2(&[[1.0f32, 2.], [4., 8.], [3., 0.]]);
+        let weights = arr2(&[[1., 2.], [4., 8.], [3., 0.]]);
         let bias = arr1(&[0.5, 2.0]);
         let dense = Dense::new(weights, bias, Relu).unwrap();
 
         let inputs = arr2(&[[10., 1., -10.], [0., 10., 0.]]);
 
-        let (y_out, z_out) = dense.run(inputs, true);
+        let (y_out, z_out) = dense.run(&inputs, true);
 
         assert_approx_eq!(f32, y_out, arr2(&[[0.0, 30.], [40.5, 82.]]));
         assert_approx_eq!(f32, z_out.unwrap(), arr2(&[[-15.5, 30.], [40.5, 82.]]));

--- a/discovery_engine_core/ai/layer/src/io.rs
+++ b/discovery_engine_core/ai/layer/src/io.rs
@@ -120,7 +120,7 @@ where
     type Error = UnexpectedNumberOfDimensions;
 
     fn try_from(array: FlattenedArray<S::Elem>) -> Result<Self, Self::Error> {
-        let shape = D::try_from(&array.shape)?;
+        let shape = <D as TryIntoDimension>::try_from(&array.shape)?;
 
         let flattened = ArrayBase::<S, Ix1>::from(array.data);
         let output = flattened.into_shape(shape);

--- a/discovery_engine_core/ai/layer/src/io.rs
+++ b/discovery_engine_core/ai/layer/src/io.rs
@@ -297,7 +297,7 @@ impl BinParamsWithScope<'_> {
         self.prefix.clone() + suffix
     }
 
-    pub fn with_scope(&mut self, scope: &str) -> BinParamsWithScope {
+    pub fn with_scope(&mut self, scope: &str) -> BinParamsWithScope<'_> {
         BinParamsWithScope {
             params: &mut *self.params,
             prefix: self.prefix.clone() + scope + "/",

--- a/discovery_engine_core/ai/layer/src/lib.rs
+++ b/discovery_engine_core/ai/layer/src/lib.rs
@@ -23,7 +23,7 @@
     rust_2021_compatibility,
     unused_qualifications
 )]
-#![warn(missing_docs)]
+#![warn(missing_docs, unreachable_pub)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/layer/src/lib.rs
+++ b/discovery_engine_core/ai/layer/src/lib.rs
@@ -13,7 +13,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! AI model building blocks.
-#![forbid(unsafe_op_in_unsafe_fn)]
+
+#![forbid(unsafe_op_in_unsafe_fn, unsafe_op_in_unsafe_fn)]
+#![deny(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions,
+    clippy::items_after_statements
+)]
 
 pub mod activation;
 pub mod conv;

--- a/discovery_engine_core/ai/layer/src/lib.rs
+++ b/discovery_engine_core/ai/layer/src/lib.rs
@@ -19,7 +19,8 @@
     clippy::pedantic,
     clippy::future_not_send,
     noop_method_call,
-    rust_2018_idioms
+    rust_2018_idioms,
+    rust_2021_compatibility
 )]
 #![allow(
     clippy::missing_errors_doc,

--- a/discovery_engine_core/ai/layer/src/lib.rs
+++ b/discovery_engine_core/ai/layer/src/lib.rs
@@ -15,7 +15,12 @@
 //! AI model building blocks.
 
 #![forbid(unsafe_op_in_unsafe_fn, unsafe_op_in_unsafe_fn)]
-#![deny(clippy::pedantic)]
+#![deny(
+    clippy::pedantic,
+    clippy::future_not_send,
+    noop_method_call,
+    rust_2018_idioms
+)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/layer/src/lib.rs
+++ b/discovery_engine_core/ai/layer/src/lib.rs
@@ -20,8 +20,10 @@
     clippy::future_not_send,
     noop_method_call,
     rust_2018_idioms,
-    rust_2021_compatibility
+    rust_2021_compatibility,
+    unused_qualifications
 )]
+#![warn(missing_docs)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/discovery_engine_core/ai/layer/src/utils.rs
+++ b/discovery_engine_core/ai/layer/src/utils.rs
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Layer utilities.
+
 use std::f32::consts::SQRT_2;
 
 use displaydoc::Display;
@@ -45,6 +47,7 @@ pub struct IncompatibleMatrices {
 }
 
 impl IncompatibleMatrices {
+    /// Creates the error.
     pub fn new(
         name_left: &'static str,
         shape_left: impl IntoDimension,

--- a/discovery_engine_core/ai/layer/src/utils.rs
+++ b/discovery_engine_core/ai/layer/src/utils.rs
@@ -101,7 +101,7 @@ where
 ///
 /// For the good distribution we could argue similarly. An alternative choice
 /// is to return `0` if the good distributions probability is `0`.)
-pub fn kl_divergence(good_dist: ArrayView1<f32>, eval_dist: ArrayView1<f32>) -> f32 {
+pub fn kl_divergence(good_dist: ArrayView1<'_, f32>, eval_dist: ArrayView1<'_, f32>) -> f32 {
     good_dist.into_iter().zip(eval_dist.into_iter()).fold(
         0.,
         |acc, (good_dist_prob, eval_dist_prob)| {

--- a/discovery_engine_core/ai/layer/src/utils.rs
+++ b/discovery_engine_core/ai/layer/src/utils.rs
@@ -30,11 +30,12 @@ use ndarray::{
     RemoveAxis,
 };
 use rand::Rng;
-use rand_distr::{Distribution, Normal};
+use rand_distr::{num_traits::Float, Distribution, Normal};
 use thiserror::Error;
 
 /// Can't combine {name_left}({shape_left:?}) with {name_right}({shape_right:?}): {hint}
 #[derive(Debug, Display, Error)]
+#[allow(clippy::doc_markdown)] // false positive in combination with displaydoc
 pub struct IncompatibleMatrices {
     name_left: &'static str,
     shape_left: IxDyn,
@@ -81,7 +82,7 @@ where
     array -= &max;
 
     // Standard 3step softmax, 1) exp(x), 2) sum up, 3) divide through sum
-    array.mapv_inplace(|v| v.exp());
+    array.mapv_inplace(Float::exp);
     let sum = array.sum_axis(axis).insert_axis(axis);
     array /= &sum;
     array
@@ -102,7 +103,7 @@ where
 /// is to return `0` if the good distributions probability is `0`.)
 pub fn kl_divergence(good_dist: ArrayView1<f32>, eval_dist: ArrayView1<f32>) -> f32 {
     good_dist.into_iter().zip(eval_dist.into_iter()).fold(
-        0f32,
+        0.,
         |acc, (good_dist_prob, eval_dist_prob)| {
             let good_dist_prob = good_dist_prob.clamp(f32::EPSILON, 1.);
             let eval_dist_prob = eval_dist_prob.clamp(f32::EPSILON, 1.);
@@ -129,6 +130,8 @@ pub fn kl_divergence(good_dist: ArrayView1<f32>, eval_dist: ArrayView1<f32>) -> 
 ///
 /// - [Website](https://www.cv-foundation.org/openaccess/content_iccv_2015/html/He_Delving_Deep_into_ICCV_2015_paper.html)
 /// - [Pdf](https://www.cv-foundation.org/openaccess/content_iccv_2015/papers/He_Delving_Deep_into_ICCV_2015_paper.pdf)
+#[allow(clippy::cast_precision_loss)] // our integers are small enough
+#[allow(clippy::missing_panics_doc)] // edge cases are handled before unwrapping
 pub fn he_normal_weights_init(
     rng: &mut (impl Rng + ?Sized),
     dim: impl IntoDimension<Dim = Ix2>,
@@ -162,15 +165,15 @@ mod tests {
 
     #[test]
     fn test_softmax_1d() {
-        let arr = arr1(&[-1_f32, 0., 1., 2., 3.]);
+        let arr = arr1(&[-1., 0., 1., 2., 3.]);
 
         // axis 0
         let res = arr1(&[
-            0.011656231_f32,
-            0.03168492,
-            0.08612854,
-            0.23412167,
-            0.6364086,
+            0.011_656_231,
+            0.031_684_92,
+            0.086_128_54,
+            0.234_121_67,
+            0.636_408_6,
         ]);
         assert_approx_eq!(f32, softmax(arr, Axis(0)), res);
     }
@@ -178,7 +181,7 @@ mod tests {
     #[test]
     fn test_softmax_2d() {
         let arr = arr2(&[
-            [-1_f32, 0., 1., 2., 3.],
+            [-1., 0., 1., 2., 3.],
             [9., 8., 7., 6., 5.],
             [1., -1., 1., -1., 1.],
         ])
@@ -187,19 +190,25 @@ mod tests {
         // axis 0
         let res = arr2(&[
             [
-                0.000045382647_f32,
-                0.00033530878,
-                0.0024665247,
-                0.017970119,
-                0.11731042,
+                0.000_045_382_647,
+                0.000_335_308_78,
+                0.002_466_524_7,
+                0.017_970_119,
+                0.117_310_42,
             ],
-            [0.99961925, 0.9995414, 0.995067, 0.9811352, 0.8668133],
             [
-                0.00033533492,
-                0.00012335321,
-                0.0024665247,
-                0.0008946795,
-                0.01587624,
+                0.999_619_25,
+                0.999_541_4,
+                0.995_067,
+                0.981_135_2,
+                0.866_813_3,
+            ],
+            [
+                0.000_335_334_92,
+                0.000_123_353_21,
+                0.002_466_524_7,
+                0.000_894_679_5,
+                0.015_876_24,
             ],
         ]);
         assert_approx_eq!(f32, softmax(arr.clone(), Axis(0)), res);
@@ -207,23 +216,36 @@ mod tests {
         // axis 1
         let res = arr2(&[
             [
-                0.011656231_f32,
-                0.03168492,
-                0.08612854,
-                0.23412167,
-                0.6364086,
+                0.011_656_231,
+                0.031_684_92,
+                0.086_128_54,
+                0.234_121_67,
+                0.636_408_6,
             ],
-            [0.6364086, 0.23412167, 0.08612854, 0.03168492, 0.011656231],
-            [0.3057477, 0.04137845, 0.3057477, 0.04137845, 0.3057477],
+            [
+                0.636_408_6,
+                0.234_121_67,
+                0.086_128_54,
+                0.031_684_92,
+                0.011_656_231,
+            ],
+            [
+                0.305_747_7,
+                0.041_378_45,
+                0.305_747_7,
+                0.041_378_45,
+                0.305_747_7,
+            ],
         ]);
         assert_approx_eq!(f32, softmax(arr, Axis(1)), res);
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_softmax_3d() {
         let arr = arr3(&[
             [
-                [-1_f32, 0., 1., 2., 3.],
+                [-1., 0., 1., 2., 3.],
                 [9., 8., 7., 6., 5.],
                 [1., -1., 1., -1., 1.],
             ],
@@ -238,20 +260,32 @@ mod tests {
         // axis 0
         let res = arr3(&[
             [
-                [0.11920292_f32, 0.26894143, 0.5, 0.7310586, 0.880797],
-                [0.999089, 0.9975274, 0.9933072, 0.98201376, 0.95257413],
-                [0.11920292, 0.01798621, 0.11920292, 0.01798621, 0.11920292],
+                [0.119_202_92, 0.268_941_43, 0.5, 0.731_058_6, 0.880_797],
+                [
+                    0.999_089,
+                    0.997_527_4,
+                    0.993_307_2,
+                    0.982_013_76,
+                    0.952_574_13,
+                ],
+                [
+                    0.119_202_92,
+                    0.017_986_21,
+                    0.119_202_92,
+                    0.017_986_21,
+                    0.119_202_92,
+                ],
             ],
             [
-                [0.880797, 0.7310586, 0.5, 0.26894143, 0.11920292],
+                [0.880_797, 0.731_058_6, 0.5, 0.268_941_43, 0.119_202_92],
                 [
-                    0.00091105123,
-                    0.0024726233,
-                    0.006692851,
-                    0.01798621,
-                    0.047425874,
+                    0.000_911_051_23,
+                    0.002_472_623_3,
+                    0.006_692_851,
+                    0.017_986_21,
+                    0.047_425_874,
                 ],
-                [0.880797, 0.98201376, 0.880797, 0.98201376, 0.880797],
+                [0.880_797, 0.982_013_76, 0.880_797, 0.982_013_76, 0.880_797],
             ],
         ]);
         assert_approx_eq!(f32, softmax(arr.clone(), Axis(0)), res);
@@ -260,25 +294,49 @@ mod tests {
         let res = arr3(&[
             [
                 [
-                    0.000045382647_f32,
-                    0.00033530878,
-                    0.0024665247,
-                    0.017970119,
-                    0.11731042,
+                    0.000_045_382_647,
+                    0.000_335_308_78,
+                    0.002_466_524_7,
+                    0.017_970_119,
+                    0.117_310_42,
                 ],
-                [0.99961925, 0.9995414, 0.995067, 0.9811352, 0.8668133],
                 [
-                    0.00033533492,
-                    0.00012335321,
-                    0.0024665247,
-                    0.0008946795,
-                    0.01587624,
+                    0.999_619_25,
+                    0.999_541_4,
+                    0.995_067,
+                    0.981_135_2,
+                    0.866_813_3,
+                ],
+                [
+                    0.000_335_334_92,
+                    0.000_123_353_21,
+                    0.002_466_524_7,
+                    0.000_894_679_5,
+                    0.015_876_24,
                 ],
             ],
             [
-                [0.09003057, 0.09003057, 0.09003057, 0.09003057, 0.09003057],
-                [0.24472848, 0.24472848, 0.24472848, 0.24472848, 0.24472848],
-                [0.66524094, 0.66524094, 0.66524094, 0.66524094, 0.66524094],
+                [
+                    0.090_030_57,
+                    0.090_030_57,
+                    0.090_030_57,
+                    0.090_030_57,
+                    0.090_030_57,
+                ],
+                [
+                    0.244_728_48,
+                    0.244_728_48,
+                    0.244_728_48,
+                    0.244_728_48,
+                    0.244_728_48,
+                ],
+                [
+                    0.665_240_94,
+                    0.665_240_94,
+                    0.665_240_94,
+                    0.665_240_94,
+                    0.665_240_94,
+                ],
             ],
         ]);
         assert_approx_eq!(f32, softmax(arr.clone(), Axis(1)), res);
@@ -287,14 +345,26 @@ mod tests {
         let res = arr3(&[
             [
                 [
-                    0.011656232_f32,
-                    0.03168492,
-                    0.08612854,
-                    0.23412167,
-                    0.6364086,
+                    0.011_656_232,
+                    0.031_684_92,
+                    0.086_128_54,
+                    0.234_121_67,
+                    0.636_408_6,
                 ],
-                [0.6364086, 0.23412167, 0.08612854, 0.03168492, 0.011656231],
-                [0.3057477, 0.04137845, 0.3057477, 0.04137845, 0.3057477],
+                [
+                    0.636_408_6,
+                    0.234_121_67,
+                    0.086_128_54,
+                    0.031_684_92,
+                    0.011_656_231,
+                ],
+                [
+                    0.305_747_7,
+                    0.041_378_45,
+                    0.305_747_7,
+                    0.041_378_45,
+                    0.305_747_7,
+                ],
             ],
             [
                 [0.2, 0.2, 0.2, 0.2, 0.2],
@@ -308,36 +378,36 @@ mod tests {
     #[test]
     fn test_softmax_edgecases() {
         // 2D axis 0
-        let arr = arr2(&[[-1_f32, 0., 1., 2., 3.]]);
-        let res = arr2(&[[1_f32, 1., 1., 1., 1.]]);
+        let arr = arr2(&[[-1., 0., 1., 2., 3.]]);
+        let res = arr2(&[[1., 1., 1., 1., 1.]]);
         assert_approx_eq!(f32, softmax(arr, Axis(0)), res);
 
         // 2D axis 1
-        let arr = arr2(&[[-1_f32], [9.], [1.]]);
-        let res = arr2(&[[1_f32], [1.], [1.]]);
+        let arr = arr2(&[[-1.], [9.], [1.]]);
+        let res = arr2(&[[1.], [1.], [1.]]);
         assert_approx_eq!(f32, softmax(arr, Axis(1)), res);
 
         // 3D axis 0
         let arr = arr3(&[[
-            [-1_f32, 0., 1., 2., 3.],
+            [-1., 0., 1., 2., 3.],
             [9., 8., 7., 6., 5.],
             [1., -1., 1., -1., 1.],
         ]]);
         let res = arr3(&[[
-            [1_f32, 1., 1., 1., 1.],
+            [1., 1., 1., 1., 1.],
             [1., 1., 1., 1., 1.],
             [1., 1., 1., 1., 1.],
         ]]);
         assert_approx_eq!(f32, softmax(arr, Axis(0)), res);
 
         // 3D axis 1
-        let arr = arr3(&[[[-1_f32, 0., 1., 2., 3.]], [[1., 1., 1., 1., 1.]]]);
-        let res = arr3(&[[[1_f32, 1., 1., 1., 1.]], [[1., 1., 1., 1., 1.]]]);
+        let arr = arr3(&[[[-1., 0., 1., 2., 3.]], [[1., 1., 1., 1., 1.]]]);
+        let res = arr3(&[[[1., 1., 1., 1., 1.]], [[1., 1., 1., 1., 1.]]]);
         assert_approx_eq!(f32, softmax(arr, Axis(1)), res);
 
         // 3D axis 2
-        let arr = arr3(&[[[-1_f32], [9.], [1.]], [[1.], [2.], [3.]]]);
-        let res = arr3(&[[[1_f32], [1.], [1.]], [[1.], [1.], [1.]]]);
+        let arr = arr3(&[[[-1.], [9.], [1.]], [[1.], [2.], [3.]]]);
+        let res = arr3(&[[[1.], [1.], [1.]], [[1.], [1.], [1.]]]);
         assert_approx_eq!(f32, softmax(arr, Axis(2)), res);
     }
 
@@ -366,16 +436,17 @@ mod tests {
         let mut rng = rand::thread_rng();
         assert_eq!(
             he_normal_weights_init(&mut rng, (0, 200)).shape(),
-            &[0, 200]
+            &[0, 200],
         );
         assert_eq!(
             he_normal_weights_init(&mut rng, (300, 0)).shape(),
-            &[300, 0]
+            &[300, 0],
         );
         assert_eq!(he_normal_weights_init(&mut rng, (0, 0)).shape(), &[0, 0]);
     }
 
     #[test]
+    #[allow(clippy::cast_precision_loss)] // our integers are small enough
     fn test_he_normal_weight_init() {
         let mut rng = rand::thread_rng();
         let weights = he_normal_weights_init(&mut rng, (300, 200));

--- a/discovery_engine_core/ai/xayn-ai/Cargo.toml
+++ b/discovery_engine_core/ai/xayn-ai/Cargo.toml
@@ -13,7 +13,6 @@ derive_more = { version = "0.99.17", default-features = false, features = ["dere
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 kpe = { path = "../kpe" }
-layer = { path = "../layer" }
 lazy_static = "1.4.0"
 # to be kept in sync with rubert
 ndarray = "=0.15.3"
@@ -27,6 +26,7 @@ serde_repr = "0.1.7"
 smallvec = "1.8.0"
 thiserror = "1.0.30"
 uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen", "v4"] }
+xayn-discovery-engine-layer = { path = "../layer" }
 xayn-discovery-engine-providers = { path = "../../providers" }
 
 # multithreaded feature


### PR DESCRIPTION
**References**

- [TY-2773]

**Summary**

- rename the crate in the first commit
- fix one lint at a time in the following commits


[TY-2773]: https://xainag.atlassian.net/browse/TY-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ