### PR TITLE
[Merged by Bors] - TY-2947 DE config as optional json

### DIFF
--- a/discovery_engine/lib/src/api/events/client_events.dart
+++ b/discovery_engine/lib/src/api/events/client_events.dart
@@ -55,10 +55,10 @@ class ClientEvent with _$ClientEvent {
   /// for the engine to work, like personalisation and feed market
   /// (for performing background queries).
   @Implements<SystemClientEvent>()
-  @Assert('aiConfig == null || aiConfig != ""')
+  @Assert('deConfig == null || deConfig != ""')
   const factory ClientEvent.init(
     Configuration configuration, {
-    String? aiConfig,
+    String? deConfig,
   }) = Init;
 
   /// Event created when the user changes market or count (nb of items per page)

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -105,7 +105,7 @@ class DiscoveryEngine {
   /// ```
   static Future<DiscoveryEngine> init({
     required Configuration configuration,
-    String? aiConfig,
+    String? deConfig,
     void Function(EngineEvent event)? onAssetsProgress,
     Object? entryPoint,
   }) async {
@@ -120,7 +120,7 @@ class DiscoveryEngine {
             .listen(onAssetsProgress);
       }
 
-      final initEvent = ClientEvent.init(configuration, aiConfig: aiConfig);
+      final initEvent = ClientEvent.init(configuration, deConfig: deConfig);
       final response = await manager.send(initEvent, timeout: null);
       await subscription?.cancel();
 

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -124,8 +124,8 @@ class EngineInitializer with EquatableMixin {
   /// The history to use for filtering initial results.
   final List<HistoricDocument> history;
 
-  /// An opaque encoded configuration for the AI in the ranker.
-  final String? aiConfig;
+  /// An opaque encoded configuration for the DE.
+  final String? deConfig;
 
   /// A set of favourite sources.
   final Set<Source> trustedSources;
@@ -138,7 +138,7 @@ class EngineInitializer with EquatableMixin {
     required this.setupData,
     required this.engineState,
     required this.history,
-    required this.aiConfig,
+    required this.deConfig,
     required this.trustedSources,
     required this.excludedSources,
   });
@@ -149,7 +149,7 @@ class EngineInitializer with EquatableMixin {
         setupData,
         engineState,
         history,
-        aiConfig,
+        deConfig,
         trustedSources,
         excludedSources,
       ];

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -162,7 +162,7 @@ class EventHandler {
       try {
         return await _initEngine(
           clientEvent.configuration,
-          aiConfig: clientEvent.aiConfig,
+          deConfig: clientEvent.deConfig,
         );
       } catch (e, st) {
         logger.e('failed to initialize the engine', e, st);
@@ -217,7 +217,7 @@ class EventHandler {
 
   Future<EngineEvent> _initEngine(
     Configuration config, {
-    String? aiConfig,
+    String? deConfig,
   }) async {
     // init hive
     registerHiveAdapters();
@@ -255,7 +255,7 @@ class EventHandler {
           setupData: setupData,
           engineState: engineState,
           history: history,
-          aiConfig: aiConfig,
+          deConfig: deConfig,
           trustedSources: trustedSources,
           excludedSources: excludedSources,
         ),

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -93,7 +93,7 @@ class DiscoveryEngineFfi implements Engine {
         setupData,
         initializer.trustedSources,
         initializer.excludedSources,
-        aiConfig: initializer.aiConfig,
+        deConfig: initializer.deConfig,
       ).allocNative().move(),
       initializer.engineState?.allocNative().move() ?? nullptr,
       initializer.history.allocNative().move(),

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -45,7 +45,7 @@ class InitConfigFfi with EquatableMixin {
   final String kpeModel;
   final String kpeCnn;
   final String kpeClassifier;
-  final String? aiConfig;
+  final String? deConfig;
 
   @override
   List<Object?> get props => [
@@ -60,7 +60,7 @@ class InitConfigFfi with EquatableMixin {
         kpeModel,
         kpeCnn,
         kpeClassifier,
-        aiConfig,
+        deConfig,
       ];
 
   factory InitConfigFfi(
@@ -68,7 +68,7 @@ class InitConfigFfi with EquatableMixin {
     NativeSetupData setupData,
     Set<Source> trustedSources,
     Set<Source> excludedSources, {
-    String? aiConfig,
+    String? deConfig,
   }) =>
       InitConfigFfi.fromParts(
         apiKey: configuration.apiKey,
@@ -82,7 +82,7 @@ class InitConfigFfi with EquatableMixin {
         kpeModel: setupData.kpeModel,
         kpeCnn: setupData.kpeCnn,
         kpeClassifier: setupData.kpeClassifier,
-        aiConfig: aiConfig,
+        deConfig: deConfig,
       );
 
   InitConfigFfi.fromParts({
@@ -97,7 +97,7 @@ class InitConfigFfi with EquatableMixin {
     required this.kpeModel,
     required this.kpeCnn,
     required this.kpeClassifier,
-    this.aiConfig,
+    this.deConfig,
   });
 
   /// Allocates a `Box<RustInitConfig>` initialized based on this instance.
@@ -120,7 +120,7 @@ class InitConfigFfi with EquatableMixin {
     kpeModel.writeNative(ffi.init_config_place_of_kpe_model(place));
     kpeCnn.writeNative(ffi.init_config_place_of_kpe_cnn(place));
     kpeClassifier.writeNative(ffi.init_config_place_of_kpe_classifier(place));
-    aiConfig.writeNative(ffi.init_config_place_of_ai_config(place));
+    deConfig.writeNative(ffi.init_config_place_of_de_config(place));
   }
 
   @visibleForTesting
@@ -148,8 +148,8 @@ class InitConfigFfi with EquatableMixin {
       kpeCnn: StringFfi.readNative(ffi.init_config_place_of_kpe_cnn(config)),
       kpeClassifier:
           StringFfi.readNative(ffi.init_config_place_of_kpe_classifier(config)),
-      aiConfig: OptionStringFfi.readNative(
-        ffi.init_config_place_of_ai_config(config),
+      deConfig: OptionStringFfi.readNative(
+        ffi.init_config_place_of_de_config(config),
       ),
     );
   }

--- a/discovery_engine/test/discovery_engine/event_concurrency_test.dart
+++ b/discovery_engine/test/discovery_engine/event_concurrency_test.dart
@@ -68,7 +68,7 @@ class MockedDiscoveryEngineWorker extends DiscoveryEngineWorker {
   @override
   Future<void> handleMessage(OneshotRequest<ClientEvent> request) async {
     final response = await request.payload.maybeWhen(
-      init: (configuration, aiConfig) async =>
+      init: (configuration, deConfig) async =>
           const EngineEvent.clientEventSucceeded(),
       restoreFeedRequested: () async {
         await Future<void>.delayed(const Duration(milliseconds: 300));

--- a/discovery_engine/test/ffi/ffi_test.dart
+++ b/discovery_engine/test/ffi/ffi_test.dart
@@ -59,7 +59,7 @@ void main() {
           setupData: setupData,
           engineState: null,
           history: [],
-          aiConfig: null,
+          deConfig: null,
           trustedSources: {},
           excludedSources: {},
         ),

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -58,7 +58,7 @@ void main() {
       kpeModel: 'yo.lo',
       kpeCnn: 'abc',
       kpeClassifier: 'magic',
-      aiConfig: '{ "key": "value" }',
+      deConfig: '{ "key": "value" }',
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -146,17 +146,17 @@ pub unsafe extern "C" fn init_config_place_of_kpe_classifier(
     unsafe { addr_of_mut!((*place).kpe_classifier) }
 }
 
-/// Returns a pointer to the `ai_config` field of a configuration.
+/// Returns a pointer to the `de_config` field of a configuration.
 ///
 /// # Safety
 ///
 /// The pointer must point to a valid [`InitConfig`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn init_config_place_of_ai_config(
+pub unsafe extern "C" fn init_config_place_of_de_config(
     place: *mut InitConfig,
 ) -> *mut Option<String> {
-    unsafe { addr_of_mut!((*place).ai_config) }
+    unsafe { addr_of_mut!((*place).de_config) }
 }
 
 /// Alloc an uninitialized `Box<InitConfig>`, mainly used for testing.

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.5.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_repr = "0.1.8"
 thiserror = "1.0.31"
-tokio = { version = "1.19.2", features = ["sync"] }
+tokio = { version = "1.19.2", features = ["macros", "sync"] }
 tracing = "0.1.35"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -124,7 +124,8 @@ impl Default for CoreConfig {
     }
 }
 
-pub(crate) fn ai_config_from_json(json: &str) -> Figment {
+/// Reads the configurations from json and sets defaults for missing fields.
+pub(crate) fn config_from_json(json: &str) -> Figment {
     Figment::new()
         .merge(Serialized::defaults(CoiSystemConfig::default()))
         .merge(Serialized::default("kpe.token_size", 150))
@@ -139,8 +140,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ai_config_from_json_default() -> Result<(), GenericError> {
-        let ai_config = ai_config_from_json("{}");
+    fn test_config_from_json_default() -> Result<(), GenericError> {
+        let ai_config = config_from_json("{}");
         assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
         assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 150);
         assert_eq!(
@@ -151,8 +152,8 @@ mod tests {
     }
 
     #[test]
-    fn test_ai_config_from_json_modified() -> Result<(), GenericError> {
-        let ai_config = ai_config_from_json(
+    fn test_config_from_json_modified() -> Result<(), GenericError> {
+        let ai_config = config_from_json(
             r#"{
                 "coi": {
                     "threshold": 0.42

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -1,0 +1,180 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use figment::{
+    providers::{Format, Json, Serialized},
+    Figment,
+};
+use tokio::sync::RwLock;
+
+use xayn_discovery_engine_ai::CoiSystemConfig;
+use xayn_discovery_engine_providers::Market;
+
+/// Configuration settings to initialize Discovery Engine with a
+/// [`xayn_discovery_engine_ai::Ranker`].
+#[derive(Clone)]
+pub struct InitConfig {
+    /// Key for accessing the API.
+    pub api_key: String,
+    /// API base url.
+    pub api_base_url: String,
+    /// List of markets to use.
+    pub markets: Vec<Market>,
+    /// List of trusted sources to use.
+    pub trusted_sources: Vec<String>,
+    /// List of excluded sources to use.
+    pub excluded_sources: Vec<String>,
+    /// S-mBert vocabulary path.
+    pub smbert_vocab: String,
+    /// S-mBert model path.
+    pub smbert_model: String,
+    /// KPE vocabulary path.
+    pub kpe_vocab: String,
+    /// KPE model path.
+    pub kpe_model: String,
+    /// KPE CNN path.
+    pub kpe_cnn: String,
+    /// KPE classifier path.
+    pub kpe_classifier: String,
+    /// AI config in JSON format.
+    pub ai_config: Option<String>,
+}
+
+/// Discovery Engine endpoint settings.
+pub(crate) struct EndpointConfig {
+    /// Page size setting for API.
+    pub(crate) page_size: usize,
+    /// Write-exclusive access to markets list.
+    pub(crate) markets: Arc<RwLock<Vec<Market>>>,
+    /// Trusted sources for news queries.
+    pub(crate) trusted_sources: Arc<RwLock<Vec<String>>>,
+    /// Sources to exclude for news queries.
+    pub(crate) excluded_sources: Arc<RwLock<Vec<String>>>,
+    /// The maximum number of requests to try to reach the number of `min_articles`.
+    pub(crate) max_requests: u32,
+    /// The minimum number of new articles to try to return when updating the stack.
+    pub(crate) min_articles: usize,
+    /// The maximum age of a headline, in days, after which we no longer
+    /// want to display them
+    pub(crate) max_headline_age_days: usize,
+    /// The maximum age of a news article, in days, after which we no longer
+    /// want to display them
+    pub(crate) max_article_age_days: usize,
+}
+
+impl From<InitConfig> for EndpointConfig {
+    fn from(config: InitConfig) -> Self {
+        Self {
+            page_size: 100,
+            markets: Arc::new(RwLock::new(config.markets)),
+            trusted_sources: Arc::new(RwLock::new(config.trusted_sources)),
+            excluded_sources: Arc::new(RwLock::new(config.excluded_sources)),
+            max_requests: 5,
+            min_articles: 20,
+            max_headline_age_days: 3,
+            max_article_age_days: 30,
+        }
+    }
+}
+
+/// Internal config to allow for configurations within the core without a mirroring outside impl.
+pub(crate) struct CoreConfig {
+    /// The number of taken top key phrases while updating the stacks.
+    pub(crate) take_top: usize,
+    /// The number of top documents per stack to keep while filtering the stacks.
+    pub(crate) keep_top: usize,
+    /// The lower bound of documents per stack at which new items are requested.
+    pub(crate) request_new: usize,
+    /// The number of times to get feed documents after which the stacks are updated without the
+    /// limitation of `request_new`.
+    pub(crate) request_after: usize,
+    /// The maximum number of top key phrases extracted from the search term in the deep search.
+    pub(crate) deep_search_top: usize,
+    /// The maximum number of documents returned from the deep search.
+    pub(crate) deep_search_max: usize,
+    /// The minimum cosine similarity wrt the original document below which documents returned from
+    /// the deep search are discarded.
+    pub(crate) deep_search_sim: f32,
+}
+
+impl Default for CoreConfig {
+    fn default() -> Self {
+        Self {
+            take_top: 3,
+            keep_top: 20,
+            request_new: 3,
+            request_after: 2,
+            deep_search_top: 3,
+            deep_search_max: 20,
+            deep_search_sim: 0.2,
+        }
+    }
+}
+
+pub(crate) fn ai_config_from_json(json: &str) -> Figment {
+    Figment::new()
+        .merge(Serialized::defaults(CoiSystemConfig::default()))
+        .merge(Serialized::default("kpe.token_size", 150))
+        .merge(Serialized::default("smbert.token_size", 150))
+        .merge(Json::string(json))
+}
+
+#[cfg(test)]
+mod tests {
+    use xayn_discovery_engine_ai::GenericError;
+
+    use super::*;
+
+    #[test]
+    fn test_ai_config_from_json_default() -> Result<(), GenericError> {
+        let ai_config = ai_config_from_json("{}");
+        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 150);
+        assert_eq!(
+            ai_config.extract::<CoiSystemConfig>()?,
+            CoiSystemConfig::default(),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ai_config_from_json_modified() -> Result<(), GenericError> {
+        let ai_config = ai_config_from_json(
+            r#"{
+                "coi": {
+                    "threshold": 0.42
+                },
+                "kpe": {
+                    "penalty": [0.99, 0.66, 0.33]
+                },
+                "smbert": {
+                    "token_size": 42,
+                    "foo": "bar"
+                },
+                "baz": 0
+            }"#,
+        );
+        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 42);
+        assert_eq!(
+            ai_config.extract::<CoiSystemConfig>()?,
+            CoiSystemConfig::default()
+                .with_threshold(0.42)?
+                .with_penalty(&[0.99, 0.66, 0.33])?,
+        );
+        Ok(())
+    }
+}

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -57,7 +57,7 @@ pub struct InitConfig {
 /// Discovery Engine endpoint settings.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(derivative::Derivative), derivative(Eq, PartialEq))]
-#[allow(clippy::unsafe_derive_deserialize)] // false positive?
+#[allow(clippy::unsafe_derive_deserialize)] // probably triggered by join! macro in the method
 pub(crate) struct EndpointConfig {
     /// Page size setting for API.
     pub(crate) page_size: usize,

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -50,8 +50,8 @@ pub struct InitConfig {
     pub kpe_cnn: String,
     /// KPE classifier path.
     pub kpe_classifier: String,
-    /// AI config in JSON format.
-    pub ai_config: Option<String>,
+    /// DE config in JSON format.
+    pub de_config: Option<String>,
 }
 
 /// Discovery Engine endpoint settings.
@@ -154,8 +154,8 @@ impl Default for CoreConfig {
     }
 }
 
-/// Reads the configurations from json and sets defaults for missing fields.
-pub(crate) fn config_from_json(json: &str) -> Figment {
+/// Reads the DE configurations from json and sets defaults for missing fields (if possible).
+pub(crate) fn de_config_from_json(json: &str) -> Figment {
     Figment::from(Json::string(json))
         .join(Serialized::default("kpe.token_size", 150))
         .join(Serialized::default("smbert.token_size", 150))
@@ -174,28 +174,28 @@ mod tests {
     impl Eq for CoreConfig {}
 
     #[test]
-    fn test_config_from_json_default() -> Result<(), GenericError> {
-        let config = config_from_json("{}");
-        assert_eq!(config.extract_inner::<usize>("kpe.token_size")?, 150);
-        assert_eq!(config.extract_inner::<usize>("smbert.token_size")?, 150);
+    fn test_de_config_from_json_default() -> Result<(), GenericError> {
+        let de_config = de_config_from_json("{}");
+        assert_eq!(de_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(de_config.extract_inner::<usize>("smbert.token_size")?, 150);
         assert_eq!(
-            config.extract::<CoiSystemConfig>()?,
+            de_config.extract::<CoiSystemConfig>()?,
             CoiSystemConfig::default(),
         );
         assert_eq!(
-            config.extract_inner::<CoreConfig>("core")?,
+            de_config.extract_inner::<CoreConfig>("core")?,
             CoreConfig::default(),
         );
         assert_eq!(
-            config.extract_inner::<EndpointConfig>("endpoint")?,
+            de_config.extract_inner::<EndpointConfig>("endpoint")?,
             EndpointConfig::default(),
         );
         Ok(())
     }
 
     #[test]
-    fn test_config_from_json_modified() -> Result<(), GenericError> {
-        let config = config_from_json(
+    fn test_de_config_from_json_modified() -> Result<(), GenericError> {
+        let de_config = de_config_from_json(
             r#"{
                 "coi": {
                     "threshold": 0.42
@@ -210,20 +210,20 @@ mod tests {
                 "baz": 0
             }"#,
         );
-        assert_eq!(config.extract_inner::<usize>("kpe.token_size")?, 150);
-        assert_eq!(config.extract_inner::<usize>("smbert.token_size")?, 42);
+        assert_eq!(de_config.extract_inner::<usize>("kpe.token_size")?, 150);
+        assert_eq!(de_config.extract_inner::<usize>("smbert.token_size")?, 42);
         assert_eq!(
-            config.extract::<CoiSystemConfig>()?,
+            de_config.extract::<CoiSystemConfig>()?,
             CoiSystemConfig::default()
                 .with_threshold(0.42)?
                 .with_penalty(&[0.99, 0.66, 0.33])?,
         );
         assert_eq!(
-            config.extract_inner::<CoreConfig>("core")?,
+            de_config.extract_inner::<CoreConfig>("core")?,
             CoreConfig::default(),
         );
         assert_eq!(
-            config.extract_inner::<EndpointConfig>("endpoint")?,
+            de_config.extract_inner::<EndpointConfig>("endpoint")?,
             EndpointConfig::default(),
         );
         Ok(())

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -56,7 +56,7 @@ use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 #[cfg(feature = "storage")]
 use crate::storage::{self, SqliteStorage, Storage};
 use crate::{
-    config::{ai_config_from_json, CoreConfig, EndpointConfig, InitConfig},
+    config::{config_from_json, CoreConfig, EndpointConfig, InitConfig},
     document::{
         self,
         Document,
@@ -917,7 +917,7 @@ impl XaynAiEngine {
         state: Option<&[u8]>,
         history: &[HistoricDocument],
     ) -> Result<Self, Error> {
-        let ai_config = ai_config_from_json(config.ai_config.as_deref().unwrap_or("{}"));
+        let ai_config = config_from_json(config.ai_config.as_deref().unwrap_or("{}"));
         let smbert_config = SMBertConfig::from_files(&config.smbert_vocab, &config.smbert_model)
             .map_err(|err| Error::Ranker(err.into()))?
             .with_token_size(

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -20,10 +20,6 @@ use std::{
 };
 
 use displaydoc::Display;
-use figment::{
-    providers::{Format, Json, Serialized},
-    Figment,
-};
 use futures::future::join_all;
 use itertools::{chain, Itertools};
 use rayon::iter::{Either, IntoParallelIterator, ParallelIterator};
@@ -36,7 +32,6 @@ use xayn_discovery_engine_ai::{
     cosine_similarity,
     nan_safe_f32_cmp,
     Builder,
-    CoiSystemConfig,
     Embedding,
     GenericError,
     KeyPhrase,
@@ -61,6 +56,7 @@ use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 #[cfg(feature = "storage")]
 use crate::storage::{self, SqliteStorage, Storage};
 use crate::{
+    config::{ai_config_from_json, CoreConfig, EndpointConfig, InitConfig},
     document::{
         self,
         Document,
@@ -137,107 +133,6 @@ pub enum Error {
     #[cfg(feature = "storage")]
     /// Storage error: {0}.
     Storage(#[from] storage::Error),
-}
-
-/// Configuration settings to initialize Discovery Engine with a
-/// [`xayn_discovery_engine_ai::Ranker`].
-#[derive(Clone)]
-pub struct InitConfig {
-    /// Key for accessing the API.
-    pub api_key: String,
-    /// API base url.
-    pub api_base_url: String,
-    /// List of markets to use.
-    pub markets: Vec<Market>,
-    /// List of trusted sources to use.
-    pub trusted_sources: Vec<String>,
-    /// List of excluded sources to use.
-    pub excluded_sources: Vec<String>,
-    /// S-mBert vocabulary path.
-    pub smbert_vocab: String,
-    /// S-mBert model path.
-    pub smbert_model: String,
-    /// KPE vocabulary path.
-    pub kpe_vocab: String,
-    /// KPE model path.
-    pub kpe_model: String,
-    /// KPE CNN path.
-    pub kpe_cnn: String,
-    /// KPE classifier path.
-    pub kpe_classifier: String,
-    /// AI config in JSON format.
-    pub ai_config: Option<String>,
-}
-
-/// Discovery Engine endpoint settings.
-pub(crate) struct EndpointConfig {
-    /// Page size setting for API.
-    pub(crate) page_size: usize,
-    /// Write-exclusive access to markets list.
-    pub(crate) markets: Arc<RwLock<Vec<Market>>>,
-    /// Trusted sources for news queries.
-    pub(crate) trusted_sources: Arc<RwLock<Vec<String>>>,
-    /// Sources to exclude for news queries.
-    pub(crate) excluded_sources: Arc<RwLock<Vec<String>>>,
-    /// The maximum number of requests to try to reach the number of `min_articles`.
-    pub(crate) max_requests: u32,
-    /// The minimum number of new articles to try to return when updating the stack.
-    pub(crate) min_articles: usize,
-    /// The maximum age of a headline, in days, after which we no longer
-    /// want to display them
-    pub(crate) max_headline_age_days: usize,
-    /// The maximum age of a news article, in days, after which we no longer
-    /// want to display them
-    pub(crate) max_article_age_days: usize,
-}
-
-impl From<InitConfig> for EndpointConfig {
-    fn from(config: InitConfig) -> Self {
-        Self {
-            page_size: 100,
-            markets: Arc::new(RwLock::new(config.markets)),
-            trusted_sources: Arc::new(RwLock::new(config.trusted_sources)),
-            excluded_sources: Arc::new(RwLock::new(config.excluded_sources)),
-            max_requests: 5,
-            min_articles: 20,
-            max_headline_age_days: 3,
-            max_article_age_days: 30,
-        }
-    }
-}
-
-/// Temporary config to allow for configurations within the core without a mirroring outside impl.
-struct CoreConfig {
-    /// The number of taken top key phrases while updating the stacks.
-    take_top: usize,
-    /// The number of top documents per stack to keep while filtering the stacks.
-    keep_top: usize,
-    /// The lower bound of documents per stack at which new items are requested.
-    request_new: usize,
-    /// The number of times to get feed documents after which the stacks are updated without the
-    /// limitation of `request_new`.
-    request_after: usize,
-    /// The maximum number of top key phrases extracted from the search term in the deep search.
-    deep_search_top: usize,
-    /// The maximum number of documents returned from the deep search.
-    deep_search_max: usize,
-    /// The minimum cosine similarity wrt the original document below which documents returned from
-    /// the deep search are discarded.
-    deep_search_sim: f32,
-}
-
-impl Default for CoreConfig {
-    fn default() -> Self {
-        Self {
-            take_top: 3,
-            keep_top: 20,
-            request_new: 3,
-            request_after: 2,
-            deep_search_top: 3,
-            deep_search_max: 20,
-            deep_search_sim: 0.2,
-        }
-    }
 }
 
 /// Discovery Engine.
@@ -1102,14 +997,6 @@ impl XaynAiEngine {
     }
 }
 
-fn ai_config_from_json(json: &str) -> Figment {
-    Figment::new()
-        .merge(Serialized::defaults(CoiSystemConfig::default()))
-        .merge(Serialized::default("kpe.token_size", 150))
-        .merge(Serialized::default("smbert.token_size", 150))
-        .merge(Json::string(json))
-}
-
 #[derive(Serialize, Deserialize)]
 struct StackState(Vec<u8>);
 
@@ -1148,46 +1035,6 @@ mod tests {
     };
 
     use super::*;
-
-    #[test]
-    fn test_ai_config_from_json_default() -> Result<(), GenericError> {
-        let ai_config = ai_config_from_json("{}");
-        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
-        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 150);
-        assert_eq!(
-            ai_config.extract::<CoiSystemConfig>()?,
-            CoiSystemConfig::default(),
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_ai_config_from_json_modified() -> Result<(), GenericError> {
-        let ai_config = ai_config_from_json(
-            r#"{
-                "coi": {
-                    "threshold": 0.42
-                },
-                "kpe": {
-                    "penalty": [0.99, 0.66, 0.33]
-                },
-                "smbert": {
-                    "token_size": 42,
-                    "foo": "bar"
-                },
-                "baz": 0
-            }"#,
-        );
-        assert_eq!(ai_config.extract_inner::<usize>("kpe.token_size")?, 150);
-        assert_eq!(ai_config.extract_inner::<usize>("smbert.token_size")?, 42);
-        assert_eq!(
-            ai_config.extract::<CoiSystemConfig>()?,
-            CoiSystemConfig::default()
-                .with_threshold(0.42)?
-                .with_penalty(&[0.99, 0.66, 0.33])?,
-        );
-        Ok(())
-    }
 
     #[test]
     fn test_usize_not_to_small() {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -954,7 +954,7 @@ impl XaynAiEngine {
             Builder::from(smbert_config, kpe_config).with_coi_system_config(coi_system_config);
 
         let client = Arc::new(Client::new(&config.api_key, &config.api_base_url));
-        let endpoint_config = config.into();
+        let endpoint_config = EndpointConfig::default().with_init_config(config);
         let stack_ops = vec![
             Box::new(BreakingNews::new(&endpoint_config, client.clone())) as BoxedOps,
             Box::new(TrustedNews::new(&endpoint_config, client.clone())) as BoxedOps,
@@ -1070,7 +1070,7 @@ mod tests {
             kpe_classifier: format!("{}/kpe_v0001/classifier.binparams", asset_base),
             ai_config: None,
         };
-        let endpoint_config = config.clone().into();
+        let endpoint_config = EndpointConfig::default().with_init_config(config.clone());
         let client = Arc::new(Client::new(&config.api_key, &config.api_base_url));
 
         // We assume that, if de-duplication works between two stacks, it'll work between

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -30,13 +30,16 @@
     clippy::must_use_candidate
 )]
 
+mod config;
 pub mod document;
 mod engine;
 mod mab;
 mod ranker;
 pub mod stack;
-
 #[cfg(feature = "storage")]
 pub mod storage;
 
-pub use crate::engine::{Engine, Error, InitConfig, XaynAiEngine};
+pub use crate::{
+    config::InitConfig,
+    engine::{Engine, Error, XaynAiEngine},
+};

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -29,8 +29,8 @@ use xayn_discovery_engine_providers::{
 };
 
 use crate::{
+    config::EndpointConfig,
     document::{Document, HistoricDocument},
-    engine::EndpointConfig,
     stack::{
         filters::{ArticleFilter, CommonFilter, SourcesFilter},
         Id,

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -30,8 +30,8 @@ use xayn_discovery_engine_providers::{
 };
 
 use crate::{
+    config::EndpointConfig,
     document::{Document, HistoricDocument},
-    engine::EndpointConfig,
     stack::{
         filters::{ArticleFilter, CommonFilter, SourcesFilter},
         Id,

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -29,8 +29,8 @@ use xayn_discovery_engine_providers::{
 };
 
 use crate::{
+    config::EndpointConfig,
     document::{Document, HistoricDocument},
-    engine::EndpointConfig,
     stack::{
         filters::{ArticleFilter, CommonFilter},
         Id,


### PR DESCRIPTION
**References**

- [TY-2947]

**Summary**

- move config related code from the `engine` module to the new `config` module
- add json config parsing for the `EndpointConfig` and `CoreConfig`


[TY-2947]: https://xainag.atlassian.net/browse/TY-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ