### PR TITLE
[Merged by Bors] - TY-2978 move active search logic to rust (2): nextActiveSearchBatchRequested

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -98,6 +98,9 @@ abstract class Engine {
     int pageSize,
   );
 
+  /// Gets the next batch of the current active search.
+  Future<List<DocumentWithActiveData>> searchNextBatch();
+
   /// Gets the current active search mode and term.
   Future<ActiveSearch> searchedBy();
 

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -144,6 +144,12 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> searchNextBatch() async {
+    _incrementCount('searchNextBatch');
+    return activeSearchDocuments.take(10).toList(growable: false);
+  }
+
+  @override
   Future<ActiveSearch> searchedBy() async {
     _incrementCount('searchedBy');
     return ActiveSearch(

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -245,6 +245,15 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> searchNextBatch() async {
+    final result = await asyncFfi.searchNextBatch(_engine.ref);
+
+    return resultVecDocumentStringFfiAdapter
+        .consumeNative(result)
+        .toDocumentListWithActiveData(isSearched: true);
+  }
+
+  @override
   Future<ActiveSearch> searchedBy() async {
     final result = await asyncFfi.searchedBy(_engine.ref);
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -195,6 +195,19 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
+    /// Gets the next batch of the current active search.
+    pub async fn search_next_batch(engine: &SharedEngine) -> Box<Result<Vec<Document>, String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .search_next_batch()
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
     /// Gets the current active search mode and term.
     pub async fn searched_by(engine: &SharedEngine) -> Box<Result<Search, String>> {
         Box::new(


### PR DESCRIPTION
**References**

- [TY-2978]
- requires #506
- followed by #509

**Summary**

- add `Engine::search_next_batch()` & corresponding ffi
- use new logic & remove corresponding db calls in `SearchManager.nextActiveSearchBatchRequested()` in dart


[TY-2978]: https://xainag.atlassian.net/browse/TY-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ