### PR TITLE
[Merged by Bors] - TY-2991 move all stack configs as subconfigs under the `stacks` key

### DIFF
--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -186,7 +186,7 @@ pub(crate) fn de_config_from_json(json: &str) -> Figment {
         .join(Serialized::default("core", CoreConfig::default()))
         .join(Serialized::default("endpoint", EndpointConfig::default()))
         .join(Serialized::default(
-            &Exploration::id().to_string(),
+            &format!("stacks.{}", Exploration::id()),
             ExplorationConfig::default(),
         ))
 }
@@ -219,7 +219,8 @@ mod tests {
             EndpointConfig::default(),
         );
         assert_eq!(
-            de_config.extract_inner::<ExplorationConfig>(&Exploration::id().to_string())?,
+            de_config
+                .extract_inner::<ExplorationConfig>(&format!("stacks.{}", Exploration::id()))?,
             ExplorationConfig::default(),
         );
         Ok(())
@@ -240,9 +241,11 @@ mod tests {
                     "foo": "bar"
                 },
                 "baz": 0,
-                "77cf9280-bb93-4158-b660-8732927e0dcc": {
-                    "number_of_candidates": 42,
-                    "alpha": 0.42
+                "stacks": {
+                    "77cf9280-bb93-4158-b660-8732927e0dcc": {
+                        "number_of_candidates": 42,
+                        "alpha": 0.42
+                    }
                 }
             }"#,
         );
@@ -263,7 +266,8 @@ mod tests {
             EndpointConfig::default(),
         );
         assert_eq!(
-            de_config.extract_inner::<ExplorationConfig>(&Exploration::id().to_string())?,
+            de_config
+                .extract_inner::<ExplorationConfig>(&format!("stacks.{}", Exploration::id()))?,
             ExplorationConfig {
                 number_of_candidates: 42,
                 ..ExplorationConfig::default()
@@ -271,11 +275,11 @@ mod tests {
         );
         assert_approx_eq!(
             f32,
-            de_config.extract_inner::<f32>(&format!("{}.alpha", Exploration::id()))?,
+            de_config.extract_inner::<f32>(&format!("stacks.{}.alpha", Exploration::id()))?,
             0.42,
         );
         assert!(de_config
-            .extract_inner::<f32>(&format!("{}.beta", Exploration::id()))
+            .extract_inner::<f32>(&format!("stacks.{}.beta", Exploration::id()))
             .is_err());
         Ok(())
     }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -951,7 +951,7 @@ impl XaynAiEngine {
             .extract_inner("core")
             .map_err(|err| Error::Ranker(err.into()))?;
         let exploration_config = de_config
-            .extract_inner(&Exploration::id().to_string())
+            .extract_inner(&format!("stacks.{}", Exploration::id()))
             .map_err(|err| Error::Ranker(err.into()))?;
         let stack_ops = vec![
             Box::new(BreakingNews::new(&endpoint_config, client.clone())) as BoxedOps,
@@ -968,10 +968,10 @@ impl XaynAiEngine {
             (HashMap::default(), builder)
         };
         for id in stack_ops.iter().map(Ops::id).chain(once(Exploration::id())) {
-            if let Ok(alpha) = de_config.extract_inner::<f32>(&format!("{id}.alpha")) {
+            if let Ok(alpha) = de_config.extract_inner::<f32>(&format!("stacks.{id}.alpha")) {
                 stack_data.entry(id).or_default().alpha = alpha;
             }
-            if let Ok(beta) = de_config.extract_inner::<f32>(&format!("{id}.beta")) {
+            if let Ok(beta) = de_config.extract_inner::<f32>(&format!("stacks.{id}.beta")) {
                 stack_data.entry(id).or_default().beta = beta;
             }
         }

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -43,7 +43,7 @@ impl Stack {
     }
 
     /// [`Id`] of this `Stack`.
-    pub(crate) fn id() -> Id {
+    pub(crate) const fn id() -> Id {
         Id(uuid!("77cf9280-bb93-4158-b660-8732927e0dcc"))
     }
 

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -62,7 +62,7 @@ impl BreakingNews {
         }
     }
 
-    pub(crate) fn id() -> Id {
+    pub(crate) const fn id() -> Id {
         Id(uuid!("1ce442c8-8a96-433e-91db-c0bee37e5a83"))
     }
 


### PR DESCRIPTION
**References**

- [TY-2991]

**Summary**

- move JSON stack configs under the `stacks` key
- update [confluence docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)


[TY-2991]: https://xainag.atlassian.net/browse/TY-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ