### PR TITLE
[Merged by Bors] - TY-2805 Do not expose paging info of ActiveSearch to API.

### DIFF
--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -74,10 +74,9 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         EngineExceptionReason;
 export 'package:xayn_discovery_engine/src/api/models/active_search.dart'
     hide ActiveSearchApiConversion;
-export 'package:xayn_discovery_engine/src/api/models/document.dart';
+export 'package:xayn_discovery_engine/src/api/models/document.dart'
+    hide DocumentApiConversion;
 export 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
-export 'package:xayn_discovery_engine/src/domain/models/document.dart'
-    show UserReaction;
 export 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarket, FeedMarkets;
 export 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'

--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -72,9 +72,11 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         DocumentsUpdated,
         EngineExceptionRaised,
         EngineExceptionReason;
+export 'package:xayn_discovery_engine/src/api/models/active_search.dart'
+    show ActiveSearch;
 export 'package:xayn_discovery_engine/src/api/models/document.dart';
 export 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch, SearchBy;
+    show SearchBy;
 export 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
 export 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show UserReaction;

--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -73,10 +73,8 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         EngineExceptionRaised,
         EngineExceptionReason;
 export 'package:xayn_discovery_engine/src/api/models/active_search.dart'
-    show ActiveSearch;
+    hide ActiveSearchApiConversion;
 export 'package:xayn_discovery_engine/src/api/models/document.dart';
-export 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show SearchBy;
 export 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
 export 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show UserReaction;

--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -13,7 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
+    show SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/configuration.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart';
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart';

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -13,8 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:xayn_discovery_engine/src/api/models/active_search.dart';
 import 'package:xayn_discovery_engine/src/api/models/document.dart';
-import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
     show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart';

--- a/discovery_engine/lib/src/api/models/active_search.dart
+++ b/discovery_engine/lib/src/api/models/active_search.dart
@@ -1,0 +1,31 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
+
+part 'active_search.freezed.dart';
+part 'active_search.g.dart';
+
+/// [ActiveSearch] represents attributes of a performed search.
+@freezed
+class ActiveSearch with _$ActiveSearch {
+  const factory ActiveSearch({
+    required String searchTerm,
+    required SearchBy searchBy,
+  }) = _ActiveSearch;
+
+  factory ActiveSearch.fromJson(Map<String, Object?> json) =>
+      _$ActiveSearchFromJson(json);
+}

--- a/discovery_engine/lib/src/api/models/active_search.dart
+++ b/discovery_engine/lib/src/api/models/active_search.dart
@@ -13,7 +13,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
+    as domain;
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
+    show SearchBy;
+
+// Re-export public parts of `domain/` to avoid juggling multiple `active_search.dart`
+// imports in the same file.
+export 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
+    show SearchBy;
 
 part 'active_search.freezed.dart';
 part 'active_search.g.dart';
@@ -28,4 +36,10 @@ class ActiveSearch with _$ActiveSearch {
 
   factory ActiveSearch.fromJson(Map<String, Object?> json) =>
       _$ActiveSearchFromJson(json);
+}
+
+@protected
+extension ActiveSearchApiConversion on domain.ActiveSearch {
+  ActiveSearch toApiRepr() =>
+      ActiveSearch(searchTerm: searchTerm, searchBy: searchBy);
 }

--- a/discovery_engine/lib/src/api/models/document.dart
+++ b/discovery_engine/lib/src/api/models/document.dart
@@ -14,10 +14,15 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
+    as domain;
+import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show UserReaction;
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart';
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
     show DocumentId;
+
+export 'package:xayn_discovery_engine/src/domain/models/document.dart'
+    show UserReaction;
 
 part 'document.freezed.dart';
 part 'document.g.dart';
@@ -38,4 +43,14 @@ class Document with _$Document {
   /// Converts json Map to [Document].
   factory Document.fromJson(Map<String, Object?> json) =>
       _$DocumentFromJson(json);
+}
+
+@protected
+extension DocumentApiConversion on domain.Document {
+  Document toApiRepr() => Document(
+        documentId: documentId,
+        resource: resource,
+        userReaction: userReaction,
+        batchIndex: batchIndex,
+      );
 }

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -46,13 +46,12 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         UserReaction,
         TrendingTopic,
         TrendingTopicsRequestSucceeded,
-        TrendingTopicsRequestFailed;
+        TrendingTopicsRequestFailed,
+        SearchBy;
 import 'package:xayn_discovery_engine/src/discovery_engine_manager.dart'
     show DiscoveryEngineManager;
 import 'package:xayn_discovery_engine/src/discovery_engine_worker.dart'
     as entry_point show main;
-import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show SearchBy;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'

--- a/discovery_engine/lib/src/domain/changed_documents_reporter.dart
+++ b/discovery_engine/lib/src/domain/changed_documents_reporter.dart
@@ -21,7 +21,6 @@ import 'package:xayn_discovery_engine/src/api/models/document.dart'
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
 
-
 /// Class that manages a stream of [DocumentsUpdated] events.
 class ChangedDocumentsReporter {
   final _changedDocsCtrl = StreamController<EngineEvent>.broadcast();

--- a/discovery_engine/lib/src/domain/changed_documents_reporter.dart
+++ b/discovery_engine/lib/src/domain/changed_documents_reporter.dart
@@ -13,10 +13,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:async' show StreamController;
+
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show EngineEvent, DocumentsUpdated;
+import 'package:xayn_discovery_engine/src/api/models/document.dart'
+    show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
+
 
 /// Class that manages a stream of [DocumentsUpdated] events.
 class ChangedDocumentsReporter {
@@ -24,7 +28,7 @@ class ChangedDocumentsReporter {
   Stream<EngineEvent> get changedDocuments => _changedDocsCtrl.stream;
 
   void notifyChanged(List<Document> documents) {
-    final payload = documents.map((it) => it.toApiDocument()).toList();
+    final payload = documents.map((it) => it.toApiRepr()).toList();
     final event = DocumentsUpdated(payload);
     _changedDocsCtrl.add(event);
   }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -16,6 +16,8 @@ import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show FeedClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show EngineEvent, FeedFailureReason;
+import 'package:xayn_discovery_engine/src/api/models/document.dart'
+    show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
@@ -96,7 +98,7 @@ class FeedManager {
                   : timeOrd;
             });
 
-          final feed = sortedActives.map((doc) => doc.toApiDocument()).toList();
+          final feed = sortedActives.map((doc) => doc.toApiRepr()).toList();
           return EngineEvent.restoreFeedSucceeded(feed);
         },
       );
@@ -123,7 +125,7 @@ class FeedManager {
     }
 
     final feed = feedDocs
-        .map((docWithData) => docWithData.document.toApiDocument())
+        .map((docWithData) => docWithData.document.toApiRepr())
         .toList();
 
     if (feed.isEmpty) {

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -15,7 +15,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart'
     show HiveType, HiveField, TypeAdapter, BinaryReader, BinaryWriter;
-import 'package:xayn_discovery_engine/src/api/models/active_search.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/repository/type_id.dart'
     show searchTypeId, searchByTypeId;
 
@@ -27,28 +26,25 @@ class ActiveSearch with EquatableMixin {
   @HiveField(0)
   final String searchTerm;
   @HiveField(1)
-  final int requestedPageNb;
+  int requestedPageNb;
   @HiveField(2)
   final int pageSize;
   @HiveField(3, defaultValue: SearchBy.query)
   final SearchBy searchBy;
 
-  const ActiveSearch({
+  ActiveSearch({
     required this.searchTerm,
     required this.requestedPageNb,
     required this.pageSize,
     required this.searchBy,
   });
 
-  ActiveSearch nextPageSearch() => ActiveSearch(
+  ActiveSearch nextPage() => ActiveSearch(
         searchTerm: searchTerm,
         requestedPageNb: requestedPageNb + 1,
         pageSize: pageSize,
         searchBy: searchBy,
       );
-
-  api.ActiveSearch toApiRepr() =>
-      api.ActiveSearch(searchBy: searchBy, searchTerm: searchTerm);
 
   @override
   List<Object?> get props => [searchTerm, requestedPageNb, pageSize, searchBy];

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -12,28 +12,46 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart'
     show HiveType, HiveField, TypeAdapter, BinaryReader, BinaryWriter;
+import 'package:xayn_discovery_engine/src/api/models/active_search.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/repository/type_id.dart'
     show searchTypeId, searchByTypeId;
 
-part 'active_search.freezed.dart';
 part 'active_search.g.dart';
 
 /// [ActiveSearch] represents attributes of a performed search.
-@freezed
-class ActiveSearch with _$ActiveSearch {
-  @HiveType(typeId: searchTypeId)
-  const factory ActiveSearch({
-    @HiveField(0) required String searchTerm,
-    @HiveField(1) required int requestedPageNb,
-    @HiveField(2) required int pageSize,
-    @HiveField(3, defaultValue: SearchBy.query) required SearchBy searchBy,
-  }) = _ActiveSearch;
+@HiveType(typeId: searchTypeId)
+class ActiveSearch with EquatableMixin {
+  @HiveField(0)
+  final String searchTerm;
+  @HiveField(1)
+  final int requestedPageNb;
+  @HiveField(2)
+  final int pageSize;
+  @HiveField(3, defaultValue: SearchBy.query)
+  final SearchBy searchBy;
 
-  factory ActiveSearch.fromJson(Map<String, Object?> json) =>
-      _$ActiveSearchFromJson(json);
+  const ActiveSearch({
+    required this.searchTerm,
+    required this.requestedPageNb,
+    required this.pageSize,
+    required this.searchBy,
+  });
+
+  ActiveSearch nextPageSearch() => ActiveSearch(
+        searchTerm: searchTerm,
+        requestedPageNb: requestedPageNb + 1,
+        pageSize: pageSize,
+        searchBy: searchBy,
+      );
+
+  api.ActiveSearch toApiRepr() =>
+      api.ActiveSearch(searchBy: searchBy, searchTerm: searchTerm);
+
+  @override
+  List<Object?> get props => [searchTerm, requestedPageNb, pageSize, searchBy];
 }
 
 @HiveType(typeId: searchByTypeId)

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -39,13 +39,6 @@ class ActiveSearch with EquatableMixin {
     required this.searchBy,
   });
 
-  ActiveSearch nextPage() => ActiveSearch(
-        searchTerm: searchTerm,
-        requestedPageNb: requestedPageNb + 1,
-        pageSize: pageSize,
-        searchBy: searchBy,
-      );
-
   @override
   List<Object?> get props => [searchTerm, requestedPageNb, pageSize, searchBy];
 }

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -16,7 +16,6 @@ import 'package:hive/hive.dart'
     show HiveType, HiveField, TypeAdapter, BinaryReader, BinaryWriter;
 import 'package:json_annotation/json_annotation.dart'
     show $enumDecode, JsonEnum, JsonValue;
-import 'package:xayn_discovery_engine/src/api/models/document.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
     show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
@@ -68,15 +67,6 @@ class Document {
     this.isActive = true,
     this.isSearched = false,
   }) : timestamp = DateTime.now().toUtc();
-
-  //FIXME move this conversion to `api/models/document.dart` e.g. as an
-  //      extension on this type.
-  api.Document toApiDocument() => api.Document(
-        documentId: documentId,
-        resource: resource,
-        userReaction: userReaction,
-        batchIndex: batchIndex,
-      );
 }
 
 /// [UserReaction] indicates user's "sentiment" towards the document,

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -69,6 +69,8 @@ class Document {
     this.isSearched = false,
   }) : timestamp = DateTime.now().toUtc();
 
+  //FIXME move this conversion to `api/models/document.dart` e.g. as an
+  //      extension on this type.
   api.Document toApiDocument() => api.Document(
         documentId: documentId,
         resource: resource,

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -17,7 +17,7 @@ import 'dart:convert' show utf8;
 import 'package:csv/csv.dart' show CsvToListConverter;
 import 'package:equatable/equatable.dart' show Equatable;
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
+import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions, WeightedKey;
 
 part 'source.freezed.dart';
 part 'source.g.dart';

--- a/discovery_engine/lib/src/domain/models/source.dart
+++ b/discovery_engine/lib/src/domain/models/source.dart
@@ -17,7 +17,7 @@ import 'dart:convert' show utf8;
 import 'package:csv/csv.dart' show CsvToListConverter;
 import 'package:equatable/equatable.dart' show Equatable;
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions, WeightedKey;
+import 'package:fuzzy/fuzzy.dart' show Fuzzy, FuzzyOptions;
 
 part 'source.freezed.dart';
 part 'source.g.dart';

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -104,7 +104,7 @@ class SearchManager {
     }
 
     return searchDocs
-        .map((docWithData) => docWithData.document.toApiDocument())
+        .map((docWithData) => docWithData.document.toApiRepr())
         .toList();
   }
 
@@ -174,7 +174,7 @@ class SearchManager {
           : timeOrd;
     });
 
-    final docs = searchDocs.map((doc) => doc.toApiDocument()).toList();
+    final docs = searchDocs.map((doc) => doc.toApiRepr()).toList();
 
     return EngineEvent.restoreSearchSucceeded(search.toApiRepr(), docs);
   }

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -16,6 +16,8 @@ import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show SearchClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show EngineEvent, SearchFailureReason;
+import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
+    show ActiveSearchApiConversion;
 import 'package:xayn_discovery_engine/src/api/models/document.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
@@ -126,7 +128,7 @@ class SearchManager {
 
   /// Obtain the next batch of search documents and persist to repositories.
   Future<EngineEvent> nextSearchBatchRequested() async {
-    var search = await _searchRepo.getCurrent();
+    final search = await _searchRepo.getCurrent();
 
     if (search == null) {
       const reason = SearchFailureReason.noActiveSearch;
@@ -134,7 +136,7 @@ class SearchManager {
     }
 
     // lets update active search params
-    search = search.nextPageSearch();
+    search.requestedPageNb += 1;
     final docs = await _getSearchDocuments(search);
     await _searchRepo.save(search);
     return EngineEvent.nextSearchBatchRequestSucceeded(

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -121,7 +121,7 @@ class SearchManager {
     );
     final docs = await _getSearchDocuments(search);
     await _searchRepo.save(search);
-    return EngineEvent.searchRequestSucceeded(search, docs);
+    return EngineEvent.searchRequestSucceeded(search.toApiRepr(), docs);
   }
 
   /// Obtain the next batch of search documents and persist to repositories.
@@ -134,10 +134,13 @@ class SearchManager {
     }
 
     // lets update active search params
-    search = search.copyWith(requestedPageNb: search.requestedPageNb + 1);
+    search = search.nextPageSearch();
     final docs = await _getSearchDocuments(search);
     await _searchRepo.save(search);
-    return EngineEvent.nextSearchBatchRequestSucceeded(search, docs);
+    return EngineEvent.nextSearchBatchRequestSucceeded(
+      search.toApiRepr(),
+      docs,
+    );
   }
 
   /// Returns the list of active search documents, ordered by their global rank.
@@ -171,7 +174,7 @@ class SearchManager {
 
     final docs = searchDocs.map((doc) => doc.toApiDocument()).toList();
 
-    return EngineEvent.restoreSearchSucceeded(search, docs);
+    return EngineEvent.restoreSearchSucceeded(search.toApiRepr(), docs);
   }
 
   /// Return the active search term.

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -67,12 +67,9 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
     this.feedDocumentsClosedResponse = const EngineEvent.clientEventSucceeded(),
     this.userReactionChangedResponse = const EngineEvent.clientEventSucceeded(),
     this.documentTimeLoggedResponse = const EngineEvent.clientEventSucceeded(),
-    this.searchRequestedResponse =
-        const EngineEvent.searchRequestSucceeded(mockActiveSearch, []),
-    this.nextSearchBatchRequestedResponse =
-        const EngineEvent.nextSearchBatchRequestSucceeded(mockActiveSearch, []),
-    this.restoreSearchResponse =
-        const EngineEvent.restoreSearchSucceeded(mockActiveSearch, []),
+    EngineEvent? searchRequestedResponse,
+    EngineEvent? nextSearchBatchRequestedResponse,
+    EngineEvent? restoreSearchResponse,
     this.searchClosedResponse = const EngineEvent.clientEventSucceeded(),
     this.searchTermRequestedResponse =
         const EngineEvent.searchTermRequestSucceeded(queryTerm),
@@ -87,7 +84,20 @@ class MockDiscoveryEngineWorker extends DiscoveryEngineWorker {
     this.trendingTopicsRequestedResponse =
         const EngineEvent.trendingTopicsRequestSucceeded([]),
     EngineEvent? availableSourcesListRequestedResponse,
-  })  : excludedSourcesListRequestedResponse =
+  })  : searchRequestedResponse = EngineEvent.searchRequestSucceeded(
+          mockActiveSearch.toApiRepr(),
+          [],
+        ),
+        nextSearchBatchRequestedResponse =
+            EngineEvent.nextSearchBatchRequestSucceeded(
+          mockActiveSearch.toApiRepr(),
+          [],
+        ),
+        restoreSearchResponse = EngineEvent.restoreSearchSucceeded(
+          mockActiveSearch.toApiRepr(),
+          [],
+        ),
+        excludedSourcesListRequestedResponse =
             excludedSourcesListRequestedResponse ??
                 EngineEvent.excludedSourcesListRequestSucceeded(
                   {Source('example.com')},

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -16,6 +16,8 @@ import 'dart:isolate' show SendPort;
 
 import 'package:xayn_discovery_engine/src/api/api.dart'
     show Configuration, EngineEvent, FeedMarket;
+import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
+    show ActiveSearchApiConversion;
 import 'package:xayn_discovery_engine/src/discovery_engine_base.dart'
     show DiscoveryEngine;
 import 'package:xayn_discovery_engine/src/discovery_engine_worker.dart'
@@ -179,7 +181,7 @@ final mockNewsResource = NewsResource(
 
 const queryTerm = 'example';
 
-const mockActiveSearch = ActiveSearch(
+final mockActiveSearch = ActiveSearch(
   searchTerm: queryTerm,
   requestedPageNb: 1,
   pageSize: 20,

--- a/discovery_engine/test/document_manager_test.dart
+++ b/discovery_engine/test/document_manager_test.dart
@@ -18,6 +18,8 @@ import 'package:hive/hive.dart' show Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show DocumentsUpdated;
+import 'package:xayn_discovery_engine/src/api/models/document.dart'
+    show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/changed_documents_reporter.dart'
     show ChangedDocumentsReporter;
 import 'package:xayn_discovery_engine/src/domain/document_manager.dart'
@@ -153,7 +155,7 @@ Future<void> main() async {
 
     test('update active document user reaction', () async {
       const newReaction = UserReaction.positive;
-      final updatedDoc = (doc1..userReaction = newReaction).toApiDocument();
+      final updatedDoc = (doc1..userReaction = newReaction).toApiRepr();
 
       expect(
         changedDocsReporter.changedDocuments,

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
   group('HiveActiveSearchRepository', () {
     late HiveActiveSearchRepository repo;
 
-    const search = ActiveSearch(
+    final search = ActiveSearch(
       searchTerm: 'example search query',
       requestedPageNb: 1,
       pageSize: 10,
@@ -93,7 +93,12 @@ Future<void> main() async {
           () async {
         await repo.save(search);
 
-        final search2 = search.nextPageSearch();
+        final search2 = ActiveSearch(
+          searchTerm: 'foobar',
+          requestedPageNb: 123,
+          pageSize: 10,
+          searchBy: SearchBy.query,
+        );
         await repo.save(search2);
 
         expect(repo.box.isNotEmpty, isTrue);

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -93,7 +93,7 @@ Future<void> main() async {
           () async {
         await repo.save(search);
 
-        final search2 = search.copyWith(requestedPageNb: 2);
+        final search2 = search.nextPageSearch();
         await repo.save(search2);
 
         expect(repo.box.isNotEmpty, isTrue);

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -32,6 +32,8 @@ import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         TrendingTopicsRequestSucceeded;
 import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
     show ActiveSearchApiConversion;
+import 'package:xayn_discovery_engine/src/api/models/document.dart'
+    show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/engine/mock_engine.dart'
     show MockEngine, mockTrendingTopic;
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
@@ -159,7 +161,7 @@ Future<void> main() async {
         final savedDocs = response.items
             // lets look for the docs in the document box
             .map((doc) => docRepo.box.get('${doc.documentId}'))
-            .map((doc) => doc!.toApiDocument())
+            .map((doc) => doc!.toApiRepr())
             .toList();
 
         expect(response.items, equals(savedDocs));
@@ -211,7 +213,7 @@ Future<void> main() async {
         final savedDocs = response.items
             // lets look for the docs in the document box
             .map((doc) => docRepo.box.get('${doc.documentId}'))
-            .map((doc) => doc!.toApiDocument())
+            .map((doc) => doc!.toApiRepr())
             .toList();
 
         expect(response.items, equals(savedDocs));
@@ -276,7 +278,7 @@ Future<void> main() async {
           equals(
             RestoreSearchSucceeded(
               mockActiveSearch.toApiRepr(),
-              [doc1.toApiDocument(), doc2.toApiDocument()],
+              [doc1.toApiRepr(), doc2.toApiRepr()],
             ),
           ),
         );

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -30,6 +30,8 @@ import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         SearchTermRequestSucceeded,
         TrendingTopicsRequestFailed,
         TrendingTopicsRequestSucceeded;
+import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
+    show ActiveSearchApiConversion;
 import 'package:xayn_discovery_engine/src/domain/engine/mock_engine.dart'
     show MockEngine, mockTrendingTopic;
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -148,7 +148,10 @@ Future<void> main() async {
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<SearchRequestSucceeded>());
-        expect((response as SearchRequestSucceeded).search, equals(newSearch));
+        expect(
+          (response as SearchRequestSucceeded).search,
+          equals(newSearch.toApiRepr()),
+        );
         expect(response.items.length, equals(2));
 
         final savedDocs = response.items
@@ -199,11 +202,8 @@ Future<void> main() async {
             (response as NextSearchBatchRequestSucceeded).search;
 
         expect(response, isA<NextSearchBatchRequestSucceeded>());
-        expect(
-          updateSearch.requestedPageNb,
-          equals(mockActiveSearch.requestedPageNb + 1),
-        );
-        expect(searchRepo.getCurrent(), completion(equals(updateSearch)));
+        final current = await searchRepo.getCurrent();
+        expect(current?.toApiRepr(), equals(updateSearch));
         expect(response.items.length, equals(2));
 
         final savedDocs = response.items
@@ -273,7 +273,7 @@ Future<void> main() async {
           response,
           equals(
             RestoreSearchSucceeded(
-              mockActiveSearch,
+              mockActiveSearch.toApiRepr(),
               [doc1.toApiDocument(), doc2.toApiDocument()],
             ),
           ),


### PR DESCRIPTION
This is archived to have an `ActiveSearch` in the API and another internal one.

Also change the internal `ActiveSearch` to no longer use `freezed` due to the shenanigans needed to be able to add additional methods on a `freezed` object (and it's  not needed anymore).

**References:**

- [TY-2805](https://xainag.atlassian.net/browse/TY-2805)