### PR TITLE
[Merged by Bors] - TY-2787 rankable trending topics

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -238,6 +238,20 @@ pub struct HistoricDocument {
     pub title: String,
 }
 
+/// A trending topic.
+pub struct TrendTopic {
+    /// Id of the topic.
+    pub id: Id,
+    /// Precomputed S-mBert of the topic.
+    pub smbert_embedding: Embedding,
+    /// Title of the topic.
+    pub name: String,
+    /// Query term that returns this topic.
+    pub query: String,
+    /// Link to a related image.
+    pub image: Option<Url>,
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -239,7 +239,7 @@ pub struct HistoricDocument {
 }
 
 /// A trending topic.
-pub struct TrendTopic {
+pub struct TrendingTopic {
     /// Id of the topic.
     pub id: Id,
     /// Precomputed S-mBert of the topic.

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1008,7 +1008,7 @@ mod tests {
         // To test de-duplication we don't really need any ranking, so this
         // this is essentially a no-op ranker.
         let mut ranker = ranker::MockRanker::new();
-        ranker.expect_rank().returning(|_| Ok(()));
+        ranker.expect_rank().returning(|_: &mut [Document]| Ok(()));
         ranker.expect_take_key_phrases().returning(|_, _| vec![]);
         ranker.expect_compute_smbert().returning(|_| {
             let embedding: Embedding = [0.0].into();

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -23,7 +23,7 @@ use xayn_ai::{
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
-    document::{Document, Id, TimeSpent, UserReacted, UserReaction},
+    document::{Document, Id, TimeSpent, TrendTopic, UserReacted, UserReaction},
     engine::GenericError,
 };
 
@@ -121,6 +121,21 @@ impl xayn_ai::ranker::Document for Document {
 
     fn date_published(&self) -> NaiveDateTime {
         self.resource.date_published
+    }
+}
+
+impl xayn_ai::ranker::Document for TrendTopic {
+    fn id(&self) -> DocumentId {
+        self.id.into()
+    }
+
+    fn smbert_embedding(&self) -> &Embedding {
+        &self.smbert_embedding
+    }
+
+    fn date_published(&self) -> NaiveDateTime {
+        // return a default value as there is no `date_published` for trending topics
+        chrono::naive::MIN_DATETIME
     }
 }
 

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -36,6 +36,9 @@ pub trait Ranker {
     /// Performs the ranking of [`Document`] items.
     fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError>;
 
+    /// Performs the ranking of [`TrendTopic`] items.
+    fn rank_topics(&mut self, items: &mut [TrendTopic]) -> Result<(), GenericError>;
+
     /// Logs the time a user spent on a document.
     fn log_document_view_time(&mut self, time_spent: &TimeSpent) -> Result<(), GenericError>;
 
@@ -63,6 +66,10 @@ pub trait Ranker {
 
 impl Ranker for xayn_ai::ranker::Ranker {
     fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError> {
+        self.rank(items).map_err(Into::into)
+    }
+
+    fn rank_topics(&mut self, items: &mut [TrendTopic]) -> Result<(), GenericError> {
         self.rank(items).map_err(Into::into)
     }
 

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -23,7 +23,7 @@ use xayn_ai::{
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
-    document::{Document, Id, TimeSpent, TrendTopic, UserReacted, UserReaction},
+    document::{Document, Id, TimeSpent, TrendingTopic, UserReacted, UserReaction},
     engine::GenericError,
 };
 
@@ -34,10 +34,9 @@ use mockall::automock;
 #[cfg_attr(test, automock)]
 pub trait Ranker {
     /// Performs the ranking of [`Document`] items.
-    fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError>;
-
-    /// Performs the ranking of [`TrendTopic`] items.
-    fn rank_topics(&mut self, items: &mut [TrendTopic]) -> Result<(), GenericError>;
+    fn rank<T>(&mut self, items: &mut [T]) -> Result<(), GenericError>
+    where
+        T: xayn_ai::ranker::Document + 'static;
 
     /// Logs the time a user spent on a document.
     fn log_document_view_time(&mut self, time_spent: &TimeSpent) -> Result<(), GenericError>;
@@ -65,11 +64,10 @@ pub trait Ranker {
 }
 
 impl Ranker for xayn_ai::ranker::Ranker {
-    fn rank(&mut self, items: &mut [Document]) -> Result<(), GenericError> {
-        self.rank(items).map_err(Into::into)
-    }
-
-    fn rank_topics(&mut self, items: &mut [TrendTopic]) -> Result<(), GenericError> {
+    fn rank<T>(&mut self, items: &mut [T]) -> Result<(), GenericError>
+    where
+        T: xayn_ai::ranker::Document + 'static,
+    {
         self.rank(items).map_err(Into::into)
     }
 
@@ -131,7 +129,7 @@ impl xayn_ai::ranker::Document for Document {
     }
 }
 
-impl xayn_ai::ranker::Document for TrendTopic {
+impl xayn_ai::ranker::Document for TrendingTopic {
     fn id(&self) -> DocumentId {
         self.id.into()
     }


### PR DESCRIPTION
**Summary**

adds a `TrendingTopic` struct, implementing `xayn_ai::ranker::Document` to allow it to be ranked.