### PR TITLE
[Merged by Bors] - TY-2963 stack mab config

### DIFF
--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -36,7 +36,7 @@ pub(crate) mod exploration;
 pub(crate) mod filters;
 pub(crate) mod ops;
 
-pub use self::ops::Ops;
+pub use self::ops::{BoxedOps, Ops};
 pub(crate) use self::{
     data::Data,
     ops::{
@@ -78,9 +78,6 @@ pub enum Error {
     /// Failed to select new items: {0}.
     Selection(#[from] exploration::Error),
 }
-
-/// Convenience type that boxes an [`ops::Ops`] and adds [`Send`] and [`Sync`].
-pub type BoxedOps = Box<dyn Ops + Send + Sync>;
 
 /// Id of a stack.
 ///

--- a/discovery_engine_core/core/src/stack/data.rs
+++ b/discovery_engine_core/core/src/stack/data.rs
@@ -36,10 +36,10 @@ pub(crate) enum Error {
 pub(crate) struct Data {
     /// The alpha parameter of the beta distribution.
     #[derivative(Default(value = "1."))]
-    pub(super) alpha: f32,
+    pub(crate) alpha: f32,
     /// The beta parameter of the beta distribution.
     #[derivative(Default(value = "1."))]
-    pub(super) beta: f32,
+    pub(crate) beta: f32,
     /// Documents in the [`Stack`](super::Stack).
     pub(crate) documents: Vec<Document>,
 }

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -73,7 +73,7 @@ pub trait Ops {
     fn merge(&self, stack: &[Document], new: &[Document]) -> Result<Vec<Document>, GenericError>;
 }
 
-/// Convenience type that boxes an [`ops::Ops`] and adds [`Send`] and [`Sync`].
+/// Convenience type that boxes an [`Ops`] and adds [`Send`] and [`Sync`].
 pub type BoxedOps = Box<dyn Ops + Send + Sync>;
 
 #[async_trait]
@@ -107,10 +107,10 @@ impl Ops for BoxedOps {
 pub(crate) mod tests {
     use super::*;
 
-    // check that Ops is object safe
     #[test]
-    fn check_ops_obj_safe() {
+    fn test_ops_trait_is_object_safe() {
         let _: Option<&dyn Ops> = None;
+        #[allow(clippy::let_underscore_drop)]
         let _: Option<BoxedOps> = None;
     }
 }

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -88,7 +88,7 @@ impl Ops for BoxedOps {
         history: &[HistoricDocument],
         stack: &[Document],
         market: &Market,
-    ) -> Result<Vec<Article>, NewItemsError> {
+    ) -> Result<Vec<GenericArticle>, NewItemsError> {
         self.as_ref()
             .new_items(key_phrases, history, stack, market)
             .await


### PR DESCRIPTION
**References**

- [TY-2963]
- requires #465
- followed by #467

**Summary**

- move `BoxedOps` into the `ops` module and implement the `Ops` trait for it
- assign MAB parameters to the respective stack data if they are present in the config


[TY-2963]: https://xainag.atlassian.net/browse/TY-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ