### PR TITLE
[Merged by Bors] - TY-3018 change used sql join style

### DIFF
--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -243,8 +243,8 @@ impl Storage for SqliteStorage {
             "SELECT
                 nr.documentId, nr.title, nr.snippet, nr.url
             FROM
-                HistoricDocument AS hd, NewsResource AS nr
-            ON hd.documentId = nr.documentId;",
+                HistoricDocument AS hd
+            JOIN NewsResource AS nr ON hd.documentId = nr.documentId;",
         )
         .persistent(false)
         .fetch_all(&mut tx)
@@ -301,12 +301,11 @@ impl FeedScope for SqliteStorage {
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
             FROM
-                NewsResource AS nr, NewscatcherData AS nc, UserReaction AS ur,
-                FeedDocument AS fd, PresentationOrdering AS po
-            ON fd.documentId = nr.documentId
-            AND fd.documentId = nc.documentId
-            AND fd.documentId = ur.documentId
-            AND fd.documentId = po.documentId
+                FeedDocument AS fd
+            JOIN NewsResource AS nr ON fd.documentId = nr.documentId
+            JOIN NewscatcherData AS nc ON fd.documentId = nc.documentId
+            JOIN PresentationOrdering AS po ON fd.documentId = po.documentId
+            JOIN UserReaction AS ur ON fd.documentId = ur.documentId
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
         )
         .persistent(false)

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -242,8 +242,7 @@ impl Storage for SqliteStorage {
         let documents = sqlx::query_as::<_, QueriedHistoricDocument>(
             "SELECT
                 nr.documentId, nr.title, nr.snippet, nr.url
-            FROM
-                HistoricDocument AS hd
+            FROM HistoricDocument AS hd
             JOIN NewsResource AS nr ON hd.documentId = nr.documentId;",
         )
         .persistent(false)
@@ -300,8 +299,7 @@ impl FeedScope for SqliteStorage {
                 nr.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
-            FROM
-                FeedDocument AS fd
+            FROM FeedDocument AS fd
             JOIN NewsResource AS nr ON fd.documentId = nr.documentId
             JOIN NewscatcherData AS nc ON fd.documentId = nc.documentId
             JOIN PresentationOrdering AS po ON fd.documentId = po.documentId
@@ -441,13 +439,11 @@ impl SearchScope for SqliteStorage {
                 "nr.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
-            FROM
-                NewsResource AS nr, NewscatcherData AS nc, UserReaction AS ur,
-                SearchDocument AS sd, PresentationOrdering AS po
-            ON sd.documentId = nr.documentId
-            AND sd.documentId = nc.documentId
-            AND sd.documentId = ur.documentId
-            AND sd.documentId = po.documentId
+            FROM SearchDocument AS sd
+            JOIN NewsResource AS nr ON sd.documentId = nr.documentId
+            JOIN NewscatcherData AS nc ON sd.documentId = nc.documentId
+            JOIN PresentationOrdering AS po ON sd.documentId = po.documentId
+            JOIN UserReaction AS ur ON sd.documentId = ur.documentId
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
             )
             .build()
@@ -476,8 +472,8 @@ impl SearchScope for SqliteStorage {
         let ids = query_builder
             .push(
                 "SELECT ur.documentId
-                FROM UserReaction AS ur, SearchDocument AS sd
-                ON ur.documentId = sd.documentID
+                FROM UserReaction AS ur
+                JOIN SearchDocument AS sd ON ur.documentId = sd.documentID
                 WHERE ur.userReaction = ?;",
             )
             .build()

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -296,14 +296,14 @@ impl FeedScope for SqliteStorage {
 
         let documents = sqlx::query_as::<_, QueriedApiDocumentView>(
             "SELECT
-                nr.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
+                fd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
-            FROM FeedDocument AS fd
-            JOIN NewsResource AS nr ON fd.documentId = nr.documentId
-            JOIN NewscatcherData AS nc ON fd.documentId = nc.documentId
-            JOIN PresentationOrdering AS po ON fd.documentId = po.documentId
-            JOIN UserReaction AS ur ON fd.documentId = ur.documentId
+            FROM FeedDocument           AS fd
+            JOIN NewsResource           AS nr   USING documentId
+            JOIN NewscatcherData        AS nc   USING documentId
+            JOIN PresentationOrdering   AS po   USING documentId
+            JOIN UserReaction           AS ur   USING documentId
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
         )
         .persistent(false)
@@ -436,14 +436,14 @@ impl SearchScope for SqliteStorage {
         let documents = query_builder
             .reset()
             .push(
-                "nr.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
+                "sd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
-            FROM SearchDocument AS sd
-            JOIN NewsResource AS nr ON sd.documentId = nr.documentId
-            JOIN NewscatcherData AS nc ON sd.documentId = nc.documentId
-            JOIN PresentationOrdering AS po ON sd.documentId = po.documentId
-            JOIN UserReaction AS ur ON sd.documentId = ur.documentId
+            FROM SearchDocument         AS sd
+            JOIN NewsResource           AS nr   USING documentId
+            JOIN NewscatcherData        AS nc   USING documentId
+            JOIN PresentationOrdering   AS po   USING documentId
+            JOIN UserReaction           AS ur   USING documentId
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
             )
             .build()

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -243,7 +243,7 @@ impl Storage for SqliteStorage {
             "SELECT
                 hd.documentId, nr.title, nr.snippet, nr.url
             FROM HistoricDocument   AS hd
-            JOIN NewsResource       AS nr   USING documentId;",
+            JOIN NewsResource       AS nr   USING(documentId);",
         )
         .persistent(false)
         .fetch_all(&mut tx)
@@ -300,10 +300,10 @@ impl FeedScope for SqliteStorage {
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
             FROM FeedDocument           AS fd
-            JOIN NewsResource           AS nr   USING documentId
-            JOIN NewscatcherData        AS nc   USING documentId
-            JOIN PresentationOrdering   AS po   USING documentId
-            JOIN UserReaction           AS ur   USING documentId
+            JOIN NewsResource           AS nr   USING(documentId)
+            JOIN NewscatcherData        AS nc   USING(documentId)
+            JOIN PresentationOrdering   AS po   USING(documentId)
+            JOIN UserReaction           AS ur   USING(documentId)
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
         )
         .persistent(false)
@@ -440,10 +440,10 @@ impl SearchScope for SqliteStorage {
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
                 ur.userReaction, po.inBatchIndex
             FROM SearchDocument         AS sd
-            JOIN NewsResource           AS nr   USING documentId
-            JOIN NewscatcherData        AS nc   USING documentId
-            JOIN PresentationOrdering   AS po   USING documentId
-            JOIN UserReaction           AS ur   USING documentId
+            JOIN NewsResource           AS nr   USING(documentId)
+            JOIN NewscatcherData        AS nc   USING(documentId)
+            JOIN PresentationOrdering   AS po   USING(documentId)
+            JOIN UserReaction           AS ur   USING(documentId)
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
             )
             .build()
@@ -473,7 +473,7 @@ impl SearchScope for SqliteStorage {
             .push(
                 "SELECT ur.documentId
                 FROM UserReaction   AS ur
-                JOIN SearchDocument AS sd   USING documentId
+                JOIN SearchDocument AS sd   USING(documentId)
                 WHERE ur.userReaction = ?;",
             )
             .build()

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -241,9 +241,9 @@ impl Storage for SqliteStorage {
 
         let documents = sqlx::query_as::<_, QueriedHistoricDocument>(
             "SELECT
-                nr.documentId, nr.title, nr.snippet, nr.url
-            FROM HistoricDocument AS hd
-            JOIN NewsResource AS nr ON hd.documentId = nr.documentId;",
+                hd.documentId, nr.title, nr.snippet, nr.url
+            FROM HistoricDocument   AS hd
+            JOIN NewsResource       AS nr   USING documentId;",
         )
         .persistent(false)
         .fetch_all(&mut tx)
@@ -472,8 +472,8 @@ impl SearchScope for SqliteStorage {
         let ids = query_builder
             .push(
                 "SELECT ur.documentId
-                FROM UserReaction AS ur
-                JOIN SearchDocument AS sd ON ur.documentId = sd.documentID
+                FROM UserReaction   AS ur
+                JOIN SearchDocument AS sd   USING documentId
                 WHERE ur.userReaction = ?;",
             )
             .build()


### PR DESCRIPTION
- use explicit `JOIN` instead of the `,` alias
- add the `ON` per-join instead of relying on sqlite handling compound `ON` nicely

Reason: We will have some `LEFT JOIN`s in the future at which point the previous stile stops working nicely.