### PR TITLE
[Merged by Bors] - Add `#[allow(clippy::unused_async)]` where needed.

### DIFF
--- a/discovery_engine_core/web-api/src/main.rs
+++ b/discovery_engine_core/web-api/src/main.rs
@@ -75,6 +75,7 @@ async fn main() {
 }
 
 // TODO: TY-3013
+#[allow(clippy::unused_async)]
 async fn handle_ranked_documents(_user_id: Uuid) -> Result<impl warp::Reply, Infallible> {
     Ok(StatusCode::NOT_IMPLEMENTED)
 }
@@ -85,6 +86,7 @@ struct UserInteractionDto {
 }
 
 // TODO: TY-3014
+#[allow(clippy::unused_async)]
 async fn handle_user_interaction(
     _user_id: Uuid,
     _body: UserInteractionDto,
@@ -93,6 +95,7 @@ async fn handle_user_interaction(
 }
 
 // TODO: TY-3015
+#[allow(clippy::unused_async)]
 async fn handle_clean_state() -> Result<impl warp::Reply, Infallible> {
     Ok(StatusCode::NOT_IMPLEMENTED)
 }


### PR DESCRIPTION
This is done so that the current master branch passes checks locally.

Currently I have this commit cherry picked in 2 feature branches. 

It's not clear how the lint triggers locally as it only should have been in rust 1.62 (but we use 1.61) and it doesn't trigger on CI, but we will sooner or later switch to 1.62 anyway :shrug: 