### PR TITLE
[Merged by Bors] - TY-2749 handle available sources event

### DIFF
--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -151,7 +151,7 @@ class EngineEvent with _$EngineEvent {
       TrustedSourcesListRequestFailed;
 
   /// Event created as a success response to AvailableSourcesListRequested event.
-  /// Passes a list of [AvailableSource] of available sources back to the client.
+  /// Passes a list of [AvailableSource]s back to the client.
   /// The list is sorted by decreasing match score.
   @Implements<FeedEngineEvent>()
   const factory EngineEvent.availableSourcesListRequestSucceeded(

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -56,7 +56,7 @@ import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/logger.dart' show logger;
 import 'package:xayn_discovery_engine/src/worker/worker.dart'
     show
@@ -295,7 +295,7 @@ class DiscoveryEngine {
     });
   }
 
-  /// Returns a [Set<AvailableSource>] with available sources.
+  /// Returns a list of [AvailableSource]s.
   ///
   /// In response it can return:
   /// - [AvailableSourcesListRequestSucceeded] indicating a successful operation,

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -132,5 +132,13 @@ class EngineInitializer with EquatableMixin {
   });
 
   @override
-  List<Object?> get props => [config, setupData, engineState, history];
+  List<Object?> get props => [
+        config,
+        setupData,
+        engineState,
+        history,
+        aiConfig,
+        trustedSources,
+        excludedSources,
+      ];
 }

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -26,7 +26,7 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
     show HistoricDocument;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show AvailableSource, Source;
+    show Source;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -56,9 +56,6 @@ abstract class Engine {
     List<HistoricDocument> history,
     Set<Source> sources,
   );
-
-  /// Retrieves the available sources related to the search term.
-  Future<List<AvailableSource>> getAvailableSources(String fuzzySearchTerm);
 
   /// Retrieves at most [maxDocuments] feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -121,7 +121,7 @@ class MockEngine implements Engine {
     String fuzzySearchTerm,
   ) async {
     _incrementCount('getAvailableSources');
-    throw UnimplementedError('TODO: TY-2749');
+    return [AvailableSource(name: 'Example', domain: 'example.com')];
   }
 
   @override

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -29,7 +29,7 @@ import 'package:xayn_discovery_engine/src/domain/models/history.dart'
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show AvailableSource, Source;
+    show Source;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -114,14 +114,6 @@ class MockEngine implements Engine {
   ) async {
     _incrementCount('setTrustedSources');
     trustedSources = sources;
-  }
-
-  @override
-  Future<List<AvailableSource>> getAvailableSources(
-    String fuzzySearchTerm,
-  ) async {
-    _incrementCount('getAvailableSources');
-    return [AvailableSource(name: 'Example', domain: 'example.com')];
   }
 
   @override

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -56,7 +56,7 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResourceAdapter;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSources, Source;
 import 'package:xayn_discovery_engine/src/domain/models/source_preference.dart'
     show SourcePreference, SourcePreferenceAdapter, PreferenceModeAdapter;
 import 'package:xayn_discovery_engine/src/domain/models/view_mode.dart'
@@ -227,6 +227,7 @@ class EventHandler {
     final history = await documentRepository.fetchHistory();
     final trustedSources = await sourcePreferenceRepository.getTrusted();
     final excludedSources = await sourcePreferenceRepository.getExcluded();
+    final availableSources = AvailableSources([]); // TODO: TY-2746
 
     final engine = await _initializeEngine(
       EngineInitializer(
@@ -259,6 +260,7 @@ class EventHandler {
       activeDataRepository,
       engineStateRepository,
       sourcePreferenceRepository,
+      availableSources,
     );
     _searchManager = SearchManager(
       engine,

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -208,6 +208,11 @@ class FeedManager {
 
   Future<EngineEvent> getAvailableSourcesList(String fuzzySearchTerm) async {
     final sources = await _engine.getAvailableSources(fuzzySearchTerm);
+
+    if (sources.isEmpty) {
+      return const EngineEvent.availableSourcesListRequestFailed();
+    }
+
     return EngineEvent.availableSourcesListRequestSucceeded(sources);
   }
 }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -23,7 +23,7 @@ import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSources, Source;
 import 'package:xayn_discovery_engine/src/domain/models/source_preference.dart'
     show SourcePreference, PreferenceMode;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
@@ -45,6 +45,7 @@ class FeedManager {
   final ActiveDocumentDataRepository _activeRepo;
   final EngineStateRepository _engineStateRepo;
   final SourcePreferenceRepository _sourcePreferenceRepository;
+  final AvailableSources _availableSources;
 
   FeedManager(
     this._engine,
@@ -53,6 +54,7 @@ class FeedManager {
     this._activeRepo,
     this._engineStateRepo,
     this._sourcePreferenceRepository,
+    this._availableSources,
   );
 
   /// Handle the given feed client event.
@@ -207,7 +209,10 @@ class FeedManager {
   }
 
   Future<EngineEvent> getAvailableSourcesList(String fuzzySearchTerm) async {
-    final sources = await _engine.getAvailableSources(fuzzySearchTerm);
+    final sources = _availableSources
+        .search(fuzzySearchTerm)
+        .map((source) => source.item)
+        .toList(growable: false);
 
     if (sources.isEmpty) {
       return const EngineEvent.availableSourcesListRequestFailed();

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -69,6 +69,7 @@ class FeedManager {
         trustedSourceAdded: addTrustedSource,
         trustedSourceRemoved: removeTrustedSource,
         trustedSourcesListRequested: getTrustedSourcesList,
+        availableSourcesListRequested: getAvailableSourcesList,
         orElse: () =>
             throw UnimplementedError('handler not implemented for $event'),
       );
@@ -203,5 +204,10 @@ class FeedManager {
   Future<EngineEvent> getTrustedSourcesList() async {
     final sources = await _sourcePreferenceRepository.getTrusted();
     return EngineEvent.trustedSourcesListRequestSucceeded(sources);
+  }
+
+  Future<EngineEvent> getAvailableSourcesList(String fuzzySearchTerm) async {
+    final sources = await _engine.getAvailableSources(fuzzySearchTerm);
+    return EngineEvent.availableSourcesListRequestSucceeded(sources);
   }
 }

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -14,6 +14,7 @@
 
 import 'package:equatable/equatable.dart' show Equatable;
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
 import 'package:meta/meta.dart' show protected;
 
 part 'source.freezed.dart';
@@ -70,4 +71,21 @@ class AvailableSource with _$AvailableSource {
 
   factory AvailableSource.fromJson(Map<String, Object?> json) =>
       _$AvailableSourceFromJson(json);
+}
+
+class AvailableSources extends Fuzzy<AvailableSource> {
+  AvailableSources(List<AvailableSource> availableSources)
+      : super(
+          availableSources,
+          options: FuzzyOptions(
+            findAllMatches: false,
+            isCaseSensitive: false,
+            minMatchCharLength: 3,
+            minTokenCharLength: 3,
+            shouldNormalize: false,
+            shouldSort: true,
+            threshold: 0.2,
+            tokenize: true,
+          ),
+        );
 }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -15,8 +15,6 @@
 import 'dart:ffi' show nullptr;
 import 'dart:typed_data' show Uint8List;
 
-import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
-
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine, EngineInitializer;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
@@ -26,7 +24,7 @@ import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
     show HistoricDocument;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show AvailableSource, Source, ToStringListExt;
+    show Source, ToStringListExt;
 import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
@@ -65,9 +63,8 @@ import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_prov
 /// A handle to the discovery engine.
 class DiscoveryEngineFfi implements Engine {
   final Boxed<RustSharedEngine> _engine;
-  final Fuzzy<AvailableSource> _availableSources;
 
-  const DiscoveryEngineFfi._(final this._engine, final this._availableSources);
+  const DiscoveryEngineFfi._(final this._engine);
 
   /// Initializes the engine.
   static Future<DiscoveryEngineFfi> initialize(
@@ -94,21 +91,7 @@ class DiscoveryEngineFfi implements Engine {
     );
     final boxedEngine = resultSharedEngineStringFfiAdapter.moveNative(result);
 
-    final availableSources = Fuzzy<AvailableSource>(
-      <AvailableSource>[], // TODO: TY-2746
-      options: FuzzyOptions(
-        findAllMatches: false,
-        isCaseSensitive: false,
-        minMatchCharLength: 3,
-        minTokenCharLength: 3,
-        shouldNormalize: false,
-        shouldSort: true,
-        threshold: 0.2,
-        tokenize: true,
-      ),
-    );
-
-    return DiscoveryEngineFfi._(boxedEngine, availableSources);
+    return DiscoveryEngineFfi._(boxedEngine);
   }
 
   /// Serializes the engine.
@@ -161,17 +144,6 @@ class DiscoveryEngineFfi implements Engine {
     );
 
     return resultVoidStringFfiAdapter.consumeNative(result);
-  }
-
-  /// Retrieves the available sources related to the search term.
-  @override
-  Future<List<AvailableSource>> getAvailableSources(
-    String fuzzySearchTerm,
-  ) async {
-    return _availableSources
-        .search(fuzzySearchTerm)
-        .map((source) => source.item)
-        .toList(growable: false);
   }
 
   /// Gets feed documents.

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   crypto: ^3.0.1
   equatable: ^2.0.3
   freezed_annotation: ^1.1.0
+  fuzzy: ^0.4.0-nullsafety.0
   hive: ^2.0.5
   http: ^0.13.4
   http_retry: ^0.2.0

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -34,7 +34,7 @@ import 'package:xayn_discovery_engine/src/domain/models/document.dart'
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show Source;
+    show AvailableSource, AvailableSources, Source;
 import 'package:xayn_discovery_engine/src/domain/models/source_preference.dart'
     show SourcePreference;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
@@ -80,6 +80,9 @@ Future<void> main() async {
   final activeRepo = HiveActiveDocumentDataRepository();
   final engineStateRepo = HiveEngineStateRepository();
   final sourcePreferenceRepo = HiveSourcePreferenceRepository();
+  final availableSources = AvailableSources(
+    [AvailableSource(name: 'Example', domain: 'example.com')],
+  );
 
   final mgr = FeedManager(
     engine,
@@ -88,6 +91,7 @@ Future<void> main() async {
     activeRepo,
     engineStateRepo,
     sourcePreferenceRepo,
+    availableSources,
   );
 
   group('FeedManager', () {

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -118,6 +118,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  fuzzy:
+    dependency: transitive
+    description:
+      name: fuzzy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0-nullsafety.0"
   hive:
     dependency: transitive
     description:
@@ -153,6 +160,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.4.0"
+  latinize:
+    dependency: transitive
+    description:
+      name: latinize
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-nullsafety.0"
   lints:
     dependency: transitive
     description:


### PR DESCRIPTION
**References**

- [TY-2749]
- [TY-2748]
- requires #354

**Summary**

- impl fuzzy search for available sources, we don't want to expose the configuration but it might likely be changed in agreement with blue once they do some experiments
- move the available sources from the engine to the feed manager (review comment from previous pr)


[TY-2749]: https://xainag.atlassian.net/browse/TY-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2748]: https://xainag.atlassian.net/browse/TY-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ