### PR TITLE
[Merged by Bors] - TY-2747 define available sources events

### DIFF
--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -14,6 +14,7 @@
 
 export 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show
+        AvailableSourcesListRequested,
         ClientEvent,
         SystemClientEvent,
         Init,
@@ -37,6 +38,8 @@ export 'package:xayn_discovery_engine/src/api/events/client_events.dart'
         TrendingTopicsRequested;
 export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show
+        AvailableSourcesListRequestSucceeded,
+        AvailableSourcesListRequestFailed,
         EngineEvent,
         FeedEngineEvent,
         RestoreFeedSucceeded,

--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -132,6 +132,12 @@ class ClientEvent with _$ClientEvent {
   const factory ClientEvent.trustedSourcesListRequested() =
       TrustedSourcesListRequested;
 
+  /// Event created when a client requests for list of available sources.
+  @Implements<FeedClientEvent>()
+  const factory ClientEvent.availableSourcesListRequested(
+    String fuzzySearchTerm,
+  ) = AvailableSourcesListRequested;
+
   /// Event created when a [Document] has been viewed in a certain mode for
   /// the given amount of time in seconds.
   @Implements<DocumentClientEvent>()

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -151,10 +151,11 @@ class EngineEvent with _$EngineEvent {
       TrustedSourcesListRequestFailed;
 
   /// Event created as a success response to AvailableSourcesListRequested event.
-  /// Passes a set of [AvailableSource] of available sources back to the client.
+  /// Passes a list of [AvailableSource] of available sources back to the client.
+  /// The list is sorted by decreasing match score.
   @Implements<FeedEngineEvent>()
   const factory EngineEvent.availableSourcesListRequestSucceeded(
-    Set<AvailableSource> availableSources,
+    List<AvailableSource> availableSources,
   ) = AvailableSourcesListRequestSucceeded;
 
   /// Event created as a failure response to AvailableSourcesListRequested event.

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -16,7 +16,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:xayn_discovery_engine/src/api/models/document.dart';
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart';
 
 part 'engine_events.freezed.dart';
@@ -149,6 +149,18 @@ class EngineEvent with _$EngineEvent {
   @Implements<FeedEngineEvent>()
   const factory EngineEvent.trustedSourcesListRequestFailed() =
       TrustedSourcesListRequestFailed;
+
+  /// Event created as a success response to AvailableSourcesListRequested event.
+  /// Passes a set of [AvailableSource] of available sources back to the client.
+  @Implements<FeedEngineEvent>()
+  const factory EngineEvent.availableSourcesListRequestSucceeded(
+    Set<AvailableSource> availableSources,
+  ) = AvailableSourcesListRequestSucceeded;
+
+  /// Event created as a failure response to AvailableSourcesListRequested event.
+  @Implements<FeedEngineEvent>()
+  const factory EngineEvent.availableSourcesListRequestFailed() =
+      AvailableSourcesListRequestFailed;
 
   /// Event created when fetching of AI assets has started.
   @Implements<AssetsStatusEngineEvent>()

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -18,6 +18,8 @@ import 'package:universal_platform/universal_platform.dart'
 import 'package:xayn_discovery_engine/src/api/api.dart'
     show
         AssetsStatusEngineEvent,
+        AvailableSourcesListRequestSucceeded,
+        AvailableSourcesListRequestFailed,
         ClientEvent,
         ClientEventSucceeded,
         Configuration,
@@ -293,6 +295,27 @@ class DiscoveryEngine {
     });
   }
 
+  /// Returns a [Set<AvailableSource>] with available sources.
+  ///
+  /// In response it can return:
+  /// - [AvailableSourcesListRequestSucceeded] indicating a successful operation,
+  /// containing a set of available sources.
+  /// - [AvailableSourcesListRequestFailed] indicating a failed operation
+  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// for such failure.
+  Future<EngineEvent> getAvailableSourcesList(String fuzzySearchTerm) {
+    return _trySend(() async {
+      final event = ClientEvent.availableSourcesListRequested(fuzzySearchTerm);
+      final response = await _manager.send(event);
+
+      return response.mapEvent(
+        availableSourcesListRequestSucceeded: true,
+        availableSourcesListRequestFailed: true,
+        engineExceptionRaised: true,
+      );
+    });
+  }
+
   /// Logs the time in seconds spent by a user on a [Document] in a certain
   /// mode.
   ///
@@ -555,6 +578,8 @@ extension _MapEvent on EngineEvent {
     bool? trendingTopicsRequestFailed,
     bool? trustedSourcesListRequestSucceeded,
     bool? trustedSourcesListRequestFailed,
+    bool? availableSourcesListRequestSucceeded,
+    bool? availableSourcesListRequestFailed,
   }) =>
       map(
         restoreFeedSucceeded: _maybePassThrough(restoreFeedSucceeded),
@@ -593,6 +618,10 @@ extension _MapEvent on EngineEvent {
             _maybePassThrough(trustedSourcesListRequestSucceeded),
         trustedSourcesListRequestFailed:
             _maybePassThrough(trustedSourcesListRequestFailed),
+        availableSourcesListRequestSucceeded:
+            _maybePassThrough(availableSourcesListRequestSucceeded),
+        availableSourcesListRequestFailed:
+            _maybePassThrough(availableSourcesListRequestFailed),
       );
 
   EngineEvent Function(EngineEvent) _maybePassThrough(bool? condition) {

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -26,7 +26,7 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
     show HistoricDocument;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -56,6 +56,9 @@ abstract class Engine {
     List<HistoricDocument> history,
     Set<Source> sources,
   );
+
+  /// Retrieves the available sources related to the search term.
+  Future<List<AvailableSource>> getAvailableSources(String fuzzySearchTerm);
 
   /// Retrieves at most [maxDocuments] feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -29,7 +29,7 @@ import 'package:xayn_discovery_engine/src/domain/models/history.dart'
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -114,6 +114,14 @@ class MockEngine implements Engine {
   ) async {
     _incrementCount('setTrustedSources');
     trustedSources = sources;
+  }
+
+  @override
+  Future<List<AvailableSource>> getAvailableSources(
+    String fuzzySearchTerm,
+  ) async {
+    _incrementCount('getAvailableSources');
+    throw UnimplementedError('TODO: TY-2749');
   }
 
   @override

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -13,7 +13,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:equatable/equatable.dart' show Equatable;
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:meta/meta.dart' show protected;
+
+part 'source.freezed.dart';
+part 'source.g.dart';
 
 /// A source of news/headlines/articles.
 class Source extends Equatable {
@@ -53,4 +57,17 @@ class Source extends Equatable {
 
 extension ToStringListExt on Set<Source> {
   List<String> toStringList() => map((s) => s._repr).toList();
+}
+
+@freezed
+class AvailableSource with _$AvailableSource {
+  @Assert('name.isNotEmpty')
+  @Assert('domain.isNotEmpty')
+  factory AvailableSource({
+    required String name,
+    required String domain,
+  }) = _AvailableSource;
+
+  factory AvailableSource.fromJson(Map<String, Object?> json) =>
+      _$AvailableSourceFromJson(json);
 }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -24,7 +24,7 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
     show HistoricDocument;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source, ToStringListExt;
+    show AvailableSource, Source, ToStringListExt;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -143,6 +143,14 @@ class DiscoveryEngineFfi implements Engine {
     );
 
     return resultVoidStringFfiAdapter.consumeNative(result);
+  }
+
+  /// Retrieves the available sources related to the search term.
+  @override
+  Future<List<AvailableSource>> getAvailableSources(
+    String fuzzySearchTerm,
+  ) async {
+    throw UnimplementedError('TODO: TY-2749');
   }
 
   /// Gets feed documents.

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -27,7 +27,7 @@ import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, Source;
 
 import '../../assets/utils/mock_manifest_reader.dart';
 
@@ -45,6 +45,7 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
   final EngineEvent trustedSourceAddedResponse;
   final EngineEvent trustedSourceRemovedResponse;
   final EngineEvent trustedSourcesListRequestedResponse;
+  final EngineEvent availableSourcesListRequestedResponse;
   final EngineEvent userReactionChangedResponse;
   final EngineEvent documentTimeLoggedResponse;
   final EngineEvent searchRequestedResponse;
@@ -85,6 +86,7 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
     EngineEvent? trustedSourcesListRequestedResponse,
     this.trendingTopicsRequestedResponse =
         const EngineEvent.trendingTopicsRequestSucceeded([]),
+    EngineEvent? availableSourcesListRequestedResponse,
   })  : excludedSourcesListRequestedResponse =
             excludedSourcesListRequestedResponse ??
                 EngineEvent.excludedSourcesListRequestSucceeded(
@@ -94,6 +96,11 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
             trustedSourcesListRequestedResponse ??
                 EngineEvent.trustedSourcesListRequestSucceeded(
                   {Source('example.com')},
+                ),
+        availableSourcesListRequestedResponse =
+            availableSourcesListRequestedResponse ??
+                EngineEvent.availableSourcesListRequestSucceeded(
+                  {AvailableSource(name: 'Example', domain: 'example.com')},
                 ),
         super(initialMessage);
 
@@ -111,6 +118,8 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
       trustedSourceAdded: (_) => trustedSourceAddedResponse,
       trustedSourceRemoved: (_) => trustedSourceRemovedResponse,
       trustedSourcesListRequested: (_) => trustedSourcesListRequestedResponse,
+      availableSourcesListRequested: (_) =>
+          availableSourcesListRequestedResponse,
       userReactionChanged: (_) => userReactionChangedResponse,
       documentTimeSpent: (_) => documentTimeLoggedResponse,
       searchRequested: (_) => searchRequestedResponse,

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -100,7 +100,7 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
         availableSourcesListRequestedResponse =
             availableSourcesListRequestedResponse ??
                 EngineEvent.availableSourcesListRequestSucceeded(
-                  {AvailableSource(name: 'Example', domain: 'example.com')},
+                  [AvailableSource(name: 'Example', domain: 'example.com')],
                 ),
         super(initialMessage);
 


### PR DESCRIPTION
**References**

- [TY-2747]
- followed by #356

**Summary**

- add `AvailableSourcesListRequested` to the `ClientEvent`s
- add `AvailableSourcesListRequestSucceeded` and `AvailableSourcesListRequestFailed` to the `EngineEvent`s
- impl stubs for the engine manager and the discovery engine to get the available sources


[TY-2747]: https://xainag.atlassian.net/browse/TY-2747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ