### PR TITLE
[Merged by Bors] - TY-2932 update just to 1.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ IOS_LIB_BASE="libxayn_discovery_engine_bindings"
 
 PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes"
 
-JUST_VERSION=0.10.5
+JUST_VERSION=1.2.0
 CARGO_SORT_VERSION=1.0.7
 # In the cases we want to use nightly we use the following version
 RUST_NIGHTLY=nightly-2022-05-19


### PR DESCRIPTION
**References**

- [TY-2932]
- requires #446
- requires https://github.com/xaynetwork/xayn_docker/pull/15

**Summary**

- update toolchain versions


[TY-2932]: https://xainag.atlassian.net/browse/TY-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ