### PR TITLE
[Merged by Bors] - TY-2856 fix dart example readme

### DIFF
--- a/discovery_engine/.gitignore
+++ b/discovery_engine/.gitignore
@@ -6,6 +6,9 @@
 build/
 **/doc/api/
 
+# Omit download dir for example's assets
+engine_data/
+
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock

--- a/discovery_engine/example/README.md
+++ b/discovery_engine/example/README.md
@@ -32,8 +32,11 @@ $ dart pub get
 ## Dart VM example
 
 ```sh
-# run the example, this executes the code in bin/example.dart
+# run the example from the discovery_engine/example/ dir, this executes the code in bin/example.dart
 $ dart run
+
+# if dynamic library path resolution fails, run the example from the discovery_engine/ dir
+$ dart run example/bin/example.dart
 ```
 
 ## Web example


### PR DESCRIPTION
**Summary**

update readme of the dart example:
- the path resolution of the loaded dynamic library fails (on macos, maybe also other) if the example is executed from its directory (used to work before, maybe due to dart update)
- same holds for the flutter example but the fix is not applicable because additional required flutter project files can't be found anymore from a different path than the example dir
