### PR TITLE
[Merged by Bors] - TY-2722 method on engine to search by topic

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -72,9 +72,16 @@ abstract class Engine {
     UserReacted userReacted,
   );
 
-  /// Perform an active search with the given query parameters.
+  /// Perform an active search by query.
   Future<List<DocumentWithActiveData>> activeSearch(
     String query,
+    int page,
+    int pageSize,
+  );
+
+  /// Perform an active search by topic.
+  Future<List<DocumentWithActiveData>> searchByTopic(
+    String topic,
     int page,
     int pageSize,
   );

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -73,7 +73,7 @@ abstract class Engine {
   );
 
   /// Perform an active search by query.
-  Future<List<DocumentWithActiveData>> activeSearch(
+  Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
     int page,
     int pageSize,

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -147,7 +147,7 @@ class MockEngine implements Engine {
   }
 
   @override
-  Future<List<DocumentWithActiveData>> activeSearch(
+  Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
     int page,
     int pageSize,

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -185,6 +185,44 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> searchByTopic(
+    String topic,
+    int page,
+    int pageSize,
+  ) async {
+    _incrementCount('searchByTopic');
+
+    final stackId = StackId.fromBytes(Uint8List.fromList(List.filled(16, 0)));
+    final doc0 = Document(
+      documentId: DocumentId(),
+      stackId: stackId,
+      batchIndex: 0,
+      resource: resource,
+      isSearched: true,
+    );
+    doc1 = Document(
+      documentId: DocumentId(),
+      stackId: stackId,
+      batchIndex: 1,
+      resource: resource,
+      isSearched: true,
+    );
+    active1 = ActiveDocumentData(Embedding.fromList([0]));
+    active0 = ActiveDocumentData(Embedding.fromList([1, 3]));
+
+    if (pageSize < 1) {
+      return [];
+    } else if (pageSize == 1) {
+      return [DocumentWithActiveData(doc0, active0)];
+    } else {
+      return [
+        DocumentWithActiveData(doc0, active0),
+        DocumentWithActiveData(doc1, active1),
+      ];
+    }
+  }
+
+  @override
   Future<void> dispose() async {
     _incrementCount('dispose');
   }

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -26,7 +26,7 @@ part 'active_search.g.dart';
 class ActiveSearch with _$ActiveSearch {
   @HiveType(typeId: searchTypeId)
   const factory ActiveSearch({
-    @HiveField(0) required String queryTerm,
+    @HiveField(0) required String searchTerm,
     @HiveField(1) required int requestedPageNb,
     @HiveField(2) required int pageSize,
     @HiveField(3, defaultValue: SearchBy.query) required SearchBy searchBy,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -76,14 +76,14 @@ class SearchManager {
     switch (search.searchBy) {
       case SearchBy.query:
         searchDocs = await _engine.activeSearch(
-          search.queryTerm,
+          search.searchTerm,
           search.requestedPageNb,
           search.pageSize,
         );
         break;
       case SearchBy.topic:
         searchDocs = await _engine.searchByTopic(
-          search.queryTerm,
+          search.searchTerm,
           search.requestedPageNb,
           search.pageSize,
         );
@@ -113,7 +113,7 @@ class SearchManager {
     await searchClosed();
 
     final search = ActiveSearch(
-      queryTerm: queryTerm,
+      searchTerm: queryTerm,
       requestedPageNb: 1,
       pageSize: _config.maxSearchDocs,
       searchBy: searchBy,
@@ -182,7 +182,7 @@ class SearchManager {
       return const EngineEvent.searchTermRequestFailed(reason);
     }
 
-    return EngineEvent.searchTermRequestSucceeded(search.queryTerm);
+    return EngineEvent.searchTermRequestSucceeded(search.searchTerm);
   }
 
   /// Clear the active search and deactivate interacted search documents.

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -107,13 +107,13 @@ class SearchManager {
 
   /// Obtain the first batch of search documents and persist to repositories.
   Future<EngineEvent> searchRequested(
-    String queryTerm,
+    String searchTerm,
     SearchBy searchBy,
   ) async {
     await searchClosed();
 
     final search = ActiveSearch(
-      searchTerm: queryTerm,
+      searchTerm: searchTerm,
       requestedPageNb: 1,
       pageSize: _config.maxSearchDocs,
       searchBy: searchBy,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -75,7 +75,7 @@ class SearchManager {
 
     switch (search.searchBy) {
       case SearchBy.query:
-        searchDocs = await _engine.activeSearch(
+        searchDocs = await _engine.searchByQuery(
           search.searchTerm,
           search.requestedPageNb,
           search.pageSize,

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -189,13 +189,13 @@ class DiscoveryEngineFfi implements Engine {
 
   /// Performs an active search by query.
   @override
-  Future<List<DocumentWithActiveData>> activeSearch(
+  Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
     int page,
     int pageSize,
   ) async {
     final boxedQuery = query.allocNative();
-    final result = await asyncFfi.activeSearch(
+    final result = await asyncFfi.searchByQuery(
       _engine.ref,
       boxedQuery.move(),
       page,
@@ -207,6 +207,7 @@ class DiscoveryEngineFfi implements Engine {
         .toDocumentListWithActiveData(isSearched: true);
   }
 
+  /// Performs an active search by topic.
   @override
   Future<List<DocumentWithActiveData>> searchByTopic(
     String topic,

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -187,7 +187,7 @@ class DiscoveryEngineFfi implements Engine {
     return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
-  /// Performs an active search.
+  /// Performs an active search by query.
   @override
   Future<List<DocumentWithActiveData>> activeSearch(
     String query,
@@ -198,6 +198,25 @@ class DiscoveryEngineFfi implements Engine {
     final result = await asyncFfi.activeSearch(
       _engine.ref,
       boxedQuery.move(),
+      page,
+      pageSize,
+    );
+
+    return resultVecDocumentStringFfiAdapter
+        .consumeNative(result)
+        .toDocumentListWithActiveData(isSearched: true);
+  }
+
+  @override
+  Future<List<DocumentWithActiveData>> searchByTopic(
+    String topic,
+    int page,
+    int pageSize,
+  ) async {
+    final boxedTopic = topic.allocNative();
+    final result = await asyncFfi.searchByTopic(
+      _engine.ref,
+      boxedTopic.move(),
       page,
       pageSize,
     );

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -157,7 +157,7 @@ final mockNewsResource = NewsResource(
 const queryTerm = 'example';
 
 const mockActiveSearch = ActiveSearch(
-  queryTerm: queryTerm,
+  searchTerm: queryTerm,
   requestedPageNb: 1,
   pageSize: 20,
   searchBy: SearchBy.query,

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -29,7 +29,7 @@ Future<void> main() async {
     late HiveActiveSearchRepository repo;
 
     const search = ActiveSearch(
-      queryTerm: 'example search query',
+      searchTerm: 'example search query',
       requestedPageNb: 1,
       pageSize: 10,
       searchBy: SearchBy.query,

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -145,7 +145,7 @@ Future<void> main() async {
         await docRepo.updateMany([doc1, doc2]);
 
         final newSearch = ActiveSearch(
-          queryTerm: 'example query',
+          searchTerm: 'example query',
           requestedPageNb: 1,
           pageSize: config.maxSearchDocs,
           searchBy: SearchBy.query,
@@ -305,7 +305,7 @@ Future<void> main() async {
         expect(response, isA<SearchTermRequestSucceeded>());
         expect(
           (response as SearchTermRequestSucceeded).searchTerm,
-          mockActiveSearch.queryTerm,
+          mockActiveSearch.searchTerm,
         );
       });
     });

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -144,7 +144,7 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
-    /// Perform an active search with the given query parameters.
+    /// Perform an active search by query.
     pub async fn active_search(
         engine: &SharedEngine,
         query: Box<String>,
@@ -157,6 +157,24 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .lock()
                 .await
                 .active_search(query.as_ref(), page, page_size)
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
+    /// Perform an active search by topic.
+    pub async fn search_by_topic(
+        engine: &SharedEngine,
+        topic: Box<String>,
+        page: u32,
+        page_size: u32,
+    ) -> Box<Result<Vec<Document>, String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .search_by_topic(topic.as_ref(), page, page_size)
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -145,7 +145,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     }
 
     /// Perform an active search by query.
-    pub async fn active_search(
+    pub async fn search_by_query(
         engine: &SharedEngine,
         query: Box<String>,
         page: u32,
@@ -156,7 +156,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .active_search(query.as_ref(), page, page_size)
+                .search_by_query(query.as_ref(), page, page_size)
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -482,7 +482,7 @@ where
         let scaled_page_size = page_size as usize / markets.len() + 1;
         let excluded_sources = self.config.excluded_sources.read().await.clone();
         for market in markets.iter() {
-            let news_query = HeadlinesQuery {
+            let headlines_query = HeadlinesQuery {
                 common: CommonQueryParts {
                     market: Some(market),
                     page_size: scaled_page_size,
@@ -492,7 +492,7 @@ where
                 trusted_sources: &[],
                 topic: Some(topic),
             };
-            match self.client.query_articles(&news_query).await {
+            match self.client.query_articles(&headlines_query).await {
                 Ok(batch) => articles.extend(batch),
                 Err(err) => errors.push(Error::Client(err.into())),
             };

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -465,7 +465,7 @@ where
     }
 
     /// Perform an active search by topic.
-    pub async fn topic_search(
+    pub async fn search_by_topic(
         &mut self,
         topic: &str,
         page: u32,


### PR DESCRIPTION
previously #330 #339

**Summary**

adds a method to the engine for searching by topic. also:

- adds ffi binding for above
- corresponding changes on the dart side to accommodate new engine method
- search manager calls the new method when search requested is by topic