### PR TITLE
[Merged by Bors] - Fix for dartdoc issue

### DIFF
--- a/.github/workflows/_reusable.dart.yml
+++ b/.github/workflows/_reusable.dart.yml
@@ -72,9 +72,5 @@ jobs:
           dart: true
           rust: true
 
-      # - name: Install dartdoc
-      #   working-directory: ${{ env.DART_WORKSPACE }}
-      #   run: dart pub global activate dartdoc
-
       - name: Check documentation
         run: just dart-check-doc

--- a/justfile
+++ b/justfile
@@ -117,7 +117,6 @@ check: rust-check dart-check flutter-check
 # Checks if dart documentation can be build without issues
 dart-check-doc: dart-build
     cd "$DART_WORKSPACE"; \
-    # dart pub global run dartdoc:dartdoc --no-generate-docs --no-quiet
     dart doc --verbose --dry-run --validate-links
 
 # Checks if rust documentation can be build without issues
@@ -128,7 +127,6 @@ rust-check-doc: _codegen-order-workaround
 # Builds dart documentation
 dart-doc *args: dart-build
     cd "$DART_WORKSPACE"; \
-    # dart pub global run dartdoc:dartdoc {{args}}
     dart doc {{args}}
 
 # Builds rust documentation


### PR DESCRIPTION
Since the `dartdoc` command is now [part of `dart` cli](https://dart.dev/tools/dart-doc), we can use it without installing `dartdoc` as global dependency.

Because of the switch some cli options are only available via `dartdoc_options.yaml` [config file](https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml).