### PR TITLE
[Merged by Bors] - TY-2816 deep search semantic

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -21,6 +21,8 @@ import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/configuration.dart'
     show Configuration;
+import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
+    show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarket, FeedMarkets;
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
@@ -89,9 +91,13 @@ abstract class Engine {
   );
 
   /// Performs a deep search by term and market.
+  ///
+  /// The documents are sorted in descending order wrt their cosine similarity towards the
+  /// original search term embedding.
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
     FeedMarket market,
+    Embedding embedding,
   );
 
   /// Returns the currently trending topics.

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -18,6 +18,8 @@ import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine, EngineInitializer;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
+import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
+    show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarket, FeedMarkets;
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
@@ -137,6 +139,7 @@ class MockEngine implements Engine {
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
     FeedMarket market,
+    Embedding embedding,
   ) async {
     _incrementCount('deepSearch');
     return deepSearchDocuments;

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -201,7 +201,8 @@ class SearchManager {
   /// These documents aren't persisted to repositories.
   Future<EngineEvent> deepSearchRequested(DocumentId id) async {
     final doc = await _docRepo.fetchById(id);
-    if (doc == null || !doc.isActive) {
+    final data = await _activeRepo.fetchById(id);
+    if (doc == null || !doc.isActive || data == null) {
       throw ArgumentError('id $id does not identify an active document');
     }
     final term = doc.resource.snippet.isNotEmpty
@@ -211,10 +212,11 @@ class SearchManager {
       countryCode: doc.resource.country,
       langCode: doc.resource.language,
     );
+    final embedding = data.smbertEmbedding;
 
     final List<DocumentWithActiveData> docs;
     try {
-      docs = await _engine.deepSearch(term, market);
+      docs = await _engine.deepSearch(term, market, embedding);
     } catch (e) {
       const fewWords =
           'The sequence must contain at least `KEY_PHRASE_SIZE` valid words';

--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -19,6 +19,7 @@ import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustEmbedding;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
     show checkFfiUsize;
 
@@ -39,5 +40,11 @@ extension EmbeddingFfi on Embedding {
     final len = ffi.get_embedding_buffer_len(place);
     final data = ffi.get_embedding_buffer(place).asTypedList(len);
     return Embedding.fromList(data);
+  }
+
+  Boxed<RustEmbedding> allocNative() {
+    final place = ffi.alloc_uninitialized_embedding();
+    writeNative(place);
+    return Boxed(place, ffi.drop_embedding);
   }
 }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -19,6 +19,8 @@ import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine, EngineInitializer;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
+import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
+    show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarket, FeedMarkets;
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
@@ -41,6 +43,8 @@ import 'package:xayn_discovery_engine/src/ffi/types/document/time_spent.dart'
     show TimeSpentFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/user_reacted.dart'
     show UserReactedFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
+    show EmbeddingFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market.dart'
     show FeedMarketFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
@@ -233,15 +237,20 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   /// Performs a deep search by term and market.
+  ///
+  /// The documents are sorted in descending order wrt their cosine similarity towards the
+  /// original search term embedding.
   @override
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
     FeedMarket market,
+    Embedding embedding,
   ) async {
     final result = await asyncFfi.deepSearch(
       _engine.ref,
       term.allocNative().move(),
       market.allocNative().move(),
+      embedding.allocNative().move(),
     );
 
     return resultVecDocumentStringFfiAdapter

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3310,6 +3310,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "xayn-discovery-engine-ai",
  "xayn-discovery-engine-core",
  "xayn-discovery-engine-providers",
 ]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1.31"
 tracing-subscriber = "0.3.9"
 url = "2.2.2"
 uuid = "1.0.0"
+xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-core = { path = "../core" }
 xayn-discovery-engine-providers = { path = "../providers" }
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -38,6 +38,7 @@ pub mod types;
 use xayn_discovery_engine_core::Engine;
 
 #[async_bindgen::api(
+    use xayn_discovery_engine_ai::ranker::Embedding;
     use xayn_discovery_engine_core::{
         document::{Document, HistoricDocument, TimeSpent, UserReacted},
         InitConfig,
@@ -186,17 +187,21 @@ impl XaynDiscoveryEngineAsyncFfi {
     }
 
     /// Performs a deep search by term and market.
+    ///
+    /// The documents are sorted in descending order wrt their cosine similarity towards the
+    /// original search term embedding.
     pub async fn deep_search(
         engine: &SharedEngine,
         term: Box<String>,
         market: Box<Market>,
+        embedding: Box<Embedding>,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .deep_search(term.as_ref(), market.as_ref())
+                .deep_search(term.as_ref(), market.as_ref(), embedding.as_ref())
                 .await
                 .map_err(|error| error.to_string()),
         )


### PR DESCRIPTION
**References**

- [TY-2816]
- requires #405

**Summary**

- filter and sort deep search documents semantically via cosine similarity
- update related rust & dart ffi


[TY-2816]: https://xainag.atlassian.net/browse/TY-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ