### PR TITLE
[Merged by Bors] - TY-3049 epsilon exploration

### DIFF
--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -190,12 +190,15 @@ impl Default for CoreConfig {
 
 /// Configurations for the exploration stack.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub(crate) struct ExplorationConfig {
     /// The number of candidates.
     pub(crate) number_of_candidates: usize,
     /// The maximum number of documents to keep.
     pub(crate) max_selected_docs: usize,
+    /// The maximum cosine similarity wrt to the closest coi below which documents are retained
+    /// when the exploration stack is updated.
+    pub(crate) max_similarity: f32,
 }
 
 impl Default for ExplorationConfig {
@@ -203,6 +206,7 @@ impl Default for ExplorationConfig {
         Self {
             number_of_candidates: 40,
             max_selected_docs: 20,
+            max_similarity: 0.7,
         }
     }
 }
@@ -267,6 +271,7 @@ mod tests {
 
     // the f32 fields are never NaN by construction
     impl Eq for CoreConfig {}
+    impl Eq for ExplorationConfig {}
 
     impl Default for FeedConfig {
         fn default() -> Self {

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -164,6 +164,11 @@ pub(crate) struct CoreConfig {
     pub(crate) deep_search_sim: f32,
     /// The probability for random exploration instead of greedy selection in the MAB.
     pub(crate) epsilon: f32,
+    /// The maximum number of likes and dislikes after which the MAB parameters are rescaled.
+    pub(crate) max_reactions: usize,
+    /// The value by how much the likes and dislikes are incremented when the MAB parameters are
+    /// updated.
+    pub(crate) incr_reactions: f32,
 }
 
 impl Default for CoreConfig {
@@ -177,6 +182,8 @@ impl Default for CoreConfig {
             deep_search_max: 20,
             deep_search_sim: 0.2,
             epsilon: 0.2,
+            max_reactions: 10,
+            incr_reactions: 1.,
         }
     }
 }

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -162,6 +162,8 @@ pub(crate) struct CoreConfig {
     /// The minimum cosine similarity wrt the original document below which documents returned from
     /// the deep search are discarded.
     pub(crate) deep_search_sim: f32,
+    /// The probability for random exploration instead of greedy selection in the MAB.
+    pub(crate) epsilon: f32,
 }
 
 impl Default for CoreConfig {
@@ -174,6 +176,7 @@ impl Default for CoreConfig {
             deep_search_top: 3,
             deep_search_max: 20,
             deep_search_sim: 0.2,
+            epsilon: 0.2,
         }
     }
 }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -595,7 +595,11 @@ impl Engine {
                     self.core_config.incr_reactions,
                 );
             } else if reacted.stack_id == Exploration::id() {
-                self.exploration_stack.update_relevance(reacted.reaction);
+                self.exploration_stack.update_relevance(
+                    reacted.reaction,
+                    self.core_config.max_reactions,
+                    self.core_config.incr_reactions,
+                );
             } else {
                 return Err(Error::InvalidStackId(reacted.stack_id));
             }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -78,7 +78,7 @@ use crate::{
         UserReaction,
         WeightedSource,
     },
-    mab::{self, BetaSampler, Bucket, SelectionIter},
+    mab::{self, BetaSampler, Bucket, SelectionIter, UniformSampler},
     stack::{
         self,
         exploration::Stack as Exploration,
@@ -495,8 +495,14 @@ impl Engine {
             once(&mut self.exploration_stack as _),
         );
 
-        let documents = SelectionIter::new(BetaSampler, all_stacks)
-            .select(self.feed_config.max_docs_per_batch)?;
+        let documents = SelectionIter::new(
+            self.core_config.epsilon,
+            UniformSampler,
+            UniformSampler,
+            BetaSampler,
+            all_stacks,
+        )?
+        .select(self.feed_config.max_docs_per_batch)?;
         for document in &documents {
             debug!(
                 document = %document.id,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -589,7 +589,11 @@ impl Engine {
         // update relevance of stack if the reacted document belongs to one
         if !reacted.stack_id.is_nil() {
             if let Some(stack) = stacks.get_mut(&reacted.stack_id) {
-                stack.update_relevance(reacted.reaction);
+                stack.update_relevance(
+                    reacted.reaction,
+                    self.core_config.max_reactions,
+                    self.core_config.incr_reactions,
+                );
             } else if reacted.stack_id == Exploration::id() {
                 self.exploration_stack.update_relevance(reacted.reaction);
             } else {

--- a/discovery_engine_core/core/src/mab.rs
+++ b/discovery_engine_core/core/src/mab.rs
@@ -15,7 +15,7 @@
 use std::{cmp::Ordering, marker::PhantomData};
 
 use displaydoc::Display;
-use rand_distr::{Beta, BetaError, Distribution};
+use rand_distr::{uniform::SampleUniform, Beta, BetaError, Distribution, Uniform};
 use thiserror::Error;
 use xayn_discovery_engine_ai::nan_safe_f32_cmp;
 
@@ -27,6 +27,8 @@ pub enum Error {
     EmptyBucket,
     /// No [`Bucket`] to pull from.
     NoBucketsToPull,
+    /// Epsilon must be a probability.
+    InvalidEpsilon,
 }
 
 pub(crate) trait BetaSample {
@@ -39,6 +41,22 @@ pub(crate) struct BetaSampler;
 impl BetaSample for BetaSampler {
     fn sample(&self, alpha: f32, beta: f32) -> Result<f32, Error> {
         Ok(Beta::new(alpha, beta)?.sample(&mut rand::thread_rng()))
+    }
+}
+
+pub(crate) trait UniformSample<T> {
+    fn sample(&self, low: T, high: T) -> T;
+}
+
+/// Sample a value from a uniform distribution.
+pub(crate) struct UniformSampler;
+
+impl<T> UniformSample<T> for UniformSampler
+where
+    T: SampleUniform,
+{
+    fn sample(&self, low: T, high: T) -> T {
+        Uniform::new(low, high).sample(&mut rand::thread_rng())
     }
 }
 
@@ -77,12 +95,17 @@ where
     }
 }
 
-/// Samples the next non-empty bucket.
-fn pull_arms<'b, T>(
-    beta_sampler: &impl BetaSample,
-    buckets: impl Iterator<Item = &'b mut impl Bucket<T>>,
-) -> Option<Result<&'b mut impl Bucket<T>, Error>> {
+/// Greedily samples the next non-empty bucket.
+fn pull_arms_greedy<'b, BS, B, T>(
+    beta_sampler: &BS,
+    buckets: &'b mut [B],
+) -> Option<Result<&'b mut B, Error>>
+where
+    BS: BetaSample,
+    B: Bucket<T>,
+{
     buckets
+        .iter_mut()
         .filter(|bucket| !bucket.is_empty())
         .try_fold(None, |max, bucket| {
             beta_sampler
@@ -103,32 +126,66 @@ fn pull_arms<'b, T>(
         .map(|result| result.map(|(_, bucket)| bucket))
 }
 
+/// Randomly samples the next non-empty bucket.
+fn pull_arms_randomly<'b, DS, B, T>(
+    uniform_discrete_sampler: &DS,
+    buckets: &'b mut [B],
+) -> Option<Result<&'b mut B, Error>>
+where
+    DS: UniformSample<usize>,
+    B: Bucket<T>,
+{
+    let count = buckets.iter().filter(|bucket| !bucket.is_empty()).count();
+    buckets
+        .iter_mut()
+        .filter(|bucket| !bucket.is_empty())
+        .nth(uniform_discrete_sampler.sample(0, count))
+        .map(Ok)
+}
+
 /// An iterator to select elements from buckets.
-pub(crate) struct SelectionIter<'b, BS, B, T>
+pub(crate) struct SelectionIter<'b, US, DS, BS, B, T>
 where
     B: ?Sized,
 {
+    epsilon: f32,
+    uniform_unit_sampler: US,
+    uniform_discrete_sampler: DS,
     beta_sampler: BS,
     buckets: Vec<&'b mut B>,
     bucket_type: PhantomData<T>,
 }
 
-impl<'b, BS, B, T> SelectionIter<'b, BS, B, T>
+impl<'b, US, DS, BS, B, T> SelectionIter<'b, US, DS, BS, B, T>
 where
     B: ?Sized,
 {
     /// Creates a selective iterator.
-    pub(crate) fn new(beta_sampler: BS, buckets: impl IntoIterator<Item = &'b mut B>) -> Self {
-        Self {
+    pub(crate) fn new(
+        epsilon: f32,
+        uniform_unit_sampler: US,
+        uniform_discrete_sampler: DS,
+        beta_sampler: BS,
+        buckets: impl IntoIterator<Item = &'b mut B>,
+    ) -> Result<Self, Error> {
+        if !(0. ..=1.).contains(&epsilon) {
+            return Err(Error::InvalidEpsilon);
+        }
+        Ok(Self {
+            epsilon,
+            uniform_unit_sampler,
+            uniform_discrete_sampler,
             beta_sampler,
             buckets: buckets.into_iter().collect(),
             bucket_type: PhantomData,
-        }
+        })
     }
 
     /// Selects up to n elements.
     pub(crate) fn select(self, n: usize) -> Result<Vec<T>, Error>
     where
+        US: UniformSample<f32>,
+        DS: UniformSample<usize>,
         BS: BetaSample,
         B: Bucket<T>,
     {
@@ -136,15 +193,22 @@ where
     }
 }
 
-impl<'b, BS, B, T> Iterator for SelectionIter<'b, BS, B, T>
+impl<'b, US, DS, BS, B, T> Iterator for SelectionIter<'b, US, DS, BS, B, T>
 where
+    US: UniformSample<f32>,
+    DS: UniformSample<usize>,
     BS: BetaSample,
     B: Bucket<T> + ?Sized,
 {
     type Item = Result<T, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        pull_arms(&self.beta_sampler, self.buckets.iter_mut()).map(|result| {
+        if self.uniform_unit_sampler.sample(0., 1.) < self.epsilon {
+            pull_arms_randomly(&self.uniform_discrete_sampler, &mut self.buckets)
+        } else {
+            pull_arms_greedy(&self.beta_sampler, &mut self.buckets)
+        }
+        .map(|result| {
             result.map(|bucket| bucket.pop().unwrap(/* sampled bucket is not empty */))
         })
     }
@@ -159,6 +223,22 @@ mod tests {
     impl BetaSample for MockBetaSampler {
         fn sample(&self, alpha: f32, beta: f32) -> Result<f32, Error> {
             Ok(alpha - beta)
+        }
+    }
+
+    struct MockUniformUnitSampler;
+
+    impl UniformSample<f32> for MockUniformUnitSampler {
+        fn sample(&self, low: f32, high: f32) -> f32 {
+            (high - low) / 2. + low
+        }
+    }
+
+    struct MockUniformDiscreteSampler;
+
+    impl UniformSample<usize> for MockUniformDiscreteSampler {
+        fn sample(&self, low: usize, high: usize) -> usize {
+            (high - low) / 2 + low
         }
     }
 
@@ -211,9 +291,16 @@ mod tests {
 
         let stacks = vec![&mut stack_0, &mut stack_1, &mut stack_2, &mut stack_3];
 
-        let docs = SelectionIter::new(MockBetaSampler, stacks)
-            .select(10)
-            .unwrap();
+        let docs = SelectionIter::new(
+            0.,
+            MockUniformUnitSampler,
+            MockUniformDiscreteSampler,
+            MockBetaSampler,
+            stacks,
+        )
+        .unwrap()
+        .select(10)
+        .unwrap();
 
         assert_eq!(docs[0], 3);
         assert_eq!(docs[1], 2);

--- a/discovery_engine_core/core/src/stack/data.rs
+++ b/discovery_engine_core/core/src/stack/data.rs
@@ -40,13 +40,19 @@ pub(crate) struct Data {
     /// The beta parameter of the beta distribution.
     #[derivative(Default(value = "1."))]
     pub(crate) beta: f32,
+    /// The number of likes.
+    #[derivative(Default(value = "1."))]
+    pub(crate) likes: f32,
+    /// The number of dislikes.
+    #[derivative(Default(value = "1."))]
+    pub(crate) dislikes: f32,
     /// Documents in the [`Stack`](super::Stack).
     pub(crate) documents: Vec<Document>,
 }
 
 impl Data {
-    #[allow(dead_code)]
     /// Create a `Data`.
+    #[cfg(test)]
     pub(crate) fn new(alpha: f32, beta: f32, documents: Vec<Document>) -> Result<Self, Error> {
         if alpha <= 0.0 {
             return Err(Error::InvalidAlpha(alpha));
@@ -59,6 +65,7 @@ impl Data {
             alpha,
             beta,
             documents,
+            ..Self::default()
         })
     }
 

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -95,21 +95,13 @@ impl Stack {
     }
 
     /// Updates the relevance of the Stack based on the user feedback.
-    pub(crate) fn update_relevance(&mut self, reaction: UserReaction) {
-        // to avoid making the distribution too skewed
-        const MAX_BETA_PARAMS: f32 = 1000.;
-
-        fn incr(value: &mut f32) {
-            if *value < MAX_BETA_PARAMS {
-                (*value) += 1.;
-            }
-        }
-
-        match reaction {
-            UserReaction::Positive => incr(&mut self.data.alpha),
-            UserReaction::Negative => incr(&mut self.data.beta),
-            UserReaction::Neutral => (),
-        }
+    pub(crate) fn update_relevance(
+        &mut self,
+        reaction: UserReaction,
+        max_reactions: usize,
+        incr_reactions: f32,
+    ) {
+        stack::update_relevance(&mut self.data, reaction, max_reactions, incr_reactions);
     }
 
     /// It checks that every document belongs to a stack.


### PR DESCRIPTION
**References**

- [TY-2992], [TY-3049]

**Summary**

- new MAB strategy: [original code](https://github.com/xaynetwork/xayn_ai_research/blob/a42f05497ec2a37672d7863e29286f99ed63cd1e/xayn_ai/rerankers/coi/mab.py#L203)
- filter docs by similarity to closest coi in exploration stack document selection
- the configuration has been extended by the following optional values (updated the [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations) as well):
```json
{
  "core": {
    "epsilon": 0.2,
    "max_reactions": 10,
    "incr_reactions": 1.0
  },
  "stacks": {
    "77cf9280-bb93-4158-b660-8732927e0dcc": {
      "max_similarity": 0.7
    }
  }
}
```


[TY-2992]: https://xainag.atlassian.net/browse/TY-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-3049]: https://xainag.atlassian.net/browse/TY-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ