### PR TITLE
[Merged by Bors] - TY-2908 update dart/flutter toolchain to 2.17.3/3.0.2

### DIFF
--- a/.env
+++ b/.env
@@ -7,8 +7,8 @@ FLUTTER_EXAMPLE_WORKSPACE=discovery_engine_flutter/example
 # Note that the Flutter package comes with its own Dart SDK,
 # so if you change either one of these, you likely also need
 # to change the other one. Make sure that they align!
-DART_VERSION=2.16.2
-FLUTTER_VERSION=2.10.5
+DART_VERSION=2.17.3
+FLUTTER_VERSION=3.0.2
 
 ANDROID_TARGETS="arm64-v8a x86_64 x86"
 ANDROID_PLATFORM_VERSION="21"

--- a/.github/workflows/_reusable.build-flutter-example.yml
+++ b/.github/workflows/_reusable.build-flutter-example.yml
@@ -47,7 +47,7 @@ jobs:
     # that needs to exist during the linking process.
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/_reusable.dart.yml
+++ b/.github/workflows/_reusable.dart.yml
@@ -7,7 +7,7 @@ jobs:
   dart-format:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
   dart-analyze:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -42,7 +42,7 @@ jobs:
   dart-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -60,7 +60,7 @@ jobs:
   dart-doc:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/_reusable.flutter.yml
+++ b/.github/workflows/_reusable.flutter.yml
@@ -7,7 +7,7 @@ jobs:
   flutter-analyze:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
   flutter-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v2
+      image: xaynetci/yellow:v3
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/discovery_engine/example/pubspec.yaml
+++ b/discovery_engine/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.14.4 <3.0.0'
+  sdk: '>=2.17.3 <3.0.0'
 
 dependencies:
   xayn_discovery_engine:

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.3 <3.0.0'
 
 dependencies:
   async: ^2.8.1

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -51,7 +51,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -86,7 +86,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -201,7 +201,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -215,7 +215,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -297,7 +297,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -332,7 +332,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -360,7 +360,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
@@ -390,5 +390,5 @@ packages:
     source: hosted
     version: "0.2.0+1"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
-  flutter: ">=2.10.0"
+  dart: ">=2.17.3 <3.0.0"
+  flutter: ">=3.0.2"

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the xayn_discovery_engine_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.14.2 <3.0.0"
+  sdk: ">=2.17.3 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
-  flutter: ">=2.10.0"
+  sdk: ">=2.17.3 <3.0.0"
+  flutter: ">=3.0.2"
 
 dependencies:
   flutter:


### PR DESCRIPTION
**References**

- [TY-2908]
- https://github.com/xaynetwork/xayn_dart_api_dl/pull/12
- https://github.com/xaynetwork/xayn_async_bindgen/pull/17
- requires #427
- requires https://github.com/xaynetwork/xayn_docker/pull/15

**Summary**

- update toolchain versions
- update docker image


[TY-2908]: https://xainag.atlassian.net/browse/TY-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ