### PR TITLE
FIX: bench deps on aarch targets

### DIFF
--- a/discovery_engine_core/ai/bert/Cargo.toml
+++ b/discovery_engine_core/ai/bert/Cargo.toml
@@ -16,11 +16,13 @@ thiserror = "1.0.30"
 tract-onnx = "0.16.1"
 xayn-discovery-engine-tokenizer = { path = "../tokenizer" }
 
+# dev-dependencies which don't work for aarch targets
+onnxruntime = { version = "0.0.13", optional = true }
+
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }
 csv = { version = "1.1.6" }
 indicatif = { version = "0.16.2" }
-onnxruntime = { version = "0.0.13" }
 xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[example]]
@@ -30,8 +32,10 @@ test = false
 [[example]]
 name = "validate"
 test = false
+required-features = ["onnxruntime"]
 
 [[bench]]
 name = "mbert"
 harness = false
 test = false
+required-features = ["onnxruntime"]

--- a/discovery_engine_core/ai/bert/benches/mbert.rs
+++ b/discovery_engine_core/ai/bert/benches/mbert.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Run as `cargo bench --bench mbert`.
+//! Run as `cargo bench --bench mbert --features onnxruntime`.
 
 use std::{io::Result, path::Path};
 

--- a/discovery_engine_core/ai/bert/examples/validate.rs
+++ b/discovery_engine_core/ai/bert/examples/validate.rs
@@ -14,7 +14,7 @@
 
 //! Compares MBert models evaluated by the onnx or the tract runtime.
 //!
-//! Run as `cargo run --release --example validate`.
+//! Run as `cargo run --release --example validate --features onnxruntime`.
 
 use std::{
     marker::PhantomPinned,


### PR DESCRIPTION
**Summary**

- `onnxruntime` doesn't compile for some `aarch` targets, hence we make it optional again
