### PR TITLE
[Merged by Bors] - TY-2939 accept log path in config

### DIFF
--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -34,6 +34,7 @@ class Configuration with _$Configuration {
     required String applicationDirectoryPath,
     required FeedMarkets feedMarkets,
     required Manifest manifest,
+    String? logFile,
   }) = _Configuration;
 
   factory Configuration.fromJson(Map<String, Object?> json) =>

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -71,7 +71,6 @@ class InitConfigFfi with EquatableMixin {
     Set<Source> trustedSources,
     Set<Source> excludedSources, {
     String? deConfig,
-    String? logFile,
   }) =>
       InitConfigFfi.fromParts(
         apiKey: configuration.apiKey,
@@ -86,7 +85,7 @@ class InitConfigFfi with EquatableMixin {
         kpeCnn: setupData.kpeCnn,
         kpeClassifier: setupData.kpeClassifier,
         deConfig: deConfig,
-        logFile: logFile,
+        logFile: configuration.logFile,
       );
 
   InitConfigFfi.fromParts({

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -46,6 +46,7 @@ class InitConfigFfi with EquatableMixin {
   final String kpeCnn;
   final String kpeClassifier;
   final String? deConfig;
+  final String? logFile;
 
   @override
   List<Object?> get props => [
@@ -61,6 +62,7 @@ class InitConfigFfi with EquatableMixin {
         kpeCnn,
         kpeClassifier,
         deConfig,
+        logFile,
       ];
 
   factory InitConfigFfi(
@@ -69,6 +71,7 @@ class InitConfigFfi with EquatableMixin {
     Set<Source> trustedSources,
     Set<Source> excludedSources, {
     String? deConfig,
+    String? logFile,
   }) =>
       InitConfigFfi.fromParts(
         apiKey: configuration.apiKey,
@@ -83,6 +86,7 @@ class InitConfigFfi with EquatableMixin {
         kpeCnn: setupData.kpeCnn,
         kpeClassifier: setupData.kpeClassifier,
         deConfig: deConfig,
+        logFile: logFile,
       );
 
   InitConfigFfi.fromParts({
@@ -98,6 +102,7 @@ class InitConfigFfi with EquatableMixin {
     required this.kpeCnn,
     required this.kpeClassifier,
     this.deConfig,
+    this.logFile,
   });
 
   /// Allocates a `Box<RustInitConfig>` initialized based on this instance.
@@ -121,6 +126,7 @@ class InitConfigFfi with EquatableMixin {
     kpeCnn.writeNative(ffi.init_config_place_of_kpe_cnn(place));
     kpeClassifier.writeNative(ffi.init_config_place_of_kpe_classifier(place));
     deConfig.writeNative(ffi.init_config_place_of_de_config(place));
+    logFile.writeNative(ffi.init_config_place_of_log_file(place));
   }
 
   @visibleForTesting
@@ -150,6 +156,9 @@ class InitConfigFfi with EquatableMixin {
           StringFfi.readNative(ffi.init_config_place_of_kpe_classifier(config)),
       deConfig: OptionStringFfi.readNative(
         ffi.init_config_place_of_de_config(config),
+      ),
+      logFile: OptionStringFfi.readNative(
+        ffi.init_config_place_of_log_file(config),
       ),
     );
   }

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1658,15 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,9 +2375,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
 
 [[package]]
 name = "regex-syntax"
@@ -3208,15 +3196,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
- "lazy_static",
- "matchers",
- "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1658,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2384,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -3180,17 +3192,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["as_r
 ndarray = "0.15.4"
 tokio = { version = "1.19.2", features = ["sync"] }
 tracing = "0.1.35"
-tracing-subscriber = "0.3.11"
+tracing-subscriber = { version="0.3.11", features = [ "env-filter", "json" ] }
 url = "2.2.2"
 uuid = "1.1.2"
 xayn-discovery-engine-ai = { path = "../ai/ai" }

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["as_r
 ndarray = "0.15.4"
 tokio = { version = "1.19.2", features = ["sync"] }
 tracing = "0.1.35"
-tracing-subscriber = { version="0.3.11", features = [ "env-filter", "json" ] }
+tracing-subscriber = { version = "0.3.11", features = [ "env-filter", "json" ] }
 url = "2.2.2"
 uuid = "1.1.2"
 xayn-discovery-engine-ai = { path = "../ai/ai" }

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["as_r
 ndarray = "0.15.4"
 tokio = { version = "1.19.2", features = ["sync"] }
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.11", features = [ "env-filter", "json" ] }
+tracing-subscriber = { version = "0.3.11", features = ["json"] }
 url = "2.2.2"
 uuid = "1.1.2"
 xayn-discovery-engine-ai = { path = "../ai/ai" }

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -35,6 +35,8 @@ pub mod async_bindings;
 mod tracing;
 pub mod types;
 
+use std::path::Path;
+
 use xayn_discovery_engine_core::Engine;
 
 #[async_bindgen::api(
@@ -55,7 +57,7 @@ impl XaynDiscoveryEngineAsyncFfi {
         state: Option<Box<Vec<u8>>>,
         history: Box<Vec<HistoricDocument>>,
     ) -> Box<Result<SharedEngine, String>> {
-        tracing::init_tracing();
+        tracing::init_tracing(config.log_file.as_deref().map(Path::new));
 
         Box::new(
             Engine::from_config(*config, state.as_deref().map(Vec::as_slice), &history)

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Setup tracing on different platform.
+//! Setup tracing on different platforms.
 
 use std::{fs::OpenOptions, io, path::Path, sync::Once};
 

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -39,8 +39,11 @@ fn init_tracing_once(log_file: Option<&Path>) {
     let android_logging;
     cfg_if::cfg_if! {
         if #[cfg(target_os = "android")] {
-            //TODO error
-            android_logging = tracing_android::layer("xayn_discovery_engine").ok()
+            android_logging = tracing_android::layer("xayn_discovery_engine")
+                .map_err(|err| {
+                    delayed_errors.push(Box::new(err) as _);
+                })
+                .ok()
         } else {
             // workaround to not have to specify a alternative type per hand
             android_logging = false.then(|| tracing_subscriber::fmt::layer())
@@ -63,7 +66,6 @@ fn init_tracing_once(log_file: Option<&Path>) {
         .transpose()
         .map_err(|err| {
             delayed_errors.push(Box::new(err) as _);
-            ()
         })
         .ok();
 

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -67,11 +67,11 @@ fn init_tracing_once(log_file: Option<&Path>) {
         .init();
 
     for error in delayed_errors {
-        tracing::error!(error=%error, "logging setup failed");
+        tracing::error!(%error, "logging setup failed");
     }
 }
 
-/// Crates an [`EnvFilter`] based on the env of `RUST_LOG`.
+/// Creates an [`EnvFilter`] based on the env of `RUST_LOG`.
 ///
 /// If `RUST_LOG` is not set/empty `DISCOVERY_ENGINE_LOG` will
 /// be used instead in the form of `info,xayn_=${DISCOVERY_ENGINE_LOG}`,

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -14,10 +14,9 @@
 
 //! Setup tracing on different platform.
 
-use std::{env::VarError, error::Error, fs::OpenOptions, io, path::Path, sync::Once};
+use std::{fs::OpenOptions, io, path::Path, sync::Once};
 
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 static INIT_TRACING: Once = Once::new();
 
@@ -29,8 +28,6 @@ pub(crate) fn init_tracing(log_file: Option<&Path>) {
 }
 
 fn init_tracing_once(log_file: Option<&Path>) {
-    let mut delayed_errors = Vec::new();
-
     let stdout_log = tracing_subscriber::fmt::layer();
 
     let subscriber = tracing_subscriber::registry();
@@ -53,60 +50,22 @@ fn init_tracing_once(log_file: Option<&Path>) {
             Ok(tracing_subscriber::fmt::layer().with_writer(writer).json())
         })
         .transpose()
-        .map_err(|err| {
-            delayed_errors.push(Box::new(err) as _);
+        .map_err(|error| {
+            tracing::error!(%error, "logging setup failed");
         })
         .ok();
 
-    let filter = build_env_filter(&mut delayed_errors);
+    let level = if log_file.is_some() {
+        LevelFilter::DEBUG
+    } else {
+        LevelFilter::INFO
+    };
 
     subscriber
         .with(stdout_log)
         .with(file_log)
-        .with(filter)
+        .with(level)
         .init();
-
-    for error in delayed_errors {
-        tracing::error!(%error, "logging setup failed");
-    }
-}
-
-/// Creates an [`EnvFilter`] based on the env of `RUST_LOG`.
-///
-/// If `RUST_LOG` is not set/empty `DISCOVERY_ENGINE_LOG` will
-/// be used instead in the form of `info,xayn_=${DISCOVERY_ENGINE_LOG}`,
-/// if that fails `info` is used.
-fn build_env_filter(errors: &mut Vec<Box<dyn Error>>) -> EnvFilter {
-    if let Some(directives) = env_var("RUST_LOG", errors) {
-        match directives.parse() {
-            Ok(val) => return val,
-            Err(err) => {
-                errors.push(Box::new(err));
-            }
-        }
-    }
-
-    if let Some(de_level) = env_var("DISCOVERY_ENGINE_LOG", errors) {
-        match format!("info,xayn_={}", de_level).parse() {
-            Ok(val) => return val,
-            Err(err) => {
-                errors.push(Box::new(err));
-            }
-        }
-    }
-
-    EnvFilter::default().add_directive(LevelFilter::INFO.into())
-}
-
-fn env_var(var: &str, errors: &mut Vec<Box<dyn Error>>) -> Option<String> {
-    match std::env::var(var) {
-        Ok(var) if !var.trim().is_empty() => return Some(var),
-        Err(err @ VarError::NotUnicode(_)) => {
-            errors.push(Box::new(err));
-        }
-        _ => (),
-    }
-    None
 }
 
 fn init_panic_logging() {

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -14,22 +14,61 @@
 
 //! Setup tracing on different platform.
 
-use std::sync::Once;
+use std::{fs::OpenOptions, io, path::Path, sync::Once};
 
-use tracing_subscriber::{filter::LevelFilter, util::SubscriberInitExt};
+use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 static INIT_TRACING: Once = Once::new();
 
-pub(crate) fn init_tracing() {
+pub(crate) fn init_tracing(log_file: Option<&Path>) {
     INIT_TRACING.call_once(|| {
-        init_tracing_once();
+        init_tracing_once(log_file);
+        init_panic_logging();
     });
 }
 
-fn init_tracing_once() {
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(LevelFilter::INFO)
-        .finish();
+fn init_tracing_once(log_file: Option<&Path>) {
+    let max_level = LevelFilter::INFO;
+
+    let error = if let Some(log_file) = log_file {
+        match init_with_file_logging(max_level, log_file) {
+            Ok(()) => return,
+            Err(err) => Some(err),
+        }
+    } else {
+        None
+    };
+
+    init_normal_logging(max_level);
+
+    if let Some(error) = error {
+        tracing::error!("Initializing file logging faile: {}", error);
+    }
+}
+
+fn init_with_file_logging(max_level: LevelFilter, log_file: &Path) -> io::Result<()> {
+    let writer = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(log_file)?;
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_ansi(false)
+        .with_writer(writer);
+
+    tracing_subscriber::fmt()
+        .with_max_level(max_level)
+        .finish()
+        .with(layer)
+        .init();
+
+    Ok(())
+}
+
+fn init_normal_logging(max_level: LevelFilter) {
+    let subscriber = tracing_subscriber::fmt().with_max_level(max_level).finish();
 
     cfg_if::cfg_if! {
         if #[cfg(target_os = "android")] {
@@ -40,11 +79,9 @@ fn init_tracing_once() {
             subscriber.init();
         }
     }
-
-    log_panic();
 }
 
-fn log_panic() {
+fn init_panic_logging() {
     std::panic::set_hook(Box::new(|panic| {
         if let Some(location) = panic.location() {
             tracing::error!(

--- a/discovery_engine_core/bindings/src/tracing.rs
+++ b/discovery_engine_core/bindings/src/tracing.rs
@@ -14,7 +14,7 @@
 
 //! Setup tracing on different platforms.
 
-use std::{fs::OpenOptions, io, path::Path, sync::Once};
+use std::{fs::OpenOptions, path::Path, sync::Once};
 
 use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -40,14 +40,13 @@ fn init_tracing_once(log_file: Option<&Path>) {
     };
 
     let file_log = log_file
-        .map(|log_file| -> io::Result<_> {
-            let writer = OpenOptions::new()
+        .map(|log_file| {
+            OpenOptions::new()
                 .write(true)
                 .truncate(true)
                 .create(true)
-                .open(log_file)?;
-
-            Ok(tracing_subscriber::fmt::layer().with_writer(writer).json())
+                .open(log_file)
+                .map(|writer| tracing_subscriber::fmt::layer().with_writer(writer).json())
         })
         .transpose()
         .map_err(|error| {

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -159,6 +159,19 @@ pub unsafe extern "C" fn init_config_place_of_de_config(
     unsafe { addr_of_mut!((*place).de_config) }
 }
 
+/// Returns a pointer to the `log_file` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_log_file(
+    place: *mut InitConfig,
+) -> *mut Option<String> {
+    unsafe { addr_of_mut!((*place).log_file) }
+}
+
 /// Alloc an uninitialized `Box<InitConfig>`, mainly used for testing.
 #[no_mangle]
 pub extern "C" fn alloc_uninitialized_init_config() -> *mut InitConfig {

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -52,6 +52,8 @@ pub struct InitConfig {
     pub kpe_classifier: String,
     /// DE config in JSON format.
     pub de_config: Option<String>,
+    /// Log file path
+    pub log_file: Option<String>,
 }
 
 /// Discovery Engine endpoint settings.

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -52,7 +52,7 @@ pub struct InitConfig {
     pub kpe_classifier: String,
     /// DE config in JSON format.
     pub de_config: Option<String>,
-    /// Log file path
+    /// Log file path.
     pub log_file: Option<String>,
 }
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1083,6 +1083,7 @@ mod tests {
             kpe_cnn: format!("{}/kpe_v0001/cnn.binparams", asset_base),
             kpe_classifier: format!("{}/kpe_v0001/classifier.binparams", asset_base),
             de_config: None,
+            log_file: None,
         };
         let endpoint_config = EndpointConfig::default()
             .with_init_config(config.clone())
@@ -1296,6 +1297,7 @@ mod tests {
             kpe_cnn: format!("{}/kpe_v0001/cnn.binparams", asset_base),
             kpe_classifier: format!("{}/kpe_v0001/classifier.binparams", asset_base),
             de_config: None,
+            log_file: None,
         };
 
         // Now we can initialize the engine with no previous history or state. This should


### PR DESCRIPTION
Allow configuring a log file into which logs will be written (formatted as one json blob per line).

As it was missing this also allows setting debug levels through env variables (see comments,
normally we set `DISCOVERY_ENGINE_LOG` to only set logging for cates/targets starting with
`xayn_` but the full `RUST_LOG` functionality is still available).

We need to be able to set the log level as some of the logging added in the follow up PR uses
the debug log level as it can become quite verbose.

**References:**

- [issue TY-2939](https://xainag.atlassian.net/browse/TY-2939)
- [story TY-2938](https://xainag.atlassian.net/browse/TY-2938)