### PR TITLE
[Merged by Bors] - TY-2964 exploration stack config

### DIFF
--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -156,6 +156,24 @@ impl Default for CoreConfig {
     }
 }
 
+/// Configurations for the exploration stack.
+#[derive(Debug)]
+pub(crate) struct ExplorationConfig {
+    /// The number of candidates.
+    pub(crate) number_of_candidates: usize,
+    /// The maximum number of documents to keep.
+    pub(crate) max_selected_docs: usize,
+}
+
+impl Default for ExplorationConfig {
+    fn default() -> Self {
+        Self {
+            number_of_candidates: 40,
+            max_selected_docs: 20,
+        }
+    }
+}
+
 /// Reads the DE configurations from json and sets defaults for missing fields (if possible).
 pub(crate) fn de_config_from_json(json: &str) -> Figment {
     Figment::from(Json::string(json))

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -37,9 +37,8 @@ pub(crate) struct Stack {
 
 impl Stack {
     /// Create a new `Stack` with the given [`Data`].
-    pub(crate) fn new(data: Data) -> Result<Self, stack::Error> {
+    pub(crate) fn new(data: Data, config: Config) -> Result<Self, stack::Error> {
         Self::validate_documents_stack_id(&data.documents, Stack::id())?;
-        let config = Config::default();
         Ok(Self { data, config })
     }
 

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -18,15 +18,11 @@ use std::collections::HashSet;
 use uuid::uuid;
 
 use crate::{
+    config::ExplorationConfig as Config,
     document::{Document, UserReaction},
     mab::Bucket,
     ranker::Ranker,
-    stack::{
-        self,
-        exploration::selection::{document_selection, Config},
-        Data,
-        Id,
-    },
+    stack::{self, exploration::selection::document_selection, Data, Id},
 };
 
 mod selection;

--- a/discovery_engine_core/core/src/stack/exploration/selection.rs
+++ b/discovery_engine_core/core/src/stack/exploration/selection.rs
@@ -28,30 +28,12 @@ use xayn_discovery_engine_ai::{
     PositiveCoi,
 };
 
-use crate::document::Document;
+use crate::{config::ExplorationConfig as Config, document::Document};
 
 #[derive(Error, Debug, Display)]
 pub enum Error {
     /// Not enough cois
     NotEnoughCois,
-}
-
-/// Configurations for the exploration stack.
-#[derive(Debug)]
-pub(crate) struct Config {
-    /// The number of candidates.
-    number_of_candidates: usize,
-    /// The maximum number of documents to keep.
-    max_selected_docs: usize,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            number_of_candidates: 40,
-            max_selected_docs: 20,
-        }
-    }
 }
 
 /// Selects documents by randomization with a threshold.


### PR DESCRIPTION
**References**

- [TY-2964]
- requires #466

**Summary**

- move the exploration stack config to the config module
- read and pass exploration stack config from json or fall back to default values


[TY-2964]: https://xainag.atlassian.net/browse/TY-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ