### PR TITLE
[Merged by Bors] - FIX min negative cois config

### DIFF
--- a/discovery_engine_core/ai/ai/src/coi/config.rs
+++ b/discovery_engine_core/ai/ai/src/coi/config.rs
@@ -110,7 +110,7 @@ impl Config {
         }
     }
 
-    /// The minimum distance between distinct cois.
+    /// The maximum similarity between distinct cois.
     pub fn threshold(&self) -> f32 {
         self.coi.threshold
     }
@@ -119,8 +119,6 @@ impl Config {
     ///
     /// # Errors
     /// Fails if the threshold is not within [`COSINE_SIMILARITY_RANGE`].
-    ///
-    /// [`COSINE_SIMILARITY_RANGE`]: crate::embedding::utils::COSINE_SIMILARITY_RANGE
     pub fn with_threshold(mut self, threshold: f32) -> Result<Self, Error> {
         if COSINE_SIMILARITY_RANGE.contains(&threshold) {
             self.coi.threshold = threshold;

--- a/discovery_engine_core/ai/ai/src/coi/config.rs
+++ b/discovery_engine_core/ai/ai/src/coi/config.rs
@@ -85,8 +85,6 @@ pub enum Error {
     Threshold,
     /// Invalid minimum number of positive cois, expected positive value
     MinPositiveCois,
-    /// Invalid minimum number of negative cois, expected positive value
-    MinNegativeCois,
     /// Invalid coi gamma, expected value from the unit interval
     Gamma,
     /// Invalid coi penalty, expected non-empty, finite and sorted values
@@ -156,16 +154,9 @@ impl Config {
     }
 
     /// Sets the minimum number of negative cois.
-    ///
-    /// # Errors
-    /// Fails if the minimum number is zero.
-    pub fn with_min_negative_cois(mut self, min_negative_cois: usize) -> Result<Self, Error> {
-        if min_negative_cois > 0 {
-            self.coi.min_negative_cois = min_negative_cois;
-            Ok(self)
-        } else {
-            Err(Error::MinNegativeCois)
-        }
+    pub fn with_min_negative_cois(mut self, min_negative_cois: usize) -> Self {
+        self.coi.min_negative_cois = min_negative_cois;
+        self
     }
 
     /// The time since the last view after which a coi becomes irrelevant.

--- a/discovery_engine_core/ai/ai/src/ranker/system.rs
+++ b/discovery_engine_core/ai/ai/src/ranker/system.rs
@@ -242,8 +242,7 @@ mod tests {
         let config = Config::default()
             .with_min_positive_cois(2)
             .unwrap()
-            .with_min_negative_cois(1)
-            .unwrap();
+            .with_min_negative_cois(1);
         let positive = create_pos_cois(&[[1., 0., 0.], [4., 12., 2.]]);
         let negative = create_neg_cois(&[[-100., -10., 0.]]);
 

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -82,10 +82,10 @@ pub(crate) struct EndpointConfig {
     /// The minimum number of new articles to try to return when updating the stack.
     pub(crate) min_articles: usize,
     /// The maximum age of a headline, in days, after which we no longer
-    /// want to display them
+    /// want to display them.
     pub(crate) max_headline_age_days: usize,
     /// The maximum age of a news article, in days, after which we no longer
-    /// want to display them
+    /// want to display them.
     pub(crate) max_article_age_days: usize,
 }
 


### PR DESCRIPTION
**Summary**

fixes small issues encountered during [TY-2943]:
- allow for 0 `min_negative_cois` in config, this is actually also the current default value
- fix some config docs


[TY-2943]: https://xainag.atlassian.net/browse/TY-2943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ