### PR TITLE
[Merged by Bors] - TY-2910 update dart dependencies

### DIFF
--- a/discovery_engine/example/pubspec.yaml
+++ b/discovery_engine/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   xayn_discovery_engine:

--- a/discovery_engine/example/pubspec.yaml
+++ b/discovery_engine/example/pubspec.yaml
@@ -11,6 +11,6 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  build_runner: ^1.10.0
-  build_web_compilers: ^2.11.0
-  lints: ^1.0.0
+  build_runner: ^2.1.11
+  build_web_compilers: ^3.2.3
+  lints: ^2.0.0

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -730,7 +730,7 @@ extension _MapEvent on EngineEvent {
   EngineEvent _passThrough(EngineEvent event) => event;
 
   // in case of a wrong event in response create an EngineExceptionRaised
-  EngineEvent _orElse(EngineEvent _event) =>
+  EngineEvent _orElse(EngineEvent event) =>
       const EngineEvent.engineExceptionRaised(
         EngineExceptionReason.wrongEventInResponse,
       );

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -8,32 +8,32 @@ environment:
   sdk: '>=2.17.3 <3.0.0'
 
 dependencies:
-  async: ^2.8.1
+  async: ^2.8.2
   csv: ^5.0.1
-  crypto: ^3.0.1
+  crypto: ^3.0.2
   equatable: ^2.0.3
-  freezed_annotation: ^1.1.0
+  freezed_annotation: ^2.0.3
   fuzzy: ^0.4.0-nullsafety.0
-  hive: ^2.0.5
+  hive: ^2.2.2
   http: ^0.13.4
   http_retry: ^0.2.0
-  json_annotation: ^4.4.0
+  json_annotation: ^4.5.0
   logger: ^1.1.0
   meta: ^1.7.0
   universal_platform: ^1.0.0+1
-  uuid: ^3.0.5
+  uuid: ^3.0.6
   async_bindgen_dart_utils:
     git:
       url: https://github.com/xaynetwork/xayn_async_bindgen.git
       path: async_bindgen_dart_utils
-      ref: fe195d99954c691c5e606ebbb3c77d371ba0e65b
+      ref: cae694e8411508ca4b5076b4d721d085e313fc0d
 
 dev_dependencies:
-  build_runner: ^2.1.7
-  freezed: '>=1.1.0 <1.1.1'
-  hive_generator: ^1.1.2
-  json_serializable: ^6.1.4
-  lints: ^1.0.1
-  test: ^1.20.1
-  ffigen: ^4.0.0
-  mockito: ^5.1.0
+  build_runner: ^2.1.11
+  freezed: ^2.0.3+1
+  hive_generator: ^1.1.3
+  json_serializable: ^6.2.0
+  lints: ^2.0.0
+  test: ^1.21.1
+  ffigen: ^6.0.1
+  mockito: ^5.2.0

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   async: ^2.8.2

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#6ff6834cb71fdac3dff06170ba4ffef724f24c27"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#29b9898bcc57462dc9bd55c4706c9819eeda6bb6"
 dependencies = [
  "async-bindgen-derive",
  "once_cell",
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-derive"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#6ff6834cb71fdac3dff06170ba4ffef724f24c27"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#29b9898bcc57462dc9bd55c4706c9819eeda6bb6"
 dependencies = [
  "heck 0.4.0",
  "once_cell",
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "async-bindgen-gen-dart"
 version = "0.1.0"
-source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#6ff6834cb71fdac3dff06170ba4ffef724f24c27"
+source = "git+https://github.com/xaynetwork/xayn_async_bindgen.git?branch=main#29b9898bcc57462dc9bd55c4706c9819eeda6bb6"
 dependencies = [
  "anyhow",
  "handlebars",
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#cacc566ba11a42dc68338c388bf7c39fce090339"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#04f9ee674e662ba9831faee152ff873268d86d22"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#cacc566ba11a42dc68338c388bf7c39fce090339"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#04f9ee674e662ba9831faee152ff873268d86d22"
 dependencies = [
  "bindgen",
  "cc",

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -391,4 +391,4 @@ packages:
     version: "0.2.0+1"
 sdks:
   dart: ">=2.17.3 <3.0.0"
-  flutter: ">=3.0.2"
+  flutter: ">=3.0.0"

--- a/discovery_engine_flutter/example/pubspec.lock
+++ b/discovery_engine_flutter/example/pubspec.lock
@@ -12,8 +12,8 @@ packages:
     dependency: transitive
     description:
       path: async_bindgen_dart_utils
-      ref: fe195d99954c691c5e606ebbb3c77d371ba0e65b
-      resolved-ref: fe195d99954c691c5e606ebbb3c77d371ba0e65b
+      ref: cae694e8411508ca4b5076b4d721d085e313fc0d
+      resolved-ref: cae694e8411508ca4b5076b4d721d085e313fc0d
       url: "https://github.com/xaynetwork/xayn_async_bindgen.git"
     source: git
     version: "0.1.0"
@@ -72,7 +72,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   equatable:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -124,7 +124,7 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.3"
   fuzzy:
     dependency: transitive
     description:
@@ -138,7 +138,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.2"
   http:
     dependency: transitive
     description:
@@ -180,7 +180,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logger:
     dependency: transitive
     description:
@@ -222,7 +222,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -6,8 +6,8 @@ description: Demonstrates how to use the xayn_discovery_engine_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
-  flutter: '>=3.0.2'
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: '>=3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -6,7 +6,8 @@ description: Demonstrates how to use the xayn_discovery_engine_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.17.3 <3.0.0"
+  sdk: '>=2.17.3 <3.0.0'
+  flutter: '>=3.0.2'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -17,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  path_provider: 2.0.8
+  path_provider: 2.0.11
   xayn_discovery_engine_flutter:
     # When depending on this package from a real application you should use:
     #   xayn_discovery_engine_flutter: ^x.y.z
@@ -28,12 +29,12 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # to use local version of xayn_discovery_engine we need to override it here
 dependency_overrides:

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
-  flutter: '>=3.0.2'
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: '>=3.0.0'
 
 dependencies:
   flutter:

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/xaynetwork/xayn_discovery_engine/
 publish_to: none
 
 environment:
-  sdk: ">=2.17.3 <3.0.0"
-  flutter: ">=3.0.2"
+  sdk: '>=2.17.3 <3.0.0'
+  flutter: '>=3.0.2'
 
 dependencies:
   flutter:
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 dependency_overrides:
   xayn_discovery_engine:


### PR DESCRIPTION
**References**

- [TY-2910]
- https://github.com/xaynetwork/xayn_dart_api_dl/pull/14
- https://github.com/xaynetwork/xayn_async_bindgen/pull/19
- requires #446

**Summary**

- update dart dependencies
- update flutter dependencies
- checked that `flutter pub get` succeeds in the `xayn_discovery_app` repo when pointed to this branch
- relax dart/flutter constraints to match those of the app


[TY-2910]: https://xainag.atlassian.net/browse/TY-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ