### PR TITLE
[Merged by Bors] - TY-2922 search and headlines use different market rank mappings

### DIFF
--- a/discovery_engine_core/providers/src/filter.rs
+++ b/discovery_engine_core/providers/src/filter.rs
@@ -54,7 +54,7 @@ pub struct Market {
 }
 
 impl Market {
-    /// Returns the default news quality rank limit for given country for search news.
+    /// Returns the default quality rank limit for news.
     pub fn news_quality_rank_limit(&self) -> Option<usize> {
         #[allow(clippy::match_same_arms)]
         Some(match &*self.country_code {
@@ -73,7 +73,7 @@ impl Market {
         })
     }
 
-    /// Returns the default news quality rank limit for given country for latest headlines.
+    /// Returns the default quality rank limit for latest headlines.
     pub fn headlines_quality_rank_limit(&self) -> Option<usize> {
         #[allow(clippy::match_same_arms)]
         Some(match &*self.country_code {

--- a/discovery_engine_core/providers/src/filter.rs
+++ b/discovery_engine_core/providers/src/filter.rs
@@ -54,8 +54,27 @@ pub struct Market {
 }
 
 impl Market {
-    /// Returns the default news quality rank limit for given country.
+    /// Returns the default news quality rank limit for given country for search news.
     pub fn news_quality_rank_limit(&self) -> Option<usize> {
+        #[allow(clippy::match_same_arms)]
+        Some(match &*self.country_code {
+            "AT" => 70_000,
+            "BE" => 70_000,
+            "CA" => 70_000,
+            "CH" => 50_000,
+            "DE" => 9_000,
+            "ES" => 40_000,
+            "GB" => 14_000,
+            "IE" => 70_000,
+            "NL" => 60_000,
+            "PL" => 50_000,
+            "US" => 9_000,
+            _ => return None,
+        })
+    }
+
+    /// Returns the default news quality rank limit for given country for latest headlines.
+    pub fn headlines_quality_rank_limit(&self) -> Option<usize> {
         #[allow(clippy::match_same_arms)]
         Some(match &*self.country_code {
             "AT" => 70_000,


### PR DESCRIPTION
(through both still use the same values for now).