### PR TITLE
[Merged by Bors] - TY-2970 allow locale example testing of published packages

### DIFF
--- a/justfile
+++ b/justfile
@@ -286,6 +286,21 @@ download-assets:
 check-android-so:
     {{justfile_directory()}}/.github/scripts/check_android_so.sh "$FLUTTER_WORKSPACE"/android/src/main/jniLibs/
 
+_override-flutter-self-deps $BUILD_ID:
+    #!/usr/bin/env bash
+    set -eux
+    cd "$FLUTTER_EXAMPLE_WORKSPACE"
+
+    SED_CMD="sed"
+    if [[ "{{os()}}" == "macos" ]]; then
+        SED_CMD="gsed"
+    fi
+
+    # This will add changes to your repo which should never be committed.
+    $SED_CMD -i s/dependency_overrides/x_dependency_overrides/ ./pubspec.yaml
+    $SED_CMD -i s/change.me.to.commit.ref/${BUILD_ID}/ ./pubspec.yaml
+
+
 _dart-publish $WORKSPACE:
     #!/usr/bin/env bash
     set -eux

--- a/justfile
+++ b/justfile
@@ -297,7 +297,7 @@ _override-flutter-self-deps $BUILD_ID:
     fi
 
     # This will add changes to your repo which should never be committed.
-    $SED_CMD -i s/dependency_overrides/x_dependency_overrides/ ./pubspec.yaml
+    $SED_CMD -i s/dependency_overrides/HACK_hide_dependency_overrides/ ./pubspec.yaml
     $SED_CMD -i s/change.me.to.commit.ref/${BUILD_ID}/ ./pubspec.yaml
 
 
@@ -314,7 +314,7 @@ _dart-publish $WORKSPACE:
     fi
 
     # Dependency overrides are not allowed in published dart packages
-    $SED_CMD -i s/dependency_overrides/x_dependency_overrides/ ./pubspec.yaml
+    $SED_CMD -i s/dependency_overrides/HACK_hide_dependency_overrides/ ./pubspec.yaml
 
     # Make it easier to figure out which builds came from `main`, and order the builds
     # by Github's "run ID". Note that this ID is reset if you change the name of the


### PR DESCRIPTION
This add a  helper function to the justfile which overrides the dependencies of the flutter package to use specific published packages instead of the local checkout.

This is useful for testing changes to the CI.

The helper function is hidden by default as it adds changes to the local repo which should never be committed.

**Based on:**
- #496 