### PR TITLE
[Merged by Bors] - Disable soname

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ ANDROID_PLATFORM_VERSION="21"
 IOS_TARGETS="aarch64-apple-ios x86_64-apple-ios"
 IOS_LIB_BASE="libxayn_discovery_engine_bindings"
 
-PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes -Clink-arg=-Wl,-soname,libxayn_discovery_engine_bindings.so"
+PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes"
 
 JUST_VERSION=0.10.5
 # In the cases we want to use nightly we use the following version

--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ ANDROID_PLATFORM_VERSION="21"
 IOS_TARGETS="aarch64-apple-ios x86_64-apple-ios"
 IOS_LIB_BASE="libxayn_discovery_engine_bindings"
 
-PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes"
+PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes -Clink-arg=-Wl,-soname,libxayn_discovery_engine_bindings.so"
 
 JUST_VERSION=0.10.5
 # In the cases we want to use nightly we use the following version

--- a/.github/scripts/check_android_so.sh
+++ b/.github/scripts/check_android_so.sh
@@ -30,7 +30,7 @@ function check_so() {
     fi
 
     if [ "$(readelf --dynamic "$SO_FILE" | grep SONAME)" = "" ]; then
-        err "NO SONAME in: '$SO_FILE'"
+        error "NO SONAME in: '$SO_FILE'"
     fi
 
     if [ "$OLD_ERROR_COUNT" = "$ERROR_COUNT" ]; then

--- a/.github/scripts/check_android_so.sh
+++ b/.github/scripts/check_android_so.sh
@@ -30,7 +30,7 @@ function check_so() {
     fi
 
     if [ "$(readelf --dynamic "$SO_FILE" | grep SONAME)" = "" ]; then
-        error "NO SONAME in: '$SO_FILE'"
+        warn "NO SONAME in: '$SO_FILE'"
     fi
 
     if [ "$OLD_ERROR_COUNT" = "$ERROR_COUNT" ]; then

--- a/.github/scripts/check_android_so.sh
+++ b/.github/scripts/check_android_so.sh
@@ -30,8 +30,7 @@ function check_so() {
     fi
 
     if [ "$(readelf --dynamic "$SO_FILE" | grep SONAME)" = "" ]; then
-        warn "AUTO-FIXED: NO SONAME in: '$SO_FILE'"
-        patchelf --set-soname "$(basename "$SO_FILE")" "$SO_FILE"
+        err "NO SONAME in: '$SO_FILE'"
     fi
 
     if [ "$OLD_ERROR_COUNT" = "$ERROR_COUNT" ]; then


### PR DESCRIPTION
For unknown reasons the lib is corrupted during the `flutter build` process on the CI and some of the local machine.
Setting the soname using the compiler flag seems to avoid this.

Edit:
Removed soname but kept the warning.