### PR TITLE
[Merged by Bors] - TY-2978 move active search logic to rust (0): activeSearchRequested

### DIFF
--- a/discovery_engine/lib/discovery_engine.dart
+++ b/discovery_engine/lib/discovery_engine.dart
@@ -31,4 +31,4 @@ export 'package:xayn_discovery_engine/src/worker/common/exceptions.dart';
 void discoveryEngineInitLogger(Logger logger) => initLogger(logger);
 Logger get discoveryEngineLogger => logger;
 
-const kCfgFeatureStorage = false;
+const cfgFeatureStorage = false;

--- a/discovery_engine/lib/discovery_engine.dart
+++ b/discovery_engine/lib/discovery_engine.dart
@@ -30,3 +30,5 @@ export 'package:xayn_discovery_engine/src/worker/common/exceptions.dart';
 
 void discoveryEngineInitLogger(Logger logger) => initLogger(logger);
 Logger get discoveryEngineLogger => logger;
+
+const kCfgFeatureStorage = false;

--- a/discovery_engine/lib/src/api/models/active_search.dart
+++ b/discovery_engine/lib/src/api/models/active_search.dart
@@ -30,8 +30,8 @@ part 'active_search.g.dart';
 @freezed
 class ActiveSearch with _$ActiveSearch {
   const factory ActiveSearch({
-    required String searchTerm,
     required SearchBy searchBy,
+    required String searchTerm,
   }) = _ActiveSearch;
 
   factory ActiveSearch.fromJson(Map<String, Object?> json) =>
@@ -41,5 +41,5 @@ class ActiveSearch with _$ActiveSearch {
 @protected
 extension ActiveSearchApiConversion on domain.ActiveSearch {
   ActiveSearch toApiRepr() =>
-      ActiveSearch(searchTerm: searchTerm, searchBy: searchBy);
+      ActiveSearch(searchBy: searchBy, searchTerm: searchTerm);
 }

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -39,7 +39,7 @@ import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
 
 /// Interface to Discovery Engine core.
 abstract class Engine {
-  /// Serializes the state of the [Engine] state.
+  /// Serializes the state of the [Engine].
   Future<Uint8List> serialize();
 
   /// Changes the currently supported markets.

--- a/discovery_engine/lib/src/domain/models/active_search.dart
+++ b/discovery_engine/lib/src/domain/models/active_search.dart
@@ -22,25 +22,32 @@ part 'active_search.g.dart';
 
 /// [ActiveSearch] represents attributes of a performed search.
 @HiveType(typeId: searchTypeId)
+// TODO: after DB migration
+// - rename `ActiveSearch` -> `Search` to match the rust side
+// - remove api/ActiveSearch & expose domain/ActiveSearch instead
+// - reorder arguments in the public events to have 1. `by` & 2. `term` to match the logical order of the rust side
 class ActiveSearch with EquatableMixin {
+  // TODO: rename `searchBy` -> `by` & `searchTerm` -> `term` to reduce redundancy & to match the rust side after DB migration
+  @HiveField(3, defaultValue: SearchBy.query)
+  final SearchBy searchBy;
   @HiveField(0)
   final String searchTerm;
+
+  // TODO: remove these fields after DB migration
   @HiveField(1)
   int requestedPageNb;
   @HiveField(2)
   final int pageSize;
-  @HiveField(3, defaultValue: SearchBy.query)
-  final SearchBy searchBy;
 
   ActiveSearch({
+    required this.searchBy,
     required this.searchTerm,
     required this.requestedPageNb,
     required this.pageSize,
-    required this.searchBy,
   });
 
   @override
-  List<Object?> get props => [searchTerm, requestedPageNb, pageSize, searchBy];
+  List<Object?> get props => [searchBy, searchTerm, requestedPageNb, pageSize];
 }
 
 @HiveType(typeId: searchByTypeId)

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:xayn_discovery_engine/discovery_engine.dart'
-    show kCfgFeatureStorage;
+    show cfgFeatureStorage;
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show SearchClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
@@ -120,7 +120,7 @@ class SearchManager {
     SearchBy by,
     String term,
   ) async {
-    if (kCfgFeatureStorage) {
+    if (cfgFeatureStorage) {
       final search = ActiveSearch(searchBy: by, searchTerm: term);
       const page = 1;
       final pageSize = _config.maxSearchDocs;

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -12,12 +12,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import 'package:xayn_discovery_engine/discovery_engine.dart'
+    show kCfgFeatureStorage;
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show SearchClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show EngineEvent, SearchFailureReason;
 import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
-    show ActiveSearchApiConversion;
+    show ActiveSearch, ActiveSearchApiConversion, SearchBy;
 import 'package:xayn_discovery_engine/src/api/models/document.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
@@ -26,7 +28,7 @@ import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
-    show ActiveSearch, SearchBy;
+    as domain show ActiveSearch;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show Document, UserReaction;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
@@ -67,7 +69,7 @@ class SearchManager {
   /// Fails if [event] does not have a handler implemented.
   Future<EngineEvent> handleSearchClientEvent(SearchClientEvent event) =>
       event.maybeWhen(
-        activeSearchRequested: activeSearchRequested,
+        activeSearchRequested: (term, by) => activeSearchRequested(by, term),
         nextActiveSearchBatchRequested: nextActiveSearchBatchRequested,
         restoreActiveSearchRequested: restoreActiveSearchRequested,
         activeSearchClosed: activeSearchClosed,
@@ -79,7 +81,7 @@ class SearchManager {
       );
 
   Future<List<api.Document>> _getActiveSearchDocuments(
-    ActiveSearch search,
+    domain.ActiveSearch search,
   ) async {
     final List<DocumentWithActiveData> searchDocs;
 
@@ -115,19 +117,51 @@ class SearchManager {
 
   /// Obtain the first batch of active search documents and persist to repositories.
   Future<EngineEvent> activeSearchRequested(
-    String searchTerm,
-    SearchBy searchBy,
+    SearchBy by,
+    String term,
   ) async {
+    if (kCfgFeatureStorage) {
+      final search = ActiveSearch(searchBy: by, searchTerm: term);
+      const page = 1;
+      final pageSize = _config.maxSearchDocs;
+      final List<DocumentWithActiveData> docs;
+      try {
+        switch (search.searchBy) {
+          case SearchBy.query:
+            docs =
+                await _engine.searchByQuery(search.searchTerm, page, pageSize);
+            break;
+          case SearchBy.topic:
+            docs =
+                await _engine.searchByTopic(search.searchTerm, page, pageSize);
+            break;
+        }
+      } on Exception catch (e) {
+        if (e.toString().contains('Search request failed: open search')) {
+          return const EngineEvent.activeSearchRequestFailed(
+            SearchFailureReason.openActiveSearch,
+          );
+        }
+        rethrow;
+      }
+      await _engineStateRepo.save(await _engine.serialize());
+
+      return EngineEvent.activeSearchRequestSucceeded(
+        search,
+        docs.map((doc) => doc.document.toApiRepr()).toList(),
+      );
+    }
+
     if (await _searchRepo.getCurrent() != null) {
       const reason = SearchFailureReason.openActiveSearch;
       return const EngineEvent.activeSearchRequestFailed(reason);
     }
 
-    final search = ActiveSearch(
-      searchTerm: searchTerm,
+    final search = domain.ActiveSearch(
+      searchBy: by,
+      searchTerm: term,
       requestedPageNb: 1,
       pageSize: _config.maxSearchDocs,
-      searchBy: searchBy,
     );
     final docs = await _getActiveSearchDocuments(search);
     await _searchRepo.save(search);

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -107,7 +107,6 @@ class DiscoveryEngineFfi implements Engine {
     return DiscoveryEngineFfi._(boxedEngine);
   }
 
-  /// Serializes the engine.
   @override
   Future<Uint8List> serialize() async {
     final result = await asyncFfi.serialize(_engine.ref);
@@ -115,7 +114,6 @@ class DiscoveryEngineFfi implements Engine {
     return resultVecU8StringFfiAdapter.consumeNative(result);
   }
 
-  /// Sets the markets.
   @override
   Future<void> setMarkets(
     final List<HistoricDocument> history,
@@ -132,7 +130,6 @@ class DiscoveryEngineFfi implements Engine {
     return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
-  /// Sets the excluded sources.
   @override
   Future<void> setExcludedSources(
     List<HistoricDocument> history,
@@ -165,7 +162,6 @@ class DiscoveryEngineFfi implements Engine {
     return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
-  /// Gets feed documents.
   @override
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     final List<HistoricDocument> history,
@@ -184,16 +180,12 @@ class DiscoveryEngineFfi implements Engine {
         .toDocumentListWithActiveData();
   }
 
-  /// Processes time spent.
   @override
   Future<void> timeSpent(final TimeSpent timeSpent) async {
     final boxedTimeSpent = timeSpent.allocNative();
     await asyncFfi.timeSpent(_engine.ref, boxedTimeSpent.move());
   }
 
-  /// Processes user reaction.
-  ///
-  /// The history is only required for positive reactions.
   @override
   Future<void> userReacted(
     final List<HistoricDocument>? history,
@@ -211,7 +203,6 @@ class DiscoveryEngineFfi implements Engine {
     return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
-  /// Performs an active search by query.
   @override
   Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
@@ -231,7 +222,6 @@ class DiscoveryEngineFfi implements Engine {
         .toDocumentListWithActiveData(isSearched: true);
   }
 
-  /// Performs an active search by topic.
   @override
   Future<List<DocumentWithActiveData>> searchByTopic(
     String topic,
@@ -251,10 +241,6 @@ class DiscoveryEngineFfi implements Engine {
         .toDocumentListWithActiveData(isSearched: true);
   }
 
-  /// Performs a deep search by term and market.
-  ///
-  /// The documents are sorted in descending order wrt their cosine similarity towards the
-  /// original search term embedding.
   @override
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
@@ -273,7 +259,6 @@ class DiscoveryEngineFfi implements Engine {
         .toDocumentListWithActiveData();
   }
 
-  /// Returns the currently trending topics.
   @override
   Future<List<TrendingTopic>> getTrendingTopics() async {
     final result = await asyncFfi.trendingTopics(_engine.ref);
@@ -283,7 +268,6 @@ class DiscoveryEngineFfi implements Engine {
         .toTrendingTopicList();
   }
 
-  /// Disposes the engine.
   @override
   Future<void> dispose() async {
     await _engine.free();

--- a/discovery_engine/test/discovery_engine/utils/utils.dart
+++ b/discovery_engine/test/discovery_engine/utils/utils.dart
@@ -236,8 +236,8 @@ List<DocumentWithActiveData> mockDocuments(
 const queryTerm = 'example';
 
 final mockActiveSearch = ActiveSearch(
+  searchBy: SearchBy.query,
   searchTerm: queryTerm,
   requestedPageNb: 1,
   pageSize: 20,
-  searchBy: SearchBy.query,
 );

--- a/discovery_engine/test/repository/hive_active_search_repo_test.dart
+++ b/discovery_engine/test/repository/hive_active_search_repo_test.dart
@@ -27,10 +27,10 @@ Future<void> main() async {
     late HiveActiveSearchRepository repo;
 
     final search = ActiveSearch(
+      searchBy: SearchBy.query,
       searchTerm: 'example search query',
       requestedPageNb: 1,
       pageSize: 10,
-      searchBy: SearchBy.query,
     );
 
     setUpAll(() async {
@@ -94,10 +94,10 @@ Future<void> main() async {
         await repo.save(search);
 
         final search2 = ActiveSearch(
+          searchBy: SearchBy.query,
           searchTerm: 'foobar',
           requestedPageNb: 123,
           pageSize: 10,
-          searchBy: SearchBy.query,
         );
         await repo.save(search2);
 

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -142,15 +142,15 @@ Future<void> main() async {
         await docRepo.updateMany([doc1, doc2]);
 
         final newSearch = ActiveSearch(
+          searchBy: SearchBy.query,
           searchTerm: 'example query',
           requestedPageNb: 1,
           pageSize: config.maxSearchDocs,
-          searchBy: SearchBy.query,
         );
 
         await searchRepo.clear();
         final response =
-            await mgr.activeSearchRequested('example query', SearchBy.query);
+            await mgr.activeSearchRequested(SearchBy.query, 'example query');
 
         expect(searchRepo.getCurrent(), completion(equals(newSearch)));
         expect(response, isA<ActiveSearchRequestSucceeded>());

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -589,11 +589,11 @@ impl Engine {
         }
 
         #[cfg(feature = "storage")]
-        if let Ok((search, _)) = self.storage.search().fetch().await {
-            if search.search_by != storage::models::SearchBy::Query || search.search_term != query {
-                return Err(storage::Error::OpenSearch.into());
-            }
-        }
+        match self.storage.search().fetch().await {
+            Ok(_) => return Err(storage::Error::OpenSearch.into()),
+            Err(storage::Error::NoSearch) => { /* continue */ }
+            Err(error) => return Err(error.into()),
+        };
 
         let filter = &Filter::default().add_keyword(&query);
         let documents = self
@@ -632,11 +632,11 @@ impl Engine {
         }
 
         #[cfg(feature = "storage")]
-        if let Ok((search, _)) = self.storage.search().fetch().await {
-            if search.search_by != storage::models::SearchBy::Topic || search.search_term != topic {
-                return Err(storage::Error::OpenSearch.into());
-            }
-        }
+        match self.storage.search().fetch().await {
+            Ok(_) => return Err(storage::Error::OpenSearch.into()),
+            Err(storage::Error::NoSearch) => { /* continue */ }
+            Err(error) => return Err(error.into()),
+        };
 
         let documents = self
             .active_search(SearchBy::Topic(topic), page, page_size)

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -29,6 +29,8 @@ pub(crate) type BoxedStorage = Box<dyn Storage + Send + Sync>;
 pub enum Error {
     /// Database error: {0}
     Database(#[source] GenericError),
+    /// Search request failed: open search
+    OpenSearch,
 }
 
 #[async_trait]

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -31,6 +31,8 @@ pub enum Error {
     Database(#[source] GenericError),
     /// Search request failed: open search
     OpenSearch,
+    /// Search request failed: no search
+    NoSearch,
 }
 
 #[async_trait]

--- a/discovery_engine_core/providers/src/helpers/expression.rs
+++ b/discovery_engine_core/providers/src/helpers/expression.rs
@@ -76,7 +76,7 @@ impl Expr {
         }
     }
 
-    /// Crate a new expression where all items in the iterator are in "or" with each other.
+    /// Create a new expression where all items in the iterator are in "or" with each other.
     pub(crate) fn or_from_iter(exprs: impl Iterator<Item = impl Into<Expr>>) -> Expr {
         let (ors, exprs): (BTreeSet<_>, BTreeSet<_>) = exprs.partition_map(|expr| {
             let expr = expr.into();


### PR DESCRIPTION
**References**

- [TY-2978]
- followed by #506

**Summary**

- add `cfgFeatureStorage` constant as a pseudo feature flag in dart
- store new searches in `Engine::search_by_query()` & `Engine::search_by_topic()` in rust
- remove corresponding db calls in `SearchManager.activeSearchRequested()` in dart
- prepare `ActiveSearch` cleanup


[TY-2978]: https://xainag.atlassian.net/browse/TY-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ