### PR TITLE
[Merged by Bors] - TY-2814 remove id in nc article struct

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -285,7 +285,6 @@ mod tests {
 
     fn mock_article() -> Article {
         Article {
-            id: "id".to_string(),
             title: "title".to_string(),
             score: Some(0.75),
             rank: 10,

--- a/discovery_engine_core/providers/src/client.rs
+++ b/discovery_engine_core/providers/src/client.rs
@@ -439,7 +439,6 @@ mod tests {
 
         let doc = docs.get(1).unwrap();
         let expected = Article {
-            id: "0251ae9f73ec12f4d3eced9c4dc9ccc8".to_string(),
             title: "Jerusalem blanketed in white after rare snowfall".to_string(),
             score: None,
             rank: 6510,

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -50,14 +50,6 @@ impl Default for Topic {
 /// A news article
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Article {
-    /// Newscatcher API's unique identifier for each news article.
-    #[serde(
-        default,
-        rename(deserialize = "_id"),
-        deserialize_with = "deserialize_null_default"
-    )]
-    pub id: String,
-
     /// The title of the article.
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub title: String,


### PR DESCRIPTION
Ticket:
- [TY-2814]

Summary:
- removed the unused field `_id`

[TY-2814]: https://xainag.atlassian.net/browse/TY-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ