### PR TITLE
[Merged by Bors] - TY 2873 Fetch from all market before update the stack

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -355,7 +355,7 @@ where
             self.core_config.take_top,
             self.core_config.keep_top,
             request_new,
-            &*markets,
+            &markets,
         )
         .await
     }
@@ -812,12 +812,13 @@ async fn update_stacks<'a>(
     // Here we gather new documents for all relevant stacks, and put them into a vector.
     // We don't update the stacks immediately, because we want to de-duplicate the documents
     // across stacks first.
-    let no_key_phrases = vec![];
     let new_document_futures = needy_stacks
         .iter()
         .flat_map(|stack| {
             markets.iter().map(|market| {
-                let key_phrases = key_phrases_by_market.get(market).unwrap_or(&no_key_phrases);
+                let key_phrases = key_phrases_by_market
+                    .get(market)
+                    .map_or(&[] as &[_], Vec::as_slice);
                 fetch_new_documents_for_stack(stack, ranker, key_phrases, history, market)
             })
         })


### PR DESCRIPTION
This PR fetch articles from all the markets before updating the stack.
The problem with the current code is that if updating from a market can bring the stack to a state where it does not need to be updated. This means that when we try to update the other markets this stack will be skipped.