### PR TITLE
[Merged by Bors] - TY-2933 close active search

### DIFF
--- a/discovery_engine/lib/src/api/api.dart
+++ b/discovery_engine/lib/src/api/api.dart
@@ -72,6 +72,8 @@ export 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         RestoreActiveSearchFailed,
         ActiveSearchTermRequestSucceeded,
         ActiveSearchTermRequestFailed,
+        ActiveSearchClosedSucceeded,
+        ActiveSearchClosedFailed,
         DeepSearchRequestSucceeded,
         DeepSearchRequestFailed,
         SearchFailureReason,

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -66,6 +66,8 @@ enum SearchFailureReason {
   noActiveSearch,
   @JsonValue(1)
   noResultsAvailable,
+  @JsonValue(2)
+  openActiveSearch,
 }
 
 enum EngineExceptionReason {

--- a/discovery_engine/lib/src/api/events/engine_events.dart
+++ b/discovery_engine/lib/src/api/events/engine_events.dart
@@ -303,6 +303,19 @@ class EngineEvent with _$EngineEvent {
     SearchFailureReason reason,
   ) = ActiveSearchTermRequestFailed;
 
+  /// Event created as a success response to ActiveSearchClosed event.
+  /// Passes the current search term back to the client.
+  @Implements<SearchEngineEvent>()
+  const factory EngineEvent.activeSearchClosedSucceeded() =
+      ActiveSearchClosedSucceeded;
+
+  /// Event created as a failure response to ActiveSearchClosed event.
+  /// Passes a failure reason back to the client.
+  @Implements<SearchEngineEvent>()
+  const factory EngineEvent.activeSearchClosedFailed(
+    SearchFailureReason reason,
+  ) = ActiveSearchClosedFailed;
+
   /// Event created as a success response to DeepSearchRequested event.
   /// Passes a list of [Document] entities back to the client.
   @Implements<SearchEngineEvent>()

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -554,6 +554,8 @@ class DiscoveryEngine {
   /// - [ActiveSearchClosedSucceeded] indicating a successful operation
   /// - [ActiveSearchClosedFailed] indicating a failed operation, with a reason
   /// for such failure.
+  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// for such failure.
   Future<EngineEvent> closeActiveSearch() {
     return _trySend(() async {
       const event = ClientEvent.activeSearchClosed();

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -41,6 +41,8 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         NextActiveSearchBatchRequestFailed,
         ActiveSearchTermRequestSucceeded,
         ActiveSearchTermRequestFailed,
+        ActiveSearchClosedSucceeded,
+        ActiveSearchClosedFailed,
         RestoreActiveSearchSucceeded,
         RestoreActiveSearchFailed,
         DeepSearchRequestSucceeded,
@@ -549,8 +551,8 @@ class DiscoveryEngine {
   /// **can NOT interact** with them.
   ///
   /// In response it can return:
-  /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [ActiveSearchClosedSucceeded] indicating a successful operation
+  /// - [ActiveSearchClosedFailed] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> closeActiveSearch() {
     return _trySend(() async {
@@ -558,7 +560,8 @@ class DiscoveryEngine {
       final response = await _manager.send(event);
 
       return response.mapEvent(
-        clientEventSucceeded: true,
+        activeSearchClosedSucceeded: true,
+        activeSearchClosedFailed: true,
         engineExceptionRaised: true,
       );
     });
@@ -689,6 +692,8 @@ extension _MapEvent on EngineEvent {
     bool? restoreActiveSearchFailed,
     bool? activeSearchTermRequestSucceeded,
     bool? activeSearchTermRequestFailed,
+    bool? activeSearchClosedSucceeded,
+    bool? activeSearchClosedFailed,
     bool? deepSearchRequestSucceeded,
     bool? deepSearchRequestFailed,
     bool? trendingTopicsRequestSucceeded,
@@ -743,6 +748,9 @@ extension _MapEvent on EngineEvent {
             _maybePassThrough(activeSearchTermRequestSucceeded),
         activeSearchTermRequestFailed:
             _maybePassThrough(activeSearchTermRequestFailed),
+        activeSearchClosedSucceeded:
+            _maybePassThrough(activeSearchClosedSucceeded),
+        activeSearchClosedFailed: _maybePassThrough(activeSearchClosedFailed),
         deepSearchRequestSucceeded:
             _maybePassThrough(deepSearchRequestSucceeded),
         deepSearchRequestFailed: _maybePassThrough(deepSearchRequestFailed),

--- a/discovery_engine/lib/src/discovery_engine_base.dart
+++ b/discovery_engine/lib/src/discovery_engine_base.dart
@@ -26,6 +26,7 @@ import 'package:xayn_discovery_engine/src/api/api.dart'
         DocumentId,
         DocumentViewMode,
         EngineEvent,
+        EngineExceptionRaised,
         EngineExceptionReason,
         FeedMarkets,
         NextFeedBatchAvailable,
@@ -152,7 +153,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> changeConfiguration({
     FeedMarkets? feedMarkets,
@@ -181,7 +182,7 @@ class DiscoveryEngine {
   /// - [RestoreFeedSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [RestoreFeedFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> restoreFeed() async {
     return _trySend(() async {
@@ -206,7 +207,7 @@ class DiscoveryEngine {
   /// a list of [Document]s
   /// - [NextFeedBatchRequestFailed] for failed response, with a reason for
   /// failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestNextFeedBatch() {
     return _trySend(() async {
@@ -229,7 +230,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> closeFeedDocuments(Set<DocumentId> documentIds) {
     return _trySend(() async {
@@ -247,7 +248,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> addSourceToExcludedList(Source source) {
     return _trySend(() async {
@@ -265,7 +266,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> removeSourceFromExcludedList(Source source) {
     return _trySend(() async {
@@ -285,7 +286,7 @@ class DiscoveryEngine {
   /// - [ExcludedSourcesListRequestSucceeded] indicating a successful operation,
   /// containing a set of sources.
   /// - [ExcludedSourcesListRequestFailed] indicating a failed operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> getExcludedSourcesList() {
     return _trySend(() async {
@@ -308,7 +309,7 @@ class DiscoveryEngine {
   /// containing sets of both trusted and excluded [Source]s.
   /// - [SetSourcesRequestFailed] indicating a failed operation because of
   /// duplicates found in provided sets, containing a set of said duplicates.
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> overrideSources({
     required Set<Source> trustedSources,
@@ -373,7 +374,7 @@ class DiscoveryEngine {
   /// - [AvailableSourcesListRequestSucceeded] indicating a successful operation,
   /// containing a set of available sources.
   /// - [AvailableSourcesListRequestFailed] indicating a failed operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> getAvailableSourcesList(String fuzzySearchTerm) {
     return _trySend(() async {
@@ -393,7 +394,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> logDocumentTime({
     required DocumentId documentId,
@@ -420,7 +421,7 @@ class DiscoveryEngine {
   ///
   /// In response it can return:
   /// - [ClientEventSucceeded] indicating a successful operation
-  /// - [EngineExceptionReason] indicating a failed operation, with a reason
+  /// - [EngineExceptionRaised] indicating a failed operation, with a reason
   /// for such failure.
   Future<EngineEvent> changeUserReaction({
     required DocumentId documentId,
@@ -443,7 +444,7 @@ class DiscoveryEngine {
   /// - [ActiveSearchRequestSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [ActiveSearchRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestQuerySearch(String queryTerm) {
     return _trySend(() async {
@@ -465,7 +466,7 @@ class DiscoveryEngine {
   /// - [ActiveSearchRequestSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [ActiveSearchRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestTopicSearch(String topic) {
     return _trySend(() async {
@@ -486,7 +487,7 @@ class DiscoveryEngine {
   /// - [NextActiveSearchBatchRequestSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [NextActiveSearchBatchRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestNextActiveSearchBatch() {
     return _trySend(() async {
@@ -507,7 +508,7 @@ class DiscoveryEngine {
   /// - [RestoreActiveSearchSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [RestoreActiveSearchFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> restoreActiveSearch() {
     return _trySend(() async {
@@ -528,7 +529,7 @@ class DiscoveryEngine {
   /// - [ActiveSearchTermRequestSucceeded] for successful response, containing the
   /// search term
   /// - [ActiveSearchTermRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> getActiveSearchTerm() {
     return _trySend(() async {
@@ -554,7 +555,7 @@ class DiscoveryEngine {
   /// - [ActiveSearchClosedSucceeded] indicating a successful operation
   /// - [ActiveSearchClosedFailed] indicating a failed operation, with a reason
   /// for such failure.
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> closeActiveSearch() {
     return _trySend(() async {
@@ -575,7 +576,7 @@ class DiscoveryEngine {
   /// - [DeepSearchRequestSucceeded] for successful response, containing a list of
   /// [Document]s
   /// - [DeepSearchRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestDeepSearch(DocumentId id) {
     return _trySend(() async {
@@ -596,7 +597,7 @@ class DiscoveryEngine {
   /// - [TrendingTopicsRequestSucceeded] for successful response, containing a list of
   /// [TrendingTopic]s
   /// - [TrendingTopicsRequestFailed] for failed response, with a reason for failure
-  /// - [EngineExceptionReason] for unexpected exception raised, with a reason
+  /// - [EngineExceptionRaised] for unexpected exception raised, with a reason
   /// for such failure.
   Future<EngineEvent> requestTrendingTopics() {
     return _trySend(() async {

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -258,6 +258,11 @@ class SearchManager {
 
   /// Clear the active search and deactivate interacted search documents.
   Future<EngineEvent> activeSearchClosed() async {
+    if (await _searchRepo.getCurrent() == null) {
+      const reason = SearchFailureReason.noActiveSearch;
+      return const EngineEvent.activeSearchClosedFailed(reason);
+    }
+
     await _searchRepo.clear();
 
     final allDocs = await _docRepo.fetchAll();
@@ -266,7 +271,7 @@ class SearchManager {
         .where((doc) => doc.isSearched && doc.isActive);
 
     if (searchDocs.isEmpty) {
-      return const EngineEvent.clientEventSucceeded();
+      return const EngineEvent.activeSearchClosedSucceeded();
     }
 
     final ids = searchDocs.map((doc) => doc.documentId);
@@ -294,6 +299,6 @@ class SearchManager {
     final nonInteractedIds = nonInteracted.map((doc) => doc.documentId).toSet();
     await _docRepo.removeByIds(nonInteractedIds);
 
-    return const EngineEvent.clientEventSucceeded();
+    return const EngineEvent.activeSearchClosedSucceeded();
   }
 }

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -118,7 +118,10 @@ class SearchManager {
     String searchTerm,
     SearchBy searchBy,
   ) async {
-    await activeSearchClosed();
+    if (await _searchRepo.getCurrent() != null) {
+      const reason = SearchFailureReason.openActiveSearch;
+      return const EngineEvent.activeSearchRequestFailed(reason);
+    }
 
     final search = ActiveSearch(
       searchTerm: searchTerm,

--- a/discovery_engine/test/integration/active_search_test.dart
+++ b/discovery_engine/test/integration/active_search_test.dart
@@ -18,9 +18,10 @@ import 'package:test/test.dart';
 
 import 'package:xayn_discovery_engine/discovery_engine.dart'
     show
+        ActiveSearchClosedFailed,
+        ActiveSearchClosedSucceeded,
         ActiveSearchRequestFailed,
         ActiveSearchRequestSucceeded,
-        ClientEventSucceeded,
         DiscoveryEngine,
         RestoreActiveSearchFailed,
         SearchFailureReason;
@@ -106,7 +107,7 @@ void main() {
 
       // Closing the search should work, since a search is active
       final closeResponse = await engine.closeActiveSearch();
-      expect(closeResponse, isA<ClientEventSucceeded>());
+      expect(closeResponse, isA<ActiveSearchClosedSucceeded>());
 
       // Restoring now should fail, as there the active search has been closed
       final restoreClosedResponse = await engine.restoreActiveSearch();
@@ -148,15 +149,16 @@ void main() {
       );
     });
 
-    /// TODO: This is the behaviour we want, but not what we have at the moment
     test(
-      'closing when no active search is running returns an error',
-      () async {
-        final response = await engine.closeActiveSearch();
-        expect(response, isA<EngineExceptionRaised>());
-      },
-      skip: true,
-    );
+        'closing when no active search is running returns an "ActiveSearchClosedFailed" error',
+        () async {
+      final response = await engine.closeActiveSearch();
+      expect(response, isA<ActiveSearchClosedFailed>());
+      expect(
+        (response as ActiveSearchClosedFailed).reason,
+        equals(SearchFailureReason.noActiveSearch),
+      );
+    });
 
     /// TODO: This is not currently enabled, but is intended behaviour for
     ///       the future.

--- a/discovery_engine/test/integration/active_search_test.dart
+++ b/discovery_engine/test/integration/active_search_test.dart
@@ -160,23 +160,21 @@ void main() {
       );
     });
 
-    /// TODO: This is not currently enabled, but is intended behaviour for
-    ///       the future.
-    test(
-      'starting a second, concurrent search throws an error',
-      () async {
-        final response1 = await engine.requestQuerySearch('first search');
-        final response2 = await engine.requestQuerySearch('second search');
+    test('starting a second, concurrent search throws an error', () async {
+      final response1 = await engine.requestQuerySearch('first search');
+      final response2 = await engine.requestQuerySearch('second search');
 
-        expect(response1, isA<ActiveSearchRequestSucceeded>());
-        expect(
-          (response1 as ActiveSearchRequestSucceeded).items,
-          isNotEmpty,
-        );
+      expect(response1, isA<ActiveSearchRequestSucceeded>());
+      expect(
+        (response1 as ActiveSearchRequestSucceeded).items,
+        isNotEmpty,
+      );
 
-        expect(response2, isA<ActiveSearchRequestFailed>());
-      },
-      skip: true,
-    );
+      expect(response2, isA<ActiveSearchRequestFailed>());
+      expect(
+        (response2 as ActiveSearchRequestFailed).reason,
+        equals(SearchFailureReason.openActiveSearch),
+      );
+    });
   });
 }

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -134,9 +134,9 @@ Future<void> main() async {
 
     group('activeSearchRequested', () {
       test(
-          'given a query term a proper active search object is persisted, '
-          'and new document and active data entries are added to the database',
-          () async {
+          'when there is no active search stored, given a query term a proper '
+          'active search object is persisted, and new document and active '
+          'data entries are added to the database', () async {
         doc1 = doc1..isSearched = false;
         doc2 = doc2..isSearched = false;
         await docRepo.updateMany([doc1, doc2]);
@@ -148,6 +148,7 @@ Future<void> main() async {
           searchBy: SearchBy.query,
         );
 
+        await searchRepo.clear();
         final response =
             await mgr.activeSearchRequested('example query', SearchBy.query);
 

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -19,7 +19,6 @@ import 'package:hive/hive.dart' show Hive;
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show
-        ClientEventSucceeded,
         NextActiveSearchBatchRequestFailed,
         NextActiveSearchBatchRequestSucceeded,
         RestoreActiveSearchFailed,
@@ -28,6 +27,7 @@ import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
         ActiveSearchRequestSucceeded,
         ActiveSearchTermRequestFailed,
         ActiveSearchTermRequestSucceeded,
+        ActiveSearchClosedSucceeded,
         TrendingTopicsRequestFailed,
         TrendingTopicsRequestSucceeded;
 import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
@@ -359,7 +359,7 @@ Future<void> main() async {
     group('activeSearchClosed', () {
       test(
           'when there are no search documents it should return '
-          '"ClientEventSucceeded" event in response and clear only '
+          '"ActiveSearchClosedSucceeded" event in response and clear only '
           'the active search repo', () async {
         doc1 = doc1..isSearched = false;
         doc2 = doc2..isSearched = false;
@@ -367,7 +367,7 @@ Future<void> main() async {
 
         final response = await mgr.activeSearchClosed();
 
-        expect(response, isA<ClientEventSucceeded>());
+        expect(response, isA<ActiveSearchClosedSucceeded>());
         expect(searchRepo.box.isEmpty, isTrue);
         expect(activeRepo.box.length, equals(2));
         expect(docRepo.box.length, equals(2));
@@ -402,7 +402,7 @@ Future<void> main() async {
 
         final response = await mgr.activeSearchClosed();
 
-        expect(response, isA<ClientEventSucceeded>());
+        expect(response, isA<ActiveSearchClosedSucceeded>());
         expect(searchRepo.box.isEmpty, isTrue);
         // only doc1 should be left in the active data and changed doc boxes
         expect(activeRepo.box.length, equals(1));


### PR DESCRIPTION
**References**

- [TY-2933]

**Summary**

- closing an active search via `Engine.closeActiveSearch()` without an existent active search returns an error, the method returns `ActiveSearchClosedSucceeded` & `ActiveSearchClosedFailed` events instead of `ClientEventSucceeded` & `EngineExceptionRaised` events (`EngineExceptionRaised` may still occur for unexpected errors)
- initiating another active search (eg via `Engine.requestQuerySearch` and `Engine.requestTopicSearch`) while an active search is still open returns an `ActiveSearchRequestFailed` error with a `SearchFailureReason.openActiveSearch` reason
- fix a doc typo


[TY-2933]: https://xainag.atlassian.net/browse/TY-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ