### PR TITLE
[Merged by Bors] - More strict justfile

### DIFF
--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0-only"
 edition = "2021"
 
 [dependencies]
-async-bindgen = { path="../async-bindgen/async-bindgen" }
+async-bindgen = { path = "../async-bindgen/async-bindgen" }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.19", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }


### PR DESCRIPTION
Now the `rust-check` task can pass even if `cargo clippy` returns an error. This is because we are using `;` as a command separator and we didn't set `-e` as a bash option.

This PR set `-euxo pipefail` for the main shell and all the shell that we use to make it fail early.