### PR TITLE
[Merged by Bors] - TY-2919 Change order of ranking the documents, fix ranking of active search & trending topics

### DIFF
--- a/discovery_engine_core/ai/ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/public.rs
@@ -53,7 +53,8 @@ impl Ranker {
         self.0.extract_key_phrases(sequence)
     }
 
-    /// Ranks the given documents in descending order based on the learned user interests.
+    /// Ranks the given documents in descending order of relevancy based on the
+    /// learned user interests.
     pub fn rank(&mut self, items: &mut [impl Document]) {
         self.0.rank(items);
     }

--- a/discovery_engine_core/ai/ai/src/ranker/public.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/public.rs
@@ -53,7 +53,7 @@ impl Ranker {
         self.0.extract_key_phrases(sequence)
     }
 
-    /// Ranks the given documents based on the learned user interests.
+    /// Ranks the given documents in descending order based on the learned user interests.
     pub fn rank(&mut self, items: &mut [impl Document]) {
         self.0.rank(items);
     }

--- a/discovery_engine_core/ai/ai/src/utils.rs
+++ b/discovery_engine_core/ai/ai/src/utils.rs
@@ -58,7 +58,7 @@ pub fn nan_safe_f32_cmp(a: &f32, b: &f32) -> Ordering {
     nan_safe_f32_cmp_base(a, b, true)
 }
 
-/// `nan_safe_f32_cmp_desc(a,b)` is syntax suggar for `nan_safe_f32_cmp(b, a)`
+/// `nan_safe_f32_cmp_desc(a,b)` is syntax sugar for `nan_safe_f32_cmp(b, a)`
 #[inline]
 #[allow(clippy::trivially_copy_pass_by_ref)] // required by calling functions
 pub fn nan_safe_f32_cmp_desc(a: &f32, b: &f32) -> Ordering {

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -140,7 +140,7 @@ impl Stack {
             .map_err(Error::Merge)?;
         ranker.rank(&mut items).map_err(Error::Ranking)?;
         self.data.documents = items;
-
+        self.data.documents.reverse();
         Ok(())
     }
 
@@ -150,7 +150,9 @@ impl Stack {
     pub(crate) fn rank(&mut self, ranker: &mut impl Ranker) -> Result<(), Error> {
         ranker
             .rank(&mut self.data.documents)
-            .map_err(Error::Ranking)
+            .map_err(Error::Ranking)?;
+        self.data.documents.reverse();
+        Ok(())
     }
 
     /// Updates the relevance of the Stack based on the user feedback.

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -84,7 +84,7 @@ impl Stack {
         )?;
         ranker.rank(&mut items).map_err(stack::Error::Ranking)?;
         self.data.documents = items;
-
+        self.data.documents.reverse();
         Ok(())
     }
 
@@ -94,7 +94,9 @@ impl Stack {
     pub(crate) fn rank(&mut self, ranker: &mut impl Ranker) -> Result<(), stack::Error> {
         ranker
             .rank(&mut self.data.documents)
-            .map_err(stack::Error::Ranking)
+            .map_err(stack::Error::Ranking)?;
+        self.data.documents.reverse();
+        Ok(())
     }
 
     /// Updates the relevance of the Stack based on the user feedback.


### PR DESCRIPTION
Ticket: 
- [TY-2919]

- adjusted the rank test (with the previous embeddings, all scores were the same)
- I don't expect any major performance losses by reversing the vec after each stack rank but an improvement could be to add an additional parameter to the rank method that specifies if the function should rank in descending or ascending order.



[TY-2919]: https://xainag.atlassian.net/browse/TY-2919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ