### PR TITLE
[Merged by Bors] - TY-2811 request deep search via document id

### DIFF
--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -191,11 +191,8 @@ class ClientEvent with _$ClientEvent {
 
   /// Event created when the user starts a new deep search.
   @Implements<SearchClientEvent>()
-  @Assert('term != ""')
-  const factory ClientEvent.deepSearchRequested(
-    String term,
-    FeedMarket market,
-  ) = DeepSearchRequested;
+  const factory ClientEvent.deepSearchRequested(DocumentId id) =
+      DeepSearchRequested;
 
   /// Event created when the client asks for the currently trending topics.
   @Implements<SearchClientEvent>()

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -56,8 +56,6 @@ import 'package:xayn_discovery_engine/src/discovery_engine_worker.dart'
     as entry_point show main;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document;
-import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
-    show FeedMarket;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
     show AvailableSource, Source;
 import 'package:xayn_discovery_engine/src/logger.dart' show logger;
@@ -497,7 +495,7 @@ class DiscoveryEngine {
     });
   }
 
-  /// Requests a new deep search for [Document]s related to `term` and `market`.
+  /// Requests a new deep search for [Document]s related to a document.
   ///
   /// In response it can return:
   /// - [DeepSearchRequestSucceeded] for successful response, containing a list of
@@ -505,9 +503,9 @@ class DiscoveryEngine {
   /// - [DeepSearchRequestFailed] for failed response, with a reason for failure
   /// - [EngineExceptionReason] for unexpected exception raised, with a reason
   /// for such failure.
-  Future<EngineEvent> requestDeepSearch(String term, FeedMarket market) {
+  Future<EngineEvent> requestDeepSearch(DocumentId id) {
     return _trySend(() async {
-      final event = ClientEvent.deepSearchRequested(term, market);
+      final event = ClientEvent.deepSearchRequested(id);
       final response = await _manager.send(event);
 
       return response.mapEvent(


### PR DESCRIPTION
**References**

- [TY-2833]
- [TY-2834]
- requires #401
- followed by #406

**Summary**

- change deep search event & handler to be called on a document id


[TY-2833]: https://xainag.atlassian.net/browse/TY-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2834]: https://xainag.atlassian.net/browse/TY-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ