### PR TITLE
[Merged by Bors] - TY-2815 remove benches from cargo test targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -171,7 +171,7 @@ rust-test: _codegen-order-workaround download-assets
     #!/usr/bin/env sh
     set -eux
     cd "$RUST_WORKSPACE";
-    cargo test --all-targets --quiet --locked
+    cargo test --lib --bins --tests --quiet --locked
     cargo test --doc --quiet --locked
 
 # Tests dart and rust


### PR DESCRIPTION
**References**

- [TY-2815]
- #409

**Summary**

unfortunately `cargo test --all-targets` resp `cargo test --benches` ignores the `test = false` flag on the benches and [uses the `bench = true` flag instead](https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection). we have to enable the `bench` flag in order to have the benches checked, hence we need to remove the `--benches` target from the `--all-targets` test targets manually.


[TY-2815]: https://xainag.atlassian.net/browse/TY-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ