### PR TITLE
[Merged by Bors] - TY-2971 impl fetch history

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+ "uuid",
  "webpki-roots",
 ]
 

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -33,7 +33,7 @@ xayn-discovery-engine-providers = { path = "../providers" }
 xayn-discovery-engine-tokenizer = { path = "../ai/tokenizer" }
 
 # feature storage
-sqlx = { version = "0.6.0", features = ["runtime-tokio-rustls", "sqlite"], optional = true }
+sqlx = { version = "0.6.0", features = ["runtime-tokio-rustls", "sqlite", "uuid"], optional = true }
 
 [dev-dependencies]
 claim = "0.5.0"

--- a/discovery_engine_core/core/build.rs
+++ b/discovery_engine_core/core/build.rs
@@ -12,18 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
-
-use crate::document::HistoricDocument;
-
-pub mod sqlite;
-
-#[async_trait]
-pub trait Storage {
-    type StorageError;
-
-    async fn init_database(&self) -> Result<(), <Self as Storage>::StorageError>;
-
-    async fn fetch_history(&self)
-        -> Result<Vec<HistoricDocument>, <Self as Storage>::StorageError>;
+fn main() {
+    println!("cargo:rerun-if-changed=src/storage/migrations");
 }

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -54,6 +54,12 @@ impl Id {
     pub(crate) fn new() -> Self {
         Self(Uuid::new_v4())
     }
+
+    #[cfg(feature = "storage")]
+    #[cfg(test)]
+    pub(crate) fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
 }
 
 impl From<Uuid> for Id {

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -55,8 +55,7 @@ impl Id {
         Self(Uuid::new_v4())
     }
 
-    #[cfg(feature = "storage")]
-    #[cfg(test)]
+    #[cfg(all(feature = "storage", test))]
     pub(crate) fn as_uuid(&self) -> &Uuid {
         &self.0
     }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -54,7 +54,10 @@ use xayn_discovery_engine_providers::{
 use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 
 #[cfg(feature = "storage")]
-use crate::storage::{self, SqliteStorage, Storage};
+use crate::storage::{
+    sqlite::{self, SqliteStorage},
+    Storage,
+};
 use crate::{
     config::{de_config_from_json, CoreConfig, EndpointConfig, ExplorationConfig, InitConfig},
     document::{
@@ -133,7 +136,7 @@ pub enum Error {
 
     #[cfg(feature = "storage")]
     /// Storage error: {0}.
-    Storage(#[from] storage::Error),
+    Storage(#[from] sqlite::Error),
 }
 
 /// Discovery Engine.
@@ -147,7 +150,7 @@ pub struct Engine<R> {
     request_after: usize,
     #[cfg(feature = "storage")]
     #[allow(dead_code)]
-    storage: Box<dyn Storage<StorageError = storage::Error> + Send + Sync>,
+    storage: Box<dyn Storage<StorageError = sqlite::Error> + Send + Sync>,
 }
 
 impl<R> Engine<R>
@@ -169,7 +172,7 @@ where
         stack_ops: Vec<BoxedOps>,
         client: Arc<Client>,
         #[cfg(feature = "storage")] storage: Box<
-            dyn Storage<StorageError = storage::Error> + Send + Sync,
+            dyn Storage<StorageError = sqlite::Error> + Send + Sync,
         >,
     ) -> Result<Self, Error> {
         let stacks = stack_ops

--- a/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
@@ -1,0 +1,52 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS Document (
+    id BLOB NOT NULL
+        PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS HistoricDocument (
+    document BLOB NOT NULL
+        PRIMARY KEY
+        REFERENCES Document(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS NewsResource (
+    document BLOB NOT NULL
+        PRIMARY KEY
+        REFERENCES Document(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    snippet TEXT NOT NULL,
+    topic TEXT NOT NULL,
+    url TEXT NOT NULL,
+    image TEXT,
+    -- format should be RFC3339/ISO8601 & sqlite compliant
+    datePublished TEXT NOT NULL,
+    -- implied by url, but allows us to easier implement
+    -- things like pruning history when excluding a source
+    source TEXT NOT NULL,
+    -- compound format <2-letter-lang><2-letter-state>
+    -- should be same as market primary key
+    -- but for now it can't be a foreign key
+    market TEXT
+);
+
+CREATE TABLE IF NOT EXISTS NewscatcherData (
+    document BLOB NOT NULL
+        PRIMARY KEY
+        REFERENCES NewsResource(document) ON DELETE CASCADE,
+    domainRank INTEGER NOT NULL,
+    score REAL NOT NULL
+);

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -186,11 +186,11 @@ mod tests {
 
         let history = storage.fetch_history().await.unwrap();
         assert_eq!(history.len(), docs.len());
-        docs.iter().zip(history).for_each(|(a, b)| {
-            assert_eq!(a.0.id, b.id);
-            assert_eq!(a.1.url, b.url);
-            assert_eq!(a.1.snippet, b.snippet);
-            assert_eq!(a.1.title, b.title);
+        history.iter().zip(docs).for_each(|(history, doc)| {
+            assert_eq!(history.id, doc.0.id);
+            assert_eq!(history.url, doc.1.url);
+            assert_eq!(history.snippet, doc.1.snippet);
+            assert_eq!(history.title, doc.1.title);
         });
     }
 }

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -185,7 +185,7 @@ mod tests {
         insert_historic_documents(&storage, docs.clone()).await;
 
         let history = storage.fetch_history().await.unwrap();
-        assert_eq!(docs.len(), history.len());
+        assert_eq!(history.len(), docs.len());
         docs.iter().zip(history).for_each(|(a, b)| {
             assert_eq!(a.0.id, b.id);
             assert_eq!(a.1.url, b.url);

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -1,0 +1,196 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use displaydoc::Display;
+use sqlx::{
+    sqlite::{Sqlite, SqliteConnectOptions, SqlitePoolOptions},
+    Pool,
+};
+use thiserror::Error;
+use url::Url;
+use uuid::Uuid;
+use xayn_discovery_engine_ai::GenericError;
+
+use crate::document::{HistoricDocument, Id};
+
+use super::Storage;
+
+#[derive(Error, Debug, Display)]
+pub enum Error {
+    /// Failed to initialize database: {0}
+    Init(#[source] sqlx::Error),
+
+    /// Failed to acquire connection: {0}
+    AcquireConnection(#[source] sqlx::Error),
+
+    /// Failed to migrate database: {0}
+    Migration(#[from] sqlx::migrate::MigrateError),
+
+    /// Failed to fetch: {0}
+    Fetch(#[source] sqlx::Error),
+
+    /// Failed to covert type: {0}
+    TypeConversion(#[source] GenericError),
+}
+
+#[derive(Clone)]
+pub(crate) struct SqliteStorage {
+    pool: Pool<Sqlite>,
+}
+
+impl SqliteStorage {
+    pub(crate) async fn connect(uri: &str) -> Result<Self, Error> {
+        let opt = SqliteConnectOptions::from_str(uri)
+            .map_err(Error::Init)?
+            .create_if_missing(true);
+
+        let pool = SqlitePoolOptions::new()
+            .connect_with(opt)
+            .await
+            .map_err(Error::Init)?;
+
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl Storage for SqliteStorage {
+    type StorageError = Error;
+
+    async fn init_database(&self) -> Result<(), <Self as Storage>::StorageError> {
+        sqlx::migrate!("src/storage/migrations")
+            .run(&self.pool)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn fetch_history(
+        &self,
+    ) -> Result<Vec<HistoricDocument>, <Self as Storage>::StorageError> {
+        #[derive(sqlx::FromRow)]
+        struct _HistoricDocument {
+            document: Uuid,
+            url: String,
+            snippet: String,
+            title: String,
+        }
+
+        let mut con = self
+            .pool
+            .acquire()
+            .await
+            .map_err(Error::AcquireConnection)?;
+
+        sqlx::query_as::<_, _HistoricDocument>("SELECT nr.document, nr.url, nr.snippet, nr.title FROM HistoricDocument AS hd, NewsResource AS nr ON hd.document = nr.document;")
+            .fetch_all(&mut con)
+            .await
+            .map_err(Error::Fetch)?
+            .into_iter()
+            .map(|hd| {
+                let url = Url::parse(&hd.url).map_err(|e| Error::TypeConversion(e.into()))?;
+                Ok(HistoricDocument {
+                    id: Id::from(hd.document),
+                    url,
+                    snippet: hd.snippet,
+                    title: hd.title,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::document::NewsResource;
+
+    use super::*;
+
+    fn create_historic_documents(n: u32) -> Vec<(HistoricDocument, NewsResource)> {
+        (0..n)
+            .map(|i| {
+                let title = format!("title-{}", i);
+                let snippet = format!("snippet-{}", i);
+                let url = Url::parse("http://example.com").unwrap();
+                (
+                    HistoricDocument {
+                        id: Id::new(),
+                        url: url.clone(),
+                        snippet: snippet.clone(),
+                        title: title.clone(),
+                    },
+                    NewsResource {
+                        title,
+                        snippet,
+                        url,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect()
+    }
+
+    async fn insert_historic_documents(
+        storage: &SqliteStorage,
+        docs: Vec<(HistoricDocument, NewsResource)>,
+    ) {
+        let mut con = storage.pool.acquire().await.unwrap();
+
+        for doc in docs {
+            sqlx::query("INSERT INTO Document (id) VALUES (?)")
+                .bind(doc.0.id.as_uuid())
+                .execute(&mut con)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO HistoricDocument (document) VALUES (?)")
+                .bind(doc.0.id.as_uuid())
+                .execute(&mut con)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO NewsResource (document, url, snippet, title, topic, datePublished, source) VALUES (?, ?, ?, ?, ?, ?, ?)")
+                .bind(doc.0.id.as_uuid())
+                .bind(doc.1.url.as_str())
+                .bind(doc.1.snippet)
+                .bind(doc.1.title)
+                .bind(doc.1.topic)
+                .bind(doc.1.date_published.to_string())
+                .bind(doc.1.source_domain)
+                .execute(&mut con)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_history() {
+        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
+        storage.init_database().await.unwrap();
+        let history = storage.fetch_history().await.unwrap();
+        assert!(history.is_empty());
+
+        let docs = create_historic_documents(10);
+        insert_historic_documents(&storage, docs.clone()).await;
+
+        let history = storage.fetch_history().await.unwrap();
+        assert_eq!(docs.len(), history.len());
+        docs.iter().zip(history).for_each(|(a, b)| {
+            assert_eq!(a.0.id, b.id);
+            assert_eq!(a.1.url, b.url);
+            assert_eq!(a.1.snippet, b.snippet);
+            assert_eq!(a.1.title, b.title);
+        });
+    }
+}


### PR DESCRIPTION
Ticket:

- [TY-2971]

Summary:

- moved `SqliteStorage` into separate file 
- added sql code for creating the `Document`, `HistoricDocument`, `NewsResource` and `NewscatcherData` tables
- added `fetch_history` to `Storage` trait and implemented the method on the `SqliteStorage` struct
- added a build script for [triggering recompilation on migration changes](https://docs.rs/sqlx/0.6.0/sqlx/macro.migrate.html#triggering-recompilation-on-migration-changes)

[TY-2971]: https://xainag.atlassian.net/browse/TY-2971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ