### PR TITLE
[Merged by Bors] - TY-2809 remove unnecessary UnsupportedError usages

### DIFF
--- a/discovery_engine/lib/src/domain/assets/data_provider.dart
+++ b/discovery_engine/lib/src/domain/assets/data_provider.dart
@@ -44,9 +44,7 @@ abstract class SetupData with EquatableMixin {
         availableSources,
       ];
 
-  Future<AvailableSources> getAvailableSources() {
-    throw UnsupportedError('Unsupported plattform.');
-  }
+  Future<AvailableSources> getAvailableSources();
 }
 
 /// Reads the assets manifest and provides the [SetupData] to further use.
@@ -54,9 +52,7 @@ abstract class DataProvider {
   AssetFetcher get assetFetcher;
   AssetReporter get assetReporter;
 
-  Future<SetupData> getSetupData(Manifest manifest) {
-    throw UnsupportedError('Unsupported platform.');
-  }
+  Future<SetupData> getSetupData(Manifest manifest);
 
   static String joinPaths(List<String> paths) {
     return paths.where((e) => e.isNotEmpty).join('/');

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -89,8 +89,6 @@ class SearchManager {
           search.pageSize,
         );
         break;
-      default:
-        throw UnsupportedError('Unknown SearchBy value');
     }
 
     await _engineStateRepo.save(await _engine.serialize());


### PR DESCRIPTION
We have some places where we `throw UnsupportedError` where it's not necessary:

1. methods of abstract classes which always need to be overridden by all implementations
    should just be abstract instead of having a body which always throw an error.
2. exhaustive switch statements over enums (with the lints we enabled dart has roughly
    exhaustive enum switch statements. Just roughly, but what matters is, it fails linting/CI
    when the switch is not exhaustive).
    
 **References:**
 
 - [TY-2809](https://xainag.atlassian.net/browse/TY-2809)