### PR TITLE
[Merged by Bors] - TY-2835 deep search engine

### DIFF
--- a/discovery_engine_core/ai/ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/public.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use xayn_discovery_engine_bert::{AveragePooler, SMBertConfig};
-use xayn_discovery_engine_kpe::Config as KpeConfig;
+use xayn_discovery_engine_kpe::{Config as KpeConfig, RankedKeyPhrases};
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
@@ -44,6 +44,11 @@ impl Ranker {
     /// Computes the `SMBert` embedding of the given `sequence`.
     pub fn compute_smbert(&self, sequence: &str) -> Result<Embedding, Error> {
         self.0.compute_smbert(sequence)
+    }
+
+    /// Extracts the key phrases of the given `sequence`.
+    pub fn extract_key_phrases(&self, sequence: &str) -> Result<RankedKeyPhrases, Error> {
+        self.0.extract_key_phrases(sequence)
     }
 
     /// Ranks the given documents based on the learned user interests.

--- a/discovery_engine_core/ai/ai/src/ranker/system.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/system.rs
@@ -19,7 +19,7 @@ use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use xayn_discovery_engine_bert::SMBert;
-use xayn_discovery_engine_kpe::Pipeline as KPE;
+use xayn_discovery_engine_kpe::{Pipeline as KPE, RankedKeyPhrases};
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
@@ -86,6 +86,11 @@ impl Ranker {
     /// Computes the `SMBert` embedding of the given `sequence`.
     pub(crate) fn compute_smbert(&self, sequence: &str) -> Result<Embedding, Error> {
         self.smbert.run(sequence).map_err(Into::into)
+    }
+
+    /// Extracts the key phrases of the given `sequence`.
+    pub(crate) fn extract_key_phrases(&self, sequence: &str) -> Result<RankedKeyPhrases, Error> {
+        self.kpe.run(sequence).map_err(Into::into)
     }
 
     /// Ranks the given documents based on the learned user interests.

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -96,6 +96,21 @@ pub struct Document {
     pub resource: NewsResource,
 }
 
+impl TryFrom<(Article, StackId, Embedding)> for Document {
+    type Error = Error;
+
+    fn try_from(
+        (article, stack_id, smbert_embedding): (Article, StackId, Embedding),
+    ) -> Result<Self, Self::Error> {
+        article.try_into().map(|resource| Self {
+            id: Id::new(),
+            stack_id,
+            smbert_embedding,
+            resource,
+        })
+    }
+}
+
 /// Represents a news that is delivered by an external content API.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NewsResource {
@@ -210,19 +225,6 @@ pub struct UserReacted {
 
     /// Market from which the document is.
     pub market: Market,
-}
-
-pub(crate) fn document_from_article(
-    article: Article,
-    stack_id: StackId,
-    smbert_embedding: Embedding,
-) -> Result<Document, Error> {
-    Ok(Document {
-        id: Id::new(),
-        stack_id,
-        smbert_embedding,
-        resource: article.try_into()?,
-    })
 }
 
 /// Represents a [`Document`] in the document history.

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -556,7 +556,7 @@ where
             );
         }
 
-        let (mut documents, article_errors) = parallel_articles_into_documents(
+        let (mut documents, article_errors) = articles_into_documents(
             StackId::nil(), // these documents are not associated with a stack
             &self.ranker,
             articles,
@@ -605,7 +605,7 @@ where
             .await
             .map_err(|error| Error::Client(error.into()))?;
         let articles = MalformedFilter::apply(&[], &[], articles)?;
-        let (documents, errors) = parallel_articles_into_documents(
+        let (documents, errors) = articles_into_documents(
             StackId::nil(), // these documents are not associated with a stack
             &self.ranker,
             articles,
@@ -809,7 +809,7 @@ async fn fetch_new_documents_for_stack(
             return Err(Error::StackOpFailed(error));
         }
     };
-    let (documents, errors) = parallel_articles_into_documents(stack.id(), ranker, articles);
+    let (documents, errors) = articles_into_documents(stack.id(), ranker, articles);
 
     // only return an error if all articles failed
     if documents.is_empty() && !errors.is_empty() {
@@ -819,7 +819,7 @@ async fn fetch_new_documents_for_stack(
     }
 }
 
-fn parallel_articles_into_documents(
+fn articles_into_documents(
     stack_id: StackId,
     ranker: &(impl Ranker + Send + Sync),
     articles: Vec<Article>,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -183,6 +183,10 @@ struct CoreConfig {
     /// The number of times to get feed documents after which the stacks are updated without the
     /// limitation of `request_new`.
     request_after: usize,
+    /// The maximum number of top key phrases extracted from the search term in the deep search.
+    deep_search_top: usize,
+    /// The maximum number of documents returned from the deep search.
+    deep_search_max: usize,
 }
 
 impl Default for CoreConfig {
@@ -192,6 +196,8 @@ impl Default for CoreConfig {
             keep_top: 20,
             request_new: 3,
             request_after: 2,
+            deep_search_top: 3,
+            deep_search_max: 20,
         }
     }
 }
@@ -584,14 +590,14 @@ where
         let excluded_sources = &self.config.excluded_sources.read().await.clone();
         let filter = &key_phrases
             .iter()
-            .take(3)
+            .take(self.core_config.deep_search_top)
             .fold(Filter::default(), |filter, key_phrase| {
                 filter.add_keyword(key_phrase)
             });
         let query = NewsQuery {
             common: CommonQueryParts {
                 market: Some(market),
-                page_size: 20,
+                page_size: self.core_config.deep_search_max,
                 page: 1,
                 excluded_sources,
             },

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -20,6 +20,7 @@ use xayn_discovery_engine_ai::{
     DocumentId,
     UserFeedback,
 };
+use xayn_discovery_engine_kpe::RankedKeyPhrases;
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
@@ -52,6 +53,9 @@ pub trait Ranker {
 
     /// Computes the S-mBert embedding of the given `sequence`.
     fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError>;
+
+    /// Extracts the key phrases of the given `sequence`.
+    fn extract_key_phrases(&self, sequence: &str) -> Result<RankedKeyPhrases, GenericError>;
 
     /// Returns the positive cois.
     fn positive_cois(&self) -> &[PositiveCoi];
@@ -101,6 +105,10 @@ impl Ranker for xayn_discovery_engine_ai::ranker::Ranker {
 
     fn compute_smbert(&self, sequence: &str) -> Result<Embedding, GenericError> {
         self.compute_smbert(sequence).map_err(Into::into)
+    }
+
+    fn extract_key_phrases(&self, sequence: &str) -> Result<RankedKeyPhrases, GenericError> {
+        self.extract_key_phrases(sequence).map_err(Into::into)
     }
 
     fn positive_cois(&self) -> &[PositiveCoi] {

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -97,6 +97,10 @@ impl Id {
         Id(Uuid::new_v4())
     }
 
+    pub(crate) const fn nil() -> Self {
+        Id(Uuid::nil())
+    }
+
     pub(crate) fn is_nil(&self) -> bool {
         self.0.is_nil()
     }

--- a/discovery_engine_core/core/src/stack/filters.rs
+++ b/discovery_engine_core/core/src/stack/filters.rs
@@ -17,7 +17,7 @@ mod deduplication;
 mod semantic;
 
 pub(crate) use self::{
-    article::{ArticleFilter, CommonFilter, SourcesFilter},
+    article::{ArticleFilter, CommonFilter, MalformedFilter, SourcesFilter},
     deduplication::DuplicateFilter,
     semantic::{filter_semantically, SemanticFilterConfig},
 };

--- a/discovery_engine_core/core/src/stack/filters/article.rs
+++ b/discovery_engine_core/core/src/stack/filters/article.rs
@@ -29,7 +29,7 @@ pub(crate) trait ArticleFilter {
     ) -> Result<Vec<Article>, GenericError>;
 }
 
-struct MalformedFilter;
+pub(crate) struct MalformedFilter;
 
 impl MalformedFilter {
     fn is_valid(article: &Article) -> bool {
@@ -79,7 +79,7 @@ impl SourcesFilter {
 mod tests {
     use std::{collections::HashMap, convert::TryInto, iter::FromIterator};
 
-    use crate::document::{document_from_article, Document};
+    use crate::document::Document;
     use itertools::Itertools;
     use xayn_discovery_engine_providers::Article;
 
@@ -97,7 +97,9 @@ mod tests {
             .take(2)
             .map(|article| {
                 let doc = Document::default();
-                document_from_article(article.clone(), doc.stack_id, doc.smbert_embedding).unwrap()
+                (article.clone(), doc.stack_id, doc.smbert_embedding)
+                    .try_into()
+                    .unwrap()
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
**References**

- [TY-2835]
- followed by #398

**Summary**

- expose key phrase extraction in the `Ranker`
- dedup code for `article_into_document()` conversion (this has the nice side effect that the active search also uses the parallized conversion now)
- impl deep search in the `Engine`


[TY-2835]: https://xainag.atlassian.net/browse/TY-2835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ