### PR TITLE
[Merged by Bors] - TY-2957 post endpoint

### DIFF
--- a/discovery_engine_core/providers/src/bing.rs
+++ b/discovery_engine_core/providers/src/bing.rs
@@ -46,10 +46,10 @@ impl TrendingTopicsProvider for BingTrendingTopicsProvider {
     ) -> Result<Vec<TrendingTopic>, Error> {
         let response = self
             .endpoint
-            .get_request::<Response, _>(|mut query| {
+            .get_request::<Response, _>(|query_append| {
                 let lang = &request.market.lang_code;
                 let country = &request.market.country_code;
-                query.append_pair("mkt", &format!("{}-{}", lang, country));
+                query_append("mkt", format!("{}-{}", lang, country));
             })
             .await?;
 

--- a/discovery_engine_core/providers/src/error.rs
+++ b/discovery_engine_core/providers/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     Fetching(#[source] reqwest::Error),
     /// Failed to decode the server's response: {0}
     Decoding(#[source] serde_json::Error),
+    /// Failed to encode the query: {0}
+    Encoding(#[source] serde_json::Error),
     /// Failed to decode the server's response at JSON path {1}: {0}
     DecodingAtPath(
         String,

--- a/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
+++ b/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
@@ -17,7 +17,8 @@ use std::{sync::Arc, time::Duration};
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
-use url::{form_urlencoded, Url, UrlQuery};
+use serde_json::{Map, Value};
+use url::Url;
 
 use crate::Error;
 
@@ -30,6 +31,7 @@ pub struct RestEndpoint {
     url: Url,
     auth_token: String,
     timeout: Duration,
+    get_as_post: bool,
 }
 
 impl RestEndpoint {
@@ -48,6 +50,7 @@ impl RestEndpoint {
             url,
             auth_token,
             timeout: Duration::from_millis(3500),
+            get_as_post: false,
         }
     }
 
@@ -60,6 +63,19 @@ impl RestEndpoint {
         self
     }
 
+    /// Configures if we should use POST for GET requests.
+    ///
+    /// This is sometimes needed when some part of the serve
+    /// pipeline puts to strict limits on the length of the
+    /// path/query.
+    ///
+    /// It's semantically still a GET request.
+    #[must_use = "dropped changed client"]
+    pub fn with_get_as_post(mut self, get_as_post: bool) -> Self {
+        self.get_as_post = get_as_post;
+        self
+    }
+
     /// Return a reference to the Url of the endpoint.
     pub fn url(&self) -> &Url {
         &self.url
@@ -67,18 +83,30 @@ impl RestEndpoint {
 
     pub async fn get_request<
         D: DeserializeOwned + Send,
-        FN: FnOnce(form_urlencoded::Serializer<'_, UrlQuery<'_>>) + Send,
+        FN: FnOnce(&mut dyn FnMut(&str, String)) + Send,
     >(
         &self,
         setup_query_params: FN,
     ) -> Result<D, Error> {
         let mut url = self.url.clone();
 
-        setup_query_params(url.query_pairs_mut());
+        let query_builder = if self.get_as_post {
+            let mut query = Map::new();
+            setup_query_params(&mut |key, value| {
+                query.insert(key.into(), Value::String(value));
+            });
+            let body = serde_json::to_vec(&Value::Object(query)).map_err(Error::Encoding)?;
+            self.client.post(url).body(body)
+        } else {
+            let mut query_mut = url.query_pairs_mut();
+            setup_query_params(&mut |key, value| {
+                query_mut.append_pair(key, &value);
+            });
+            drop(query_mut);
+            self.client.get(url)
+        };
 
-        let response = self
-            .client
-            .get(url)
+        let response = query_builder
             .timeout(self.timeout)
             .bearer_auth(&self.auth_token)
             .send()

--- a/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
+++ b/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
@@ -65,9 +65,8 @@ impl RestEndpoint {
 
     /// Configures if we should use POST for GET requests.
     ///
-    /// This is sometimes needed when some part of the serve
-    /// pipeline puts to strict limits on the length of the
-    /// path/query.
+    /// This is sometimes needed when the server
+    /// puts limits on the length of the query.
     ///
     /// It's semantically still a GET request.
     #[must_use = "dropped changed client"]
@@ -83,10 +82,10 @@ impl RestEndpoint {
 
     pub async fn get_request<
         D: DeserializeOwned + Send,
-        FN: FnOnce(&mut dyn FnMut(&str, String)) + Send,
+        F: FnOnce(&mut dyn FnMut(&str, String)) + Send,
     >(
         &self,
-        setup_query_params: FN,
+        setup_query_params: F,
     ) -> Result<D, Error> {
         let mut url = self.url.clone();
 


### PR DESCRIPTION
Allow using POST for semantic GET requests on some endpoints to work around limitations of some software in the pipeline which limits the length of the GET query.

The query parameters will be added to as a json body mapping query parameter names to values.

This currently adds all values as Strings even numbers, this currently works, but we might want to consider fixing it, but doing so adds quite a bunch of code.

**References:**

- [TY-2957](https://xainag.atlassian.net/browse/TY-2957)
- based on #462 