### PR TITLE
[Merged by Bors] - TY-2746 available sources asset

### DIFF
--- a/discovery_engine/lib/assets/asset_manifest.json
+++ b/discovery_engine/lib/assets/asset_manifest.json
@@ -35,6 +35,12 @@
       "url_suffix": "kpe_v0001/classifier.binparams",
       "checksum": "cd78be076b246d3065c7a646fe1ca19b57c1c670424f093ce1bd5211fa21082c",
       "fragments": []
+    },
+    {
+      "id": "availableSources",
+      "url_suffix": "sources_v0000/available_sources.csv",
+      "checksum": "e28996c4bb59ea358f6310835fc93b5b390eed99fab15cfae42f5bed0528742c",
+      "fragments": []
     }
   ]
 }

--- a/discovery_engine/lib/src/domain/assets/asset.dart
+++ b/discovery_engine/lib/src/domain/assets/asset.dart
@@ -70,6 +70,7 @@ enum AssetType {
   kpeModel,
   kpeCnn,
   kpeClassifier,
+  availableSources,
 }
 
 /// A fragment of an asset.

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -15,6 +15,8 @@
 import 'package:equatable/equatable.dart' show EquatableMixin;
 import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
     show AssetFetcher, AssetReporter, Manifest;
+import 'package:xayn_discovery_engine/src/domain/models/source.dart'
+    show AvailableSources;
 
 const _kEnginePath = 'engine_data';
 const kAssetsPath = '$_kEnginePath/assets';
@@ -41,6 +43,10 @@ abstract class SetupData with EquatableMixin {
         kpeClassifier,
         availableSources,
       ];
+
+  Future<AvailableSources> getAvailableSources() {
+    throw UnsupportedError('Unsupported plattform.');
+  }
 }
 
 /// Reads the assets manifest and provides the [SetupData] to further use.

--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -29,10 +29,18 @@ abstract class SetupData with EquatableMixin {
   Object get kpeModel;
   Object get kpeCnn;
   Object get kpeClassifier;
+  Object get availableSources;
 
   @override
-  List<Object?> get props =>
-      [smbertVocab, smbertModel, kpeVocab, kpeModel, kpeCnn, kpeClassifier];
+  List<Object?> get props => [
+        smbertVocab,
+        smbertModel,
+        kpeVocab,
+        kpeModel,
+        kpeCnn,
+        kpeClassifier,
+        availableSources,
+      ];
 }
 
 /// Reads the assets manifest and provides the [SetupData] to further use.

--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -38,4 +38,10 @@ class Configuration with _$Configuration {
 
   factory Configuration.fromJson(Map<String, Object?> json) =>
       _$ConfigurationFromJson(json);
+
+  const Configuration._();
+
+  bool isMocked() =>
+      apiKey == 'use-mock-engine' &&
+      apiBaseUrl == 'https://use-mock-engine.test';
 }

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -18,7 +18,6 @@ import 'package:csv/csv.dart' show CsvToListConverter;
 import 'package:equatable/equatable.dart' show Equatable;
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
-import 'package:meta/meta.dart' show protected;
 
 part 'source.freezed.dart';
 part 'source.g.dart';

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -12,6 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:convert' show utf8;
+
+import 'package:csv/csv.dart' show CsvToListConverter;
 import 'package:equatable/equatable.dart' show Equatable;
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
@@ -88,4 +91,31 @@ class AvailableSources extends Fuzzy<AvailableSource> {
             tokenize: true,
           ),
         );
+
+  static Future<AvailableSources> fromBytes(Stream<List<int>> bytes) async {
+    const converter = CsvToListConverter(
+      fieldDelimiter: ';',
+      textDelimiter: '\b',
+      textEndDelimiter: '\b',
+      eol: '\n',
+      shouldParseNumbers: false,
+      allowInvalid: false,
+    );
+    final sources =
+        await bytes.transform(utf8.decoder).transform(converter).toList();
+
+    return AvailableSources(
+      sources
+          .map(
+            (source) => AvailableSource(
+              name: source[0] as String,
+              domain: source[1] as String,
+            ),
+          )
+          .toList(),
+    );
+  }
 }
+
+final mockedAvailableSources =
+    AvailableSources([AvailableSource(name: 'Example', domain: 'example.com')]);

--- a/discovery_engine/lib/src/infrastructure/assets/native/data_provider.dart
+++ b/discovery_engine/lib/src/infrastructure/assets/native/data_provider.dart
@@ -59,6 +59,7 @@ class NativeDataProvider extends DataProvider {
       kpeModel: paths[AssetType.kpeModel]!,
       kpeCnn: paths[AssetType.kpeCnn]!,
       kpeClassifier: paths[AssetType.kpeClassifier]!,
+      availableSources: paths[AssetType.availableSources]!,
     );
   }
 
@@ -138,6 +139,8 @@ class NativeSetupData extends SetupData {
   final String kpeCnn;
   @override
   final String kpeClassifier;
+  @override
+  final String availableSources;
 
   NativeSetupData({
     required this.smbertVocab,
@@ -146,6 +149,7 @@ class NativeSetupData extends SetupData {
     required this.kpeModel,
     required this.kpeCnn,
     required this.kpeClassifier,
+    required this.availableSources,
   });
 }
 

--- a/discovery_engine/lib/src/infrastructure/assets/native/data_provider.dart
+++ b/discovery_engine/lib/src/infrastructure/assets/native/data_provider.dart
@@ -26,6 +26,8 @@ import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
         Manifest,
         SetupData,
         tmpFileExt;
+import 'package:xayn_discovery_engine/src/domain/models/source.dart'
+    show AvailableSources;
 
 class NativeDataProvider extends DataProvider {
   @override
@@ -151,6 +153,10 @@ class NativeSetupData extends SetupData {
     required this.kpeClassifier,
     required this.availableSources,
   });
+
+  @override
+  Future<AvailableSources> getAvailableSources() async =>
+      AvailableSources.fromBytes(File(availableSources).openRead());
 }
 
 DataProvider createDataProvider(

--- a/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
+++ b/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
@@ -22,6 +22,8 @@ import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
         DataProvider,
         Manifest,
         SetupData;
+import 'package:xayn_discovery_engine/src/domain/models/source.dart'
+    show AvailableSources;
 
 class WebDataProvider extends DataProvider {
   @override
@@ -87,6 +89,10 @@ class WebSetupData extends SetupData {
     required this.kpeClassifier,
     required this.availableSources,
   });
+
+  @override
+  Future<AvailableSources> getAvailableSources() async =>
+      AvailableSources.fromBytes(Stream.value(availableSources.toList()));
 }
 
 DataProvider createDataProvider(

--- a/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
+++ b/discovery_engine/lib/src/infrastructure/assets/web/data_provider.dart
@@ -57,6 +57,7 @@ class WebDataProvider extends DataProvider {
       kpeModel: fetched[AssetType.kpeModel]!,
       kpeCnn: fetched[AssetType.kpeCnn]!,
       kpeClassifier: fetched[AssetType.kpeClassifier]!,
+      availableSources: fetched[AssetType.availableSources]!,
     );
   }
 }
@@ -74,6 +75,8 @@ class WebSetupData extends SetupData {
   final Uint8List kpeCnn;
   @override
   final Uint8List kpeClassifier;
+  @override
+  final Uint8List availableSources;
 
   WebSetupData({
     required this.smbertVocab,
@@ -82,6 +85,7 @@ class WebSetupData extends SetupData {
     required this.kpeModel,
     required this.kpeCnn,
     required this.kpeClassifier,
+    required this.availableSources,
   });
 }
 

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   async: ^2.8.1
+  csv: ^5.0.1
   crypto: ^3.0.1
   equatable: ^2.0.3
   freezed_annotation: ^1.1.0

--- a/discovery_engine/test/assets/data_provider_test.dart
+++ b/discovery_engine/test/assets/data_provider_test.dart
@@ -48,6 +48,7 @@ void main() {
         kpeModel: '$outputPath/kpeModel',
         kpeClassifier: '$outputPath/kpeClassifier',
         kpeCnn: '$outputPath/kpeCnn',
+        availableSources: '$outputPath/availableSources',
       );
       final tmpSetupData = NativeSetupData(
         smbertVocab: '$outputPath/smbertVocab.$tmpFileExt',
@@ -56,6 +57,7 @@ void main() {
         kpeModel: '$outputPath/kpeModel.$tmpFileExt',
         kpeClassifier: '$outputPath/kpeClassifier.$tmpFileExt',
         kpeCnn: '$outputPath/kpeCnn.$tmpFileExt',
+        availableSources: '$outputPath/availableSources.$tmpFileExt',
       );
 
       late LocalAssetServer server;
@@ -92,7 +94,7 @@ void main() {
 
         expect(setupData, equals(finalSetupData));
         expect(allSetupDataFilesExist(finalSetupData), isTrue);
-        expect(assetFetcher.callCount, equals(8));
+        expect(assetFetcher.callCount, equals(9));
       });
 
       test(
@@ -131,7 +133,7 @@ void main() {
         expect(setupData, equals(finalSetupData));
         expect(allSetupDataFilesExist(finalSetupData), isTrue);
         expect(allSetupDataFilesExist(tmpSetupData), isFalse);
-        expect(assetFetcher.callCount, equals(8));
+        expect(assetFetcher.callCount, equals(9));
       });
 
       test(
@@ -153,8 +155,8 @@ void main() {
 
         expect(setupData, equals(finalSetupData));
         expect(allSetupDataFilesExist(finalSetupData), isTrue);
-        expect(server.callCountSum, equals(8));
-        expect(assetFetcher.callCount, equals(8));
+        expect(server.callCountSum, equals(9));
+        expect(assetFetcher.callCount, equals(9));
       });
     });
   });
@@ -185,6 +187,7 @@ bool allSetupDataFilesExist(NativeSetupData setupData) {
     File(setupData.kpeModel).existsSync(),
     File(setupData.kpeCnn).existsSync(),
     File(setupData.kpeClassifier).existsSync(),
+    File(setupData.availableSources).existsSync(),
   ];
   return list.any((it) => it == false) == false;
 }

--- a/discovery_engine/test/assets/utils/local_asset_server.dart
+++ b/discovery_engine/test/assets/utils/local_asset_server.dart
@@ -22,6 +22,7 @@ const bytesMap = {
   'kpeModel': _bytes,
   'kpeCnn': _bytes,
   'kpeClassifier': _bytes,
+  'availableSources': _bytes,
 };
 
 class LocalAssetServer {

--- a/discovery_engine/test/assets/utils/mock_manifest_reader.dart
+++ b/discovery_engine/test/assets/utils/mock_manifest_reader.dart
@@ -43,6 +43,7 @@ final goodJson = {
     'kpeModel',
     'kpeCnn',
     'kpeClassifier',
+    'availableSources',
   ]
       .map(
         (id) => {

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -27,7 +27,7 @@ import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show AvailableSource, Source;
+    show mockedAvailableSources, Source;
 
 import '../../assets/utils/mock_manifest_reader.dart';
 
@@ -100,7 +100,7 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
         availableSourcesListRequestedResponse =
             availableSourcesListRequestedResponse ??
                 EngineEvent.availableSourcesListRequestSucceeded(
-                  [AvailableSource(name: 'Example', domain: 'example.com')],
+                  mockedAvailableSources.list,
                 ),
         super(initialMessage);
 

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -34,7 +34,7 @@ import 'package:xayn_discovery_engine/src/domain/models/document.dart'
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
-    show AvailableSource, AvailableSources, Source;
+    show mockedAvailableSources, Source;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_document_repo.dart'
@@ -61,10 +61,6 @@ Future<void> main() async {
   final engine = MockEngine();
   final config = EventConfig(maxFeedDocs: 5, maxSearchDocs: 20);
 
-  final availableSources = AvailableSources(
-    [AvailableSource(name: 'Example', domain: 'example.com')],
-  );
-
   EventHandler.registerHiveAdapters();
 
   group('FeedManager', () {
@@ -88,7 +84,7 @@ Future<void> main() async {
         activeRepo,
         engineStateRepo,
         sourcePreferenceRepo,
-        availableSources,
+        mockedAvailableSources,
       );
 
       data = ActiveDocumentData(Embedding.fromList([44]));
@@ -207,7 +203,7 @@ Future<void> main() async {
         activeRepo,
         engineStateRepo,
         sourcePreferenceRepo,
-        availableSources,
+        mockedAvailableSources,
       );
       engine.resetCallCounter();
     });

--- a/discovery_engine/test/ffi/ffi_test.dart
+++ b/discovery_engine/test/ffi/ffi_test.dart
@@ -50,6 +50,7 @@ void main() {
       kpeModel: '',
       kpeCnn: '',
       kpeClassifier: '',
+      availableSources: '',
     );
     expect(
       DiscoveryEngineFfi.initialize(

--- a/discovery_engine_flutter/example/.gitignore
+++ b/discovery_engine_flutter/example/.gitignore
@@ -55,3 +55,5 @@ app.*.map.json
 !/assets/smbert_v0001
 !/assets/smbert_v0001/.gitkeep
 !/assets/smbert_v0001/smbert-mocked.onnx
+!/assets/sources_v0000
+!/assets/sources_v0000/.gitkeep

--- a/discovery_engine_flutter/example/download_assets.sh
+++ b/discovery_engine_flutter/example/download_assets.sh
@@ -40,3 +40,4 @@ download()
 
 download smbert v0001
 download kpe v0001
+download sources v0000

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -59,6 +59,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csv:
+    dependency: transitive
+    description:
+      name: csv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -55,6 +55,7 @@ flutter:
   assets:
     - assets/kpe_v0001/
     - assets/smbert_v0001/
+    - assets/sources_v0000/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.

--- a/discovery_engine_flutter/test/xayn_discovery_engine_flutter_test.dart
+++ b/discovery_engine_flutter/test/xayn_discovery_engine_flutter_test.dart
@@ -62,6 +62,7 @@ void main() {
         'kpeModel',
         'kpeCnn',
         'kpeClassifier',
+        'availableSources',
       ]
           .map(
             (id) => {


### PR DESCRIPTION
**References**

- [TY-2746]
- requires #356
- followed by #372

**Summary**

- add the available sources asset to the setup data, the asset itself is already uploaded to the yellow and staging buckets
- load it during engine initialization and parse the csv content


[TY-2746]: https://xainag.atlassian.net/browse/TY-2746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ