### PR TITLE
[Merged by Bors] - TY-2845 port providers crate to DE conventions

### DIFF
--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -16,14 +16,19 @@
 
 #![forbid(unsafe_code, unsafe_op_in_unsafe_fn)]
 #![deny(
-    clippy::pedantic,
     clippy::future_not_send,
+    clippy::pedantic,
     noop_method_call,
     rust_2018_idioms,
     unused_qualifications
 )]
 #![warn(missing_docs, unreachable_pub)]
-#![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
+#![allow(
+    clippy::items_after_statements,
+    clippy::missing_errors_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate
+)]
 
 mod client;
 mod expression;


### PR DESCRIPTION
**References**

- [TY-2845]

**Summary**

- align lints with DE


[TY-2845]: https://xainag.atlassian.net/browse/TY-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ