### PR TITLE
[Merged by Bors] - TY-2867 fix market handling when doing requests

### DIFF
--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 use xayn_discovery_engine_ai::ranker::KeyPhrase;
-use xayn_discovery_engine_providers::Article;
+use xayn_discovery_engine_providers::{Article, Market};
 
 use crate::{
     document::{Document, HistoricDocument, Id as DocumentId, UserReaction},
@@ -198,9 +198,10 @@ impl Stack {
         &self,
         key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
+        market: &Market,
     ) -> Result<Vec<Article>, Error> {
         self.ops
-            .new_items(key_phrases, history, &self.data.documents)
+            .new_items(key_phrases, history, &self.data.documents, market)
             .await
             .map_err(Error::New)
     }

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -19,7 +19,7 @@ use mockall::automock;
 use thiserror::Error;
 
 use xayn_discovery_engine_ai::ranker::KeyPhrase;
-use xayn_discovery_engine_providers::Article;
+use xayn_discovery_engine_providers::{Article, Market};
 
 use crate::{
     document::{Document, HistoricDocument},
@@ -64,6 +64,7 @@ pub trait Ops {
         key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
+        market: &Market,
     ) -> Result<Vec<Article>, NewItemsError>;
 
     /// Returns if `[new_items]` needs the key phrases to work.

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -98,6 +98,7 @@ impl Ops for BreakingNews {
         request_min_new_items(
             self.max_requests,
             self.min_articles,
+            self.page_size,
             |request_num| {
                 spawn_headlines_request(
                     self.client.clone(),

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -37,16 +37,11 @@ use crate::{
     },
 };
 
-use super::{
-    common::{create_requests_for_markets, request_min_new_items},
-    NewItemsError,
-    Ops,
-};
+use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for breaking news items.
 pub(crate) struct BreakingNews {
     client: Arc<Client>,
-    markets: Arc<RwLock<Vec<Market>>>,
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
     max_requests: u32,
@@ -58,7 +53,6 @@ impl BreakingNews {
     pub(crate) fn new(config: &EndpointConfig, client: Arc<Client>) -> Self {
         Self {
             client,
-            markets: config.markets.clone(),
             excluded_sources: config.excluded_sources.clone(),
             page_size: config.page_size,
             max_requests: config.max_requests,
@@ -97,24 +91,21 @@ impl Ops for BreakingNews {
         _key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
+        market: &Market,
     ) -> Result<Vec<Article>, NewItemsError> {
-        let markets = self.markets.read().await.clone();
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
 
         request_min_new_items(
             self.max_requests,
             self.min_articles,
             |request_num| {
-                create_requests_for_markets(markets.clone(), |market| {
-                    let page = request_num as usize + 1;
-                    spawn_headlines_request(
-                        self.client.clone(),
-                        market,
-                        self.page_size,
-                        page,
-                        excluded_sources.clone(),
-                    )
-                })
+                spawn_headlines_request(
+                    self.client.clone(),
+                    market.clone(),
+                    self.page_size,
+                    request_num as usize + 1,
+                    excluded_sources.clone(),
+                )
             },
             |articles| Self::filter_articles(history, stack, articles, &excluded_sources),
         )

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -12,58 +12,32 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::task::JoinHandle;
-use xayn_discovery_engine_providers::Market;
 
 use crate::engine::GenericError;
 
 type ItemsResult<I> = Result<Vec<I>, GenericError>;
-type Requests<I> = FuturesUnordered<JoinHandle<ItemsResult<I>>>;
-
-async fn request_new_items<I: Send>(
-    requests_fn: impl FnOnce() -> Requests<I> + Send,
-) -> ItemsResult<I> {
-    let mut requests = requests_fn();
-    let mut items = Vec::new();
-    let mut error = None;
-
-    while let Some(handle) = requests.next().await {
-        // should we also push handle errors?
-        if let Ok(result) = handle {
-            match result {
-                Ok(batch) => items.extend(batch),
-                Err(err) => {
-                    error.replace(err);
-                }
-            }
-        }
-    }
-
-    if items.is_empty() && error.is_some() {
-        Err(error.unwrap(/* nonempty error */))
-    } else {
-        Ok(items)
-    }
-}
+type Request<I> = JoinHandle<ItemsResult<I>>;
 
 pub(super) async fn request_min_new_items<I: Send>(
     max_requests: u32,
     min_articles: usize,
-    requests_fn: impl Fn(u32) -> Requests<I> + Send + Sync,
+    request_fn: impl Fn(u32) -> Request<I> + Send + Sync,
     filter_fn: impl Fn(Vec<I>) -> ItemsResult<I> + Send + Sync,
 ) -> ItemsResult<I> {
-    let mut items = Vec::new();
+    let mut items = Vec::with_capacity(min_articles);
     let mut error = None;
 
     for request_num in 0..max_requests {
-        match request_new_items(|| requests_fn(request_num)).await {
+        match request_fn(request_num).await {
             // if the API doesn't return any new items, we stop requesting more pages
-            Ok(batch) if batch.is_empty() => break,
-            Ok(batch) => items.extend(batch),
-            Err(err) => {
+            Ok(Ok(batch)) if batch.is_empty() => break,
+            Ok(Ok(batch)) => items.extend(batch),
+            Ok(Err(err)) => {
                 error.replace(err);
             }
+            // should we also push handle errors?
+            Err(_) => {}
         };
 
         items = filter_fn(items)
@@ -82,23 +56,13 @@ pub(super) async fn request_min_new_items<I: Send>(
     }
 }
 
-pub(super) fn create_requests_for_markets<I>(
-    markets: Vec<Market>,
-    request_fn: impl Fn(Market) -> JoinHandle<ItemsResult<I>> + Send,
-) -> Requests<I> {
-    markets
-        .into_iter()
-        .map(request_fn)
-        .collect::<FuturesUnordered<_>>()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    struct Resp(Result<Vec<u32>, GenericError>);
+    struct Response(ItemsResult<u32>);
 
-    impl Resp {
+    impl Response {
         fn ok(items: &[u32]) -> Self {
             Self(Ok(items.to_owned()))
         }
@@ -106,46 +70,10 @@ mod tests {
         fn err(msg: &str) -> Self {
             Self(Err(GenericError::from(msg)))
         }
-    }
 
-    fn client(responses: Vec<Resp>) -> Requests<u32> {
-        responses
-            .into_iter()
-            .map(|response| tokio::spawn(async { response.0 }))
-            .collect::<FuturesUnordered<_>>()
-    }
-
-    #[tokio::test]
-    async fn test_request_new_items() {
-        let items = request_new_items(|| {
-            let responses = vec![Resp::ok(&[1]), Resp::ok(&[2, 3])];
-            client(responses)
-        })
-        .await
-        .unwrap();
-        assert_eq!(items.len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_request_new_items_only_errors() {
-        let res = request_new_items(|| {
-            let responses = vec![Resp::err("0"), Resp::err("1")];
-            client(responses)
-        })
-        .await;
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err().to_string(), "1");
-    }
-
-    #[tokio::test]
-    async fn test_request_new_items_mixed() {
-        let items = request_new_items(|| {
-            let responses = vec![Resp::err("0"), Resp::ok(&[1])];
-            client(responses)
-        })
-        .await
-        .unwrap();
-        assert_eq!(items.len(), 1);
+        fn request(self) -> Request<u32> {
+            tokio::spawn(async { self.0 })
+        }
     }
 
     #[tokio::test]
@@ -153,10 +81,7 @@ mod tests {
         let items = request_min_new_items(
             3,
             2,
-            |i| {
-                let responses = vec![Resp::ok(&[i])];
-                client(responses)
-            },
+            |i| Response::ok(&[i]).request(),
             |items| Ok(items.into_iter().filter(|item| *item != 2).collect()),
         )
         .await
@@ -166,13 +91,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_min_new_items_filter_error() {
-        let res: Result<Vec<u32>, GenericError> = request_min_new_items(
+        let res = request_min_new_items(
             1,
             1,
-            |_| {
-                let responses = vec![Resp::ok(&[0])];
-                client(responses)
-            },
+            |_| Response::ok(&[0]).request(),
             |_| Err(GenericError::from("filter")),
         )
         .await;
@@ -182,32 +104,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_min_new_items() {
-        let items = request_min_new_items(
-            2,
-            2,
-            |i| {
-                let responses = vec![Resp::ok(&[i])];
-                client(responses)
-            },
-            Ok,
-        )
-        .await
-        .unwrap();
+        let items = request_min_new_items(2, 2, |i| Response::ok(&[i]).request(), Ok)
+            .await
+            .unwrap();
         assert_eq!(items.len(), 2);
     }
 
     #[tokio::test]
     async fn test_request_min_new_items_only_errors() {
-        let res = request_min_new_items(
-            2,
-            2,
-            |i| {
-                let responses = vec![Resp::err(&format!("{}", i))];
-                client(responses)
-            },
-            Ok,
-        )
-        .await;
+        let res =
+            request_min_new_items(2, 2, |i| Response::err(&format!("{}", i)).request(), Ok).await;
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(), "1");
     }
@@ -218,29 +124,25 @@ mod tests {
             2,
             2,
             |i| {
-                let responses = vec![Resp::err(&format!("{}", i)), Resp::ok(&[i])];
-                client(responses)
+                match i {
+                    0 => Response::err(&format!("{}", i)),
+                    1 => Response::ok(&[i]),
+                    _ => unreachable!(),
+                }
+                .request()
             },
             Ok,
         )
         .await
         .unwrap();
-        assert_eq!(items.len(), 2);
+        assert_eq!(items.len(), 1);
     }
 
     #[tokio::test]
     async fn test_request_min_new_items_less_than_min() {
-        let items = request_min_new_items(
-            3,
-            10,
-            |i| {
-                let responses = vec![Resp::ok(&[i])];
-                client(responses)
-            },
-            Ok,
-        )
-        .await
-        .unwrap();
+        let items = request_min_new_items(3, 10, |i| Response::ok(&[i]).request(), Ok)
+            .await
+            .unwrap();
         assert_eq!(items.len(), 3);
     }
 
@@ -250,8 +152,11 @@ mod tests {
             3,
             1,
             |i| {
-                let responses = vec![Resp::ok(&[i]), Resp::ok(&[i])];
-                client(responses)
+                match i {
+                    0 => Response::ok(&[i, i + 1]),
+                    _ => unreachable!(),
+                }
+                .request()
             },
             Ok,
         )
@@ -263,38 +168,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_min_new_items_no_requests() {
-        let items = request_min_new_items(
-            0,
-            0,
-            |i| {
-                let responses = vec![Resp::ok(&[i]), Resp::ok(&[i])];
-                client(responses)
-            },
-            Ok,
-        )
-        .await
-        .unwrap();
+        let items = request_min_new_items(0, 0, |i| Response::ok(&[i]).request(), Ok)
+            .await
+            .unwrap();
         assert!(items.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_request_min_new_items_exit_early() {
-        let items = request_min_new_items(
-            5,
-            10,
-            |i| {
-                if i == 2 {
-                    FuturesUnordered::new()
-                } else {
-                    let responses = vec![Resp::ok(&[i])];
-                    client(responses)
-                }
-            },
-            Ok,
-        )
-        .await
-        .unwrap();
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[1], 1);
     }
 }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -102,6 +102,7 @@ impl Ops for PersonalizedNews {
         request_min_new_items(
             self.max_requests,
             self.min_articles,
+            self.page_size,
             |request_num| {
                 spawn_news_request(
                     self.client.clone(),

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -38,16 +38,11 @@ use crate::{
     },
 };
 
-use super::{
-    common::{create_requests_for_markets, request_min_new_items},
-    NewItemsError,
-    Ops,
-};
+use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for personalized news items.
 pub(crate) struct PersonalizedNews {
     client: Arc<Client>,
-    markets: Arc<RwLock<Vec<Market>>>,
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
     max_requests: u32,
@@ -59,7 +54,6 @@ impl PersonalizedNews {
     pub(crate) fn new(config: &EndpointConfig, client: Arc<Client>) -> Self {
         Self {
             client,
-            markets: config.markets.clone(),
             page_size: config.page_size,
             excluded_sources: config.excluded_sources.clone(),
             max_requests: config.max_requests,
@@ -94,6 +88,7 @@ impl Ops for PersonalizedNews {
         key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
+        market: &Market,
     ) -> Result<Vec<Article>, NewItemsError> {
         if key_phrases.is_empty() {
             return Err(NewItemsError::NotReady);
@@ -102,24 +97,20 @@ impl Ops for PersonalizedNews {
         let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
             filter.add_keyword(kp.words())
         }));
-        let markets = self.markets.read().await.clone();
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
 
         request_min_new_items(
             self.max_requests,
             self.min_articles,
             |request_num| {
-                create_requests_for_markets(markets.clone(), |market| {
-                    let page = request_num as usize + 1;
-                    spawn_news_request(
-                        self.client.clone(),
-                        market,
-                        filter.clone(),
-                        self.page_size,
-                        page,
-                        excluded_sources.clone(),
-                    )
-                })
+                spawn_news_request(
+                    self.client.clone(),
+                    market.clone(),
+                    filter.clone(),
+                    self.page_size,
+                    request_num as usize + 1,
+                    excluded_sources.clone(),
+                )
             },
             |articles| Self::filter_articles(history, stack, articles, &excluded_sources),
         )

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -12,10 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{iter, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::stream::FuturesUnordered;
 use itertools::chain;
 use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::uuid;
@@ -25,6 +24,7 @@ use xayn_discovery_engine_providers::{
     Client,
     CommonQueryParts,
     HeadlinesQuery,
+    Market,
     DEFAULT_WHEN,
 };
 
@@ -85,6 +85,7 @@ impl Ops for TrustedNews {
         _key_phrases: &[KeyPhrase],
         history: &[HistoricDocument],
         stack: &[Document],
+        _market: &Market,
     ) -> Result<Vec<Article>, NewItemsError> {
         let sources = Arc::new(self.sources.read().await.clone());
         if sources.is_empty() {
@@ -95,14 +96,12 @@ impl Ops for TrustedNews {
             self.max_requests,
             self.min_articles,
             |request_num| {
-                let page = request_num as usize + 1;
-                let future = spawn_trusted_request(
+                spawn_trusted_request(
                     self.client.clone(),
                     self.page_size,
-                    page,
+                    request_num as usize + 1,
                     sources.clone(),
-                );
-                iter::once(future).collect::<FuturesUnordered<_>>()
+                )
             },
             |articles| Self::filter_articles(history, stack, articles),
         )

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -95,6 +95,7 @@ impl Ops for TrustedNews {
         request_min_new_items(
             self.max_requests,
             self.min_articles,
+            self.page_size,
             |request_num| {
                 spawn_trusted_request(
                     self.client.clone(),


### PR DESCRIPTION
**References**

- [TY-2867]

**Summary**

- pass the current `Market` when fetching `new_items()` for a `Stack` and use it for the `BreakingNews` & `PersonalizedNews` stacks


[TY-2867]: https://xainag.atlassian.net/browse/TY-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ