### PR TITLE
[Merged by Bors] - TY-2852 Handle snippet too short for kpe

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -90,6 +90,7 @@ class DocumentManager {
       UserReacted(
         id: id,
         stackId: doc.stackId,
+        title: doc.resource.title,
         snippet: doc.snippet,
         smbertEmbedding: smbertEmbedding,
         reaction: userReaction,

--- a/discovery_engine/lib/src/domain/models/user_reacted.dart
+++ b/discovery_engine/lib/src/domain/models/user_reacted.dart
@@ -26,6 +26,7 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
 class UserReacted with EquatableMixin {
   final DocumentId id;
   final StackId stackId;
+  final String title;
   final String snippet;
   final Embedding smbertEmbedding;
   final UserReaction reaction;
@@ -34,6 +35,7 @@ class UserReacted with EquatableMixin {
   UserReacted({
     required this.id,
     required this.stackId,
+    required this.title,
     required this.snippet,
     required this.smbertEmbedding,
     required this.reaction,

--- a/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
+++ b/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
@@ -56,7 +56,7 @@ extension UserReactedFfi on UserReacted {
   void writeNative(final Pointer<RustUserReacted> place) {
     id.writeNative(ffi.user_reacted_place_of_id(place));
     stackId.writeNative(ffi.user_reacted_place_of_stack_id(place));
-    title.writeNative(ffi.user_reacted_place_of_snippet(place));
+    title.writeNative(ffi.user_reacted_place_of_title(place));
     snippet.writeNative(ffi.user_reacted_place_of_snippet(place));
     smbertEmbedding
         .writeNative(ffi.user_reacted_place_of_smbert_embedding(place));

--- a/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
+++ b/discovery_engine/lib/src/ffi/types/document/user_reacted.dart
@@ -35,6 +35,7 @@ extension UserReactedFfi on UserReacted {
     return UserReacted(
       id: DocumentIdFfi.readNative(ffi.user_reacted_place_of_id(place)),
       stackId: StackIdFfi.readNative(ffi.user_reacted_place_of_stack_id(place)),
+      title: StringFfi.readNative(ffi.user_reacted_place_of_title(place)),
       snippet: StringFfi.readNative(ffi.user_reacted_place_of_snippet(place)),
       smbertEmbedding: EmbeddingFfi.readNative(
         ffi.user_reacted_place_of_smbert_embedding(place),
@@ -55,6 +56,7 @@ extension UserReactedFfi on UserReacted {
   void writeNative(final Pointer<RustUserReacted> place) {
     id.writeNative(ffi.user_reacted_place_of_id(place));
     stackId.writeNative(ffi.user_reacted_place_of_stack_id(place));
+    title.writeNative(ffi.user_reacted_place_of_snippet(place));
     snippet.writeNative(ffi.user_reacted_place_of_snippet(place));
     smbertEmbedding
         .writeNative(ffi.user_reacted_place_of_smbert_embedding(place));

--- a/discovery_engine/test/ffi/types/document/user_reacted_test.dart
+++ b/discovery_engine/test/ffi/types/document/user_reacted_test.dart
@@ -31,6 +31,7 @@ void main() {
     final document = UserReacted(
       id: DocumentId(),
       stackId: StackId(),
+      title: 'title',
       snippet: 'Cloning brought back the dodo.',
       smbertEmbedding: Embedding.fromList([.9, .1]),
       reaction: UserReaction.negative,

--- a/discovery_engine_core/ai/ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/public.rs
@@ -66,12 +66,13 @@ impl Ranker {
     pub fn log_user_reaction(
         &mut self,
         user_feedback: UserFeedback,
+        title: &str,
         snippet: &str,
         embedding: &Embedding,
         market: &Market,
     ) {
         self.0
-            .log_user_reaction(user_feedback, snippet, embedding, market);
+            .log_user_reaction(user_feedback, title, snippet, embedding, market);
     }
 
     /// Takes the top key phrases from the positive cois and market, sorted in descending relevance.

--- a/discovery_engine_core/ai/kpe/examples/kpe.rs
+++ b/discovery_engine_core/ai/kpe/examples/kpe.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let kpe = Pipeline::from(config)?;
 
-    let key_phrases = kpe.run("This sequence will be split into key phrases.")?;
+    let key_phrases = kpe.run("Berlin & Brandenburg")?;
     println!("{:?}", key_phrases);
     assert_eq!(key_phrases.len(), 30);
 

--- a/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
+++ b/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
@@ -65,7 +65,7 @@ impl ValidMask {
 
     /// Checks if the valid mask is valid, i.e. at least `key_phrase_size` valid entries.
     pub(crate) fn is_valid(&self, key_phrase_size: usize) -> bool {
-        dbg!(dbg!(self.count()) >= dbg!(key_phrase_size))
+        self.count() >= key_phrase_size
     }
 }
 
@@ -96,11 +96,10 @@ pub(crate) struct Encoding {
 impl Encoding {
     /// Checks if all parts of the encoding are valid.
     pub(crate) fn is_valid(&self, vocab_size: usize, key_phrase_size: usize) -> bool {
-        dbg!(self.active_mask.is_valid());
-        dbg!(self.token_ids.is_valid(vocab_size))
-            && dbg!(self.attention_mask.is_valid())
-            && dbg!(self.valid_mask.is_valid(key_phrase_size))
-            && dbg!(self.active_mask.is_valid())
+        self.token_ids.is_valid(vocab_size)
+            && self.attention_mask.is_valid()
+            && self.valid_mask.is_valid(key_phrase_size)
+            && self.active_mask.is_valid()
     }
 }
 

--- a/discovery_engine_core/ai/kpe/src/tokenizer/key_phrase.rs
+++ b/discovery_engine_core/ai/kpe/src/tokenizer/key_phrase.rs
@@ -20,7 +20,7 @@ use ndarray::Array2;
 use crate::{model::classifier::Scores, tokenizer::encoding::ActiveMask};
 
 /// The collection of all potential key phrases.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct KeyPhrases<const KEY_PHRASE_SIZE: usize> {
     choices: Vec<String>,
     mentions: Vec<i64>,
@@ -31,6 +31,12 @@ pub(crate) struct KeyPhrases<const KEY_PHRASE_SIZE: usize> {
 /// The ranked key phrases in descending order.
 #[derive(Clone, Debug, Default, Deref, From)]
 pub struct RankedKeyPhrases(pub(crate) Vec<String>);
+
+impl From<RankedKeyPhrases> for Vec<String> {
+    fn from(v: RankedKeyPhrases) -> Vec<String> {
+        v.0
+    }
+}
 
 impl<const KEY_PHRASE_SIZE: usize> KeyPhrases<KEY_PHRASE_SIZE> {
     /// Collects all potential key phrases from the words.

--- a/discovery_engine_core/bindings/src/types/document/user_reacted.rs
+++ b/discovery_engine_core/bindings/src/types/document/user_reacted.rs
@@ -54,6 +54,17 @@ pub unsafe extern "C" fn user_reacted_place_of_snippet(place: *mut UserReacted) 
     unsafe { addr_of_mut!((*place).snippet) }
 }
 
+/// Returns a pointer to the `title` field of an [`UserReacted`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`UserReacted`] memory object, it
+/// might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn user_reacted_place_of_title(place: *mut UserReacted) -> *mut String {
+    unsafe { addr_of_mut!((*place).title) }
+}
+
 /// Returns a pointer to the `smbert_embedding` field of an [`UserReacted`].
 ///
 /// # Safety

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -199,6 +199,9 @@ pub struct UserReacted {
     /// Stack from which the document has been taken.
     pub stack_id: StackId,
 
+    /// Text title of the document.
+    pub title: String,
+
     /// Text snippet of the document.
     pub snippet: String,
 

--- a/discovery_engine_core/core/src/ranker.rs
+++ b/discovery_engine_core/core/src/ranker.rs
@@ -84,6 +84,7 @@ impl Ranker for xayn_discovery_engine_ai::ranker::Ranker {
     fn log_user_reaction(&mut self, reaction: &UserReacted) -> Result<(), GenericError> {
         self.log_user_reaction(
             reaction.reaction.into(),
+            &reaction.title,
             &reaction.snippet,
             &reaction.smbert_embedding,
             &reaction.market,


### PR DESCRIPTION
In some case the snippet is not long enough to perform kpe extraction, in this case we retry using the `title` concatenated with the `snippet`, if also this fails we use as the key phrase the `title` if not empty, otherwise the `snippet`.