### PR TITLE
[Merged by Bors] - TY-2904 set in parameter for gnews

### DIFF
--- a/discovery_engine_core/providers/src/gnews.rs
+++ b/discovery_engine_core/providers/src/gnews.rs
@@ -55,10 +55,12 @@ impl NewsProvider for NewsProviderImpl {
     async fn query_news(&self, request: &NewsQuery<'_>) -> Result<Vec<Article>, Error> {
         self.0
             .fetch::<Response, _>(|mut query| {
-                query.append_pair("sortby", "relevance");
+                query.append_pair("sortby", "relevance")
+                    .append_pair("q", &request.filter.build())
+                    .append_pair("in", "title,description,content");
+
                 append_common_query_parts(&mut query, &request.common);
                 append_market(&mut query, request.market);
-                query.append_pair("q", &request.filter.build());
             })
             .await
             .map(|response| {

--- a/discovery_engine_core/providers/src/gnews.rs
+++ b/discovery_engine_core/providers/src/gnews.rs
@@ -55,7 +55,8 @@ impl NewsProvider for NewsProviderImpl {
     async fn query_news(&self, request: &NewsQuery<'_>) -> Result<Vec<Article>, Error> {
         self.0
             .fetch::<Response, _>(|mut query| {
-                query.append_pair("sortby", "relevance")
+                query
+                    .append_pair("sortby", "relevance")
                     .append_pair("q", &request.filter.build())
                     .append_pair("in", "title,description,content");
 


### PR DESCRIPTION

Set `in` parameter for gnews/search to `title,description,content`.

**References:**

- [story TY-2810](https://xainag.atlassian.net/browse/TY-2810)
- [issue TY-2904](https://xainag.atlassian.net/browse/TY-2904)

**Bases on:**

- #433 