### PR TITLE
[Merged by Bors] - TY-2994 fix ci installing new rust

### DIFF
--- a/.github/actions/setup-job-macos/action.yml
+++ b/.github/actions/setup-job-macos/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Install rustup
       shell: bash
-      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 
     - name: Install rust toolchain
       working-directory: ${{ env.RUST_WORKSPACE }}

--- a/.github/actions/setup-job-macos/action.yml
+++ b/.github/actions/setup-job-macos/action.yml
@@ -84,7 +84,7 @@ runs:
       run: |
           # Rustup when used will automatically install the toolchain
           # specified in rust-toolchain.toml
-          rustup show
+          rustup show active-toolchain
 
     - name: Install rust target
       if: inputs.rust-target != ''


### PR DESCRIPTION
**References**

- [TY-2994]

**Summary**

- don't install any default toolchain on mac during rustup installation
- just install the active toolchain and no default during rustup show


[TY-2994]: https://xainag.atlassian.net/browse/TY-2994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ