### PR TITLE
[Merged by Bors] - Use env bash instead of env sh.

### DIFF
--- a/justfile
+++ b/justfile
@@ -287,7 +287,7 @@ check-android-so:
     {{justfile_directory()}}/.github/scripts/check_android_so.sh "$FLUTTER_WORKSPACE"/android/src/main/jniLibs/
 
 _dart-publish $WORKSPACE:
-    #!/usr/bin/env sh
+    #!/usr/bin/env bash
     set -eux
     cd "$WORKSPACE"
 


### PR DESCRIPTION
Due to a funny coincidence the errors caused by this
kinda "evened" out their effects in the tests.