### PR TITLE
[Merged by Bors] - TY-2799 compact engine state box

### DIFF
--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -339,6 +339,8 @@ class EventHandler {
   }
 
   /// Tries to open a box persisted on disk. In case of failure opens it in memory.
+  /// If `compact` is set to `true`, compaction of the box will be triggered
+  /// after opening.
   static Future<void> _openDbBox<T>(String name, {bool compact = false}) async {
     try {
       final box = await Hive.openBox<T>(name);

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -325,7 +325,7 @@ class EventHandler {
       _openDbBox<ActiveDocumentData>(activeDocumentDataBox),
 
       /// See TY-2799
-      /// Hive usually compact our boxes automatically. However, with the default
+      /// Hive usually compacts our boxes automatically. However, with the default
       /// strategy, compaction is triggered after 60 deleted entries. This leads
       /// to the problem that our engine state is constantly growing because we
       /// are only overwriting it and not deleting it. Therefore we call it with


### PR DESCRIPTION
Ticket:
- [TY-2799]

I checked the `HiveActiveSearchRepository` and it has a [`clear`](https://github.com/xaynetwork/xayn_discovery_engine/blob/1bd2a34c484d4b37e11729d0f20cf323202ddf67/discovery_engine/lib/src/infrastructure/repository/hive_active_search_repo.dart#L33) method that we call in the code.

[TY-2799]: https://xainag.atlassian.net/browse/TY-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ