### PR TITLE
[Merged by Bors] - TY-2692 persist active search by topic

### DIFF
--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -21,7 +21,7 @@ import 'package:xayn_discovery_engine/src/domain/repository/type_id.dart'
 part 'active_search.freezed.dart';
 part 'active_search.g.dart';
 
-/// [ActiveSearch] is representing attributes of a performed search query.
+/// [ActiveSearch] represents attributes of a performed search.
 @freezed
 class ActiveSearch with _$ActiveSearch {
   @HiveType(typeId: searchTypeId)
@@ -29,7 +29,7 @@ class ActiveSearch with _$ActiveSearch {
     @HiveField(0) required String queryTerm,
     @HiveField(1) required int requestedPageNb,
     @HiveField(2) required int pageSize,
-    @HiveField(3) required SearchBy searchBy,
+    @HiveField(3, defaultValue: SearchBy.query) required SearchBy searchBy,
   }) = _ActiveSearch;
 
   factory ActiveSearch.fromJson(Map<String, Object?> json) =>


### PR DESCRIPTION
previously #330 added a `searchBy` field to `ActiveSearch`

**Summary**

support persistence of the current topic-based (or query-based) search to the `ActiveSearchRepository`.
in particular, migrate an "old" active search to the new-style (possibly topic-based) active search.

hive reference for [updating a class](https://docs.hivedb.dev/#/custom-objects/generate_adapter?id=updating-a-class). 