### PR TITLE
[Merged by Bors] - TY-2792 implement trending topics method on engine

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
 
-use xayn_discovery_engine_providers::{Article, Market};
+use xayn_discovery_engine_providers::{Article, Market, TrendingTopic as BingTopic};
 
 use crate::stack::Id as StackId;
 
@@ -255,6 +255,23 @@ pub struct TrendingTopic {
     pub query: String,
     /// Link to a related image.
     pub image: Option<Url>,
+}
+
+impl TryFrom<(BingTopic, Embedding)> for TrendingTopic {
+    type Error = Error;
+    fn try_from((topic, smbert_embedding): (BingTopic, Embedding)) -> Result<Self, Self::Error> {
+        let image = topic.image.url;
+
+        Ok(Self {
+            id: Id::new(),
+            smbert_embedding,
+            name: topic.name,
+            query: topic.query.text,
+            image: (!image.is_empty())
+                .then(|| Url::parse(&image))
+                .transpose()?,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -152,16 +152,17 @@ impl TryFrom<Article> for NewsResource {
     type Error = Error;
     fn try_from(article: Article) -> Result<Self, Self::Error> {
         let media = article.media;
+        let image = (!media.is_empty())
+            .then(|| Url::parse(&media))
+            .transpose()?;
 
-        Ok(NewsResource {
+        Ok(Self {
             title: article.title,
             snippet: article.excerpt,
             date_published: article.published_date,
             url: Url::parse(&article.link)?,
             source_domain: article.source_domain,
-            image: (!media.is_empty())
-                .then(|| Url::parse(&media))
-                .transpose()?,
+            image,
             rank: article.rank,
             score: article.score,
             country: article.country,
@@ -260,16 +261,15 @@ pub struct TrendingTopic {
 impl TryFrom<(BingTopic, Embedding)> for TrendingTopic {
     type Error = Error;
     fn try_from((topic, smbert_embedding): (BingTopic, Embedding)) -> Result<Self, Self::Error> {
-        let image = topic.image.url;
+        let url = topic.image.url;
+        let image = (!url.is_empty()).then(|| Url::parse(&url)).transpose()?;
 
         Ok(Self {
             id: Id::new(),
             smbert_embedding,
             name: topic.name,
             query: topic.query.text,
-            image: (!image.is_empty())
-                .then(|| Url::parse(&image))
-                .transpose()?,
+            image,
         })
     }
 }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -44,11 +44,21 @@ use xayn_discovery_engine_providers::{
     HeadlinesQuery,
     Market,
     NewsQuery,
+    TrendingQuery,
+    TrendingTopic as BingTopic,
 };
 use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 
 use crate::{
-    document::{self, Document, HistoricDocument, TimeSpent, UserReacted, UserReaction},
+    document::{
+        self,
+        Document,
+        HistoricDocument,
+        TimeSpent,
+        TrendingTopic,
+        UserReacted,
+        UserReaction,
+    },
     mab::{self, BetaSampler, Bucket, SelectionIter},
     ranker::Ranker,
     stack::{
@@ -568,7 +578,7 @@ where
             );
         }
 
-        let (mut documents, article_errors) = articles_into_documents(
+        let (mut documents, article_errors) = documentify_articles(
             StackId::nil(), // these documents are not associated with a stack
             &self.ranker,
             articles,
@@ -617,7 +627,7 @@ where
             .await
             .map_err(|error| Error::Client(error.into()))?;
         let articles = MalformedFilter::apply(&[], &[], articles)?;
-        let (documents, errors) = articles_into_documents(
+        let (documents, errors) = documentify_articles(
             StackId::nil(), // these documents are not associated with a stack
             &self.ranker,
             articles,
@@ -628,6 +638,33 @@ where
             Err(Error::Errors(errors))
         } else {
             Ok(documents)
+        }
+    }
+
+    /// Returns the current trending topics.
+    pub async fn trending_topics(&mut self) -> Result<Vec<TrendingTopic>, Error> {
+        let mut errors = Vec::new();
+        let mut topics = Vec::new();
+
+        let markets = self.config.markets.read().await;
+        for market in markets.iter() {
+            let query = TrendingQuery { market };
+            match self.client.query_trending(&query).await {
+                Ok(batch) => topics.extend(batch),
+                Err(err) => errors.push(Error::Client(err.into())),
+            };
+        }
+
+        let (mut topics, topic_errors) = documentify_topics(&self.ranker, topics);
+        errors.extend(topic_errors);
+
+        if let Err(err) = self.ranker.rank(&mut topics) {
+            errors.push(Error::Ranker(err));
+        };
+        if topics.is_empty() && !errors.is_empty() {
+            Err(Error::Errors(errors))
+        } else {
+            Ok(topics)
         }
     }
 
@@ -844,7 +881,7 @@ async fn fetch_new_documents_for_stack(
             return Err(Error::StackOpFailed(error));
         }
     };
-    let (documents, errors) = articles_into_documents(stack.id(), ranker, articles);
+    let (documents, errors) = documentify_articles(stack.id(), ranker, articles);
 
     // only return an error if all articles failed
     if documents.is_empty() && !errors.is_empty() {
@@ -854,7 +891,7 @@ async fn fetch_new_documents_for_stack(
     }
 }
 
-fn articles_into_documents(
+fn documentify_articles(
     stack_id: StackId,
     ranker: &(impl Ranker + Send + Sync),
     articles: Vec<Article>,
@@ -878,6 +915,30 @@ fn articles_into_documents(
         .partition_map(|result| match result {
             Ok(document) => Either::Left(document),
             Err(error) => Either::Right(error),
+        })
+}
+
+fn documentify_topics(
+    ranker: &(impl Ranker + Send + Sync),
+    topics: Vec<BingTopic>,
+) -> (Vec<TrendingTopic>, Vec<Error>) {
+    topics
+        .into_par_iter()
+        .map(|topic| {
+            let embedding = ranker.compute_smbert(&topic.name).map_err(|err| {
+                let error = Error::Ranker(err);
+                error!("{}", error);
+                error
+            })?;
+            (topic, embedding).try_into().map_err(|err| {
+                let error = Error::Document(err);
+                error!("{}", error);
+                error
+            })
+        })
+        .partition_map(|result| match result {
+            Ok(topic) => Either::Left(topic),
+            Err(err) => Either::Right(err),
         })
 }
 

--- a/discovery_engine_core/providers/src/bing.rs
+++ b/discovery_engine_core/providers/src/bing.rs
@@ -87,31 +87,31 @@ pub struct Response {
 pub struct TrendingTopic {
     /// Title of the trending topic.
     #[serde(default, deserialize_with = "deserialize_null_default")]
-    pub(crate) name: String,
+    pub name: String,
 
     /// Search query that returns this topic.
     #[serde(default)]
-    pub(crate) query: SearchQuery,
+    pub query: SearchQuery,
 
     /// Link to a related image.
     #[serde(default)]
-    pub(crate) image: Image,
+    pub image: Image,
 }
 
 /// Search query returning a trending topic.
 #[derive(Serialize, Deserialize, Debug, Default)]
-pub(crate) struct SearchQuery {
+pub struct SearchQuery {
     /// Query text.
     #[serde(default, deserialize_with = "deserialize_null_default")]
-    pub(crate) text: String,
+    pub text: String,
 }
 
 /// Image relating to a trending topic.
 #[derive(Serialize, Deserialize, Debug, Default)]
-pub(crate) struct Image {
+pub struct Image {
     /// URL to the image.
     #[serde(default, deserialize_with = "deserialize_null_default")]
-    pub(crate) url: String,
+    pub url: String,
 }
 
 // TODO relocate

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -37,7 +37,7 @@ mod expression;
 mod filter;
 mod newscatcher;
 
-pub use bing::TrendingQuery;
+pub use bing::{TrendingQuery, TrendingTopic};
 pub use clean_query::clean_query;
 pub use client::{
     default_from,


### PR DESCRIPTION
**Summary**

- previously #374
- and #391

adds a method in the engine for obtaining the current `trending_topics`.

_footnote_. also the helper function `articles_into_documents` was renamed to be consistent with a new helper `documentify_topics`