### PR TITLE
[Merged by Bors] - TY-2802 improve error handling for invalid engine state

### DIFF
--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -84,6 +84,8 @@ enum EngineExceptionReason {
   engineDisposed,
   @JsonValue(7)
   failedToGetAssets,
+  @JsonValue(8)
+  invalidEngineState,
   // other possible errors will be added below
 }
 

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -317,7 +317,7 @@ class DiscoveryEngine {
   ///
   /// [UserReaction] variants are defined as:
   /// - [UserReaction.positive] indicates that the [Document] was **liked**
-  /// - [UserReaction.negative] indicates that the [Document] was **diliked**
+  /// - [UserReaction.negative] indicates that the [Document] was **disliked**
   /// - [UserReaction.neutral] as a default **neutral** state of the [Document].
   ///
   /// In response it can return:

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -163,9 +163,14 @@ class EventHandler {
         );
       } catch (e, st) {
         logger.e('failed to initialize the engine', e, st);
-        final reason = e is AssetFetcherException
-            ? EngineExceptionReason.failedToGetAssets
-            : EngineExceptionReason.genericError;
+        final EngineExceptionReason reason;
+        if (e is AssetFetcherException) {
+          reason = EngineExceptionReason.failedToGetAssets;
+        } else if (e is InvalidEngineStateException) {
+          reason = EngineExceptionReason.invalidEngineState;
+        } else {
+          reason = EngineExceptionReason.genericError;
+        }
         return EngineEvent.engineExceptionRaised(
           reason,
           message: '$e',
@@ -228,17 +233,26 @@ class EventHandler {
     final trustedSources = await sourcePreferenceRepository.getTrusted();
     final excludedSources = await sourcePreferenceRepository.getExcluded();
 
-    final engine = await _initializeEngine(
-      EngineInitializer(
-        config: config,
-        setupData: setupData,
-        engineState: engineState,
-        history: history,
-        aiConfig: aiConfig,
-        trustedSources: trustedSources,
-        excludedSources: excludedSources,
-      ),
-    );
+    final Engine engine;
+    try {
+      engine = await _initializeEngine(
+        EngineInitializer(
+          config: config,
+          setupData: setupData,
+          engineState: engineState,
+          history: history,
+          aiConfig: aiConfig,
+          trustedSources: trustedSources,
+          excludedSources: excludedSources,
+        ),
+      );
+    } catch (e) {
+      if ('$e'.contains('Unsupported serialized data.')) {
+        await engineStateRepository.clear();
+        throw InvalidEngineStateException('$e');
+      }
+      rethrow;
+    }
 
     // init managers
     final eventConfig = EventConfig(
@@ -341,4 +355,15 @@ class EventHandler {
       await Hive.openBox<T>(name, bytes: Uint8List(0));
     }
   }
+}
+
+/// Thrown when the engine cannot be recovered from the given state.
+class InvalidEngineStateException implements Exception {
+  final String message;
+
+  InvalidEngineStateException(this.message);
+
+  @override
+  String toString() =>
+      'InvalidEngineStateException: $message. Try to restart the engine.';
 }

--- a/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
+++ b/discovery_engine/lib/src/domain/repository/engine_state_repo.dart
@@ -21,4 +21,7 @@ abstract class EngineStateRepository {
 
   /// Persist the state of the engine.
   Future<void> save(Uint8List bytes);
+
+  /// Remove current engine state.
+  Future<void> clear();
 }

--- a/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
+++ b/discovery_engine/lib/src/infrastructure/repository/hive_engine_state_repo.dart
@@ -31,4 +31,9 @@ class HiveEngineStateRepository implements EngineStateRepository {
 
   @override
   Future<void> save(Uint8List bytes) => box.put(stateKey, bytes);
+
+  @override
+  Future<void> clear() async {
+    await box.clear();
+  }
 }


### PR DESCRIPTION
Ticket: 
- [TY-2802]

Summary:

Currently, if the engine cannot be restored from the saved state (if the version of the saved state > the expected version), the error is simply propagated to the caller. However, the caller has no way of clearing the invalid engine state or starting the engine from scratch. Therefore, we need to improve the error handling for this specific error. The idea is to just clear invalid engine status when this error occurs and return an error to the caller saying that they should try again. 

The improved error handling is implemented in Dart so that team blue can catch those errors and emit events for them. 

[TY-2802]: https://xainag.atlassian.net/browse/TY-2802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ