### PR TITLE
[Merged by Bors] - TY-2978 move active search logic to rust (3): restoreActiveSearchRequested

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -102,7 +102,7 @@ abstract class Engine {
   Future<List<DocumentWithActiveData>> searchNextBatch();
 
   /// Restores the current active search, ordered by their global rank (timestamp & local rank).
-  Future<List<DocumentWithActiveData>> searched();
+  Future<List<DocumentWithActiveData>> restoreSearch();
 
   /// Gets the current active search mode and term.
   Future<ActiveSearch> searchedBy();

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -101,6 +101,9 @@ abstract class Engine {
   /// Gets the next batch of the current active search.
   Future<List<DocumentWithActiveData>> searchNextBatch();
 
+  /// Restores the current active search, ordered by their global rank (timestamp & local rank).
+  Future<List<DocumentWithActiveData>> searched();
+
   /// Gets the current active search mode and term.
   Future<ActiveSearch> searchedBy();
 

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -150,7 +150,7 @@ class MockEngine implements Engine {
   }
 
   @override
-  Future<List<DocumentWithActiveData>> searched() async {
+  Future<List<DocumentWithActiveData>> restoreSearch() async {
     _incrementCount('searched');
     return activeSearchDocuments.take(10).toList(growable: false);
   }

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -150,6 +150,12 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> searched() async {
+    _incrementCount('searched');
+    return activeSearchDocuments.take(10).toList(growable: false);
+  }
+
+  @override
   Future<ActiveSearch> searchedBy() async {
     _incrementCount('searchedBy');
     return ActiveSearch(

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -218,7 +218,7 @@ class SearchManager {
       final List<DocumentWithActiveData> docs;
       try {
         search = await _engine.searchedBy();
-        docs = await _engine.searched();
+        docs = await _engine.restoreSearch();
       } on Exception catch (e) {
         if (e.toString().contains('Search request failed: no search')) {
           return const EngineEvent.nextActiveSearchBatchRequestFailed(

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -254,8 +254,8 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
-  Future<List<DocumentWithActiveData>> searched() async {
-    final result = await asyncFfi.searched(_engine.ref);
+  Future<List<DocumentWithActiveData>> restoreSearch() async {
+    final result = await asyncFfi.restoreSearch(_engine.ref);
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -254,6 +254,15 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> searched() async {
+    final result = await asyncFfi.searched(_engine.ref);
+
+    return resultVecDocumentStringFfiAdapter
+        .consumeNative(result)
+        .toDocumentListWithActiveData(isSearched: true);
+  }
+
+  @override
   Future<ActiveSearch> searchedBy() async {
     final result = await asyncFfi.searchedBy(_engine.ref);
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -208,6 +208,19 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
+    /// Restores the current active search, ordered by their global rank (timestamp & local rank).
+    pub async fn searched(engine: &SharedEngine) -> Box<Result<Vec<Document>, String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .searched()
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
     /// Gets the current active search mode and term.
     pub async fn searched_by(engine: &SharedEngine) -> Box<Result<Search, String>> {
         Box::new(

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -209,13 +209,13 @@ impl XaynDiscoveryEngineAsyncFfi {
     }
 
     /// Restores the current active search, ordered by their global rank (timestamp & local rank).
-    pub async fn searched(engine: &SharedEngine) -> Box<Result<Vec<Document>, String>> {
+    pub async fn restore_search(engine: &SharedEngine) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .searched()
+                .restore_search()
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -700,7 +700,8 @@ impl Engine {
     }
 
     /// Restores the current active search, ordered by their global rank (timestamp & local rank).
-    pub async fn searched(&self) -> Result<Vec<Document>, Error> {
+    // TODO: rename methods to `searched()` and adjust events & docs accordingly after DB migration
+    pub async fn restore_search(&self) -> Result<Vec<Document>, Error> {
         #[cfg(feature = "storage")]
         {
             let (_, documents) = self.storage.search().fetch().await?;

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -699,6 +699,23 @@ impl Engine {
         unimplemented!("requires 'storage' feature")
     }
 
+    /// Restores the current active search, ordered by their global rank (timestamp & local rank).
+    pub async fn searched(&self) -> Result<Vec<Document>, Error> {
+        #[cfg(feature = "storage")]
+        {
+            let (_, documents) = self.storage.search().fetch().await?;
+            let documents = documents
+                .into_iter()
+                .map(|document| document.into_document(StackId::nil()))
+                .collect();
+
+            return Ok(documents);
+        }
+
+        #[cfg(not(feature = "storage"))]
+        unimplemented!("requires 'storage' feature")
+    }
+
     /// Gets the current active search mode and term.
     pub async fn searched_by(&self) -> Result<SearchBy<'_>, Error> {
         #[cfg(feature = "storage")]

--- a/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
@@ -50,3 +50,10 @@ CREATE TABLE IF NOT EXISTS NewscatcherData (
     domainRank BIGINT NOT NULL,
     score REAL
 );
+
+CREATE TABLE IF NOT EXISTS Embedding(
+    documentId BLOB NOT NULL
+        PRIMARY KEY
+        REFERENCES Document(id) ON DELETE CASCADE,
+    embedding BLOB NOT NULL
+);

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -25,6 +25,7 @@ use sqlx::{
     Transaction,
 };
 use url::Url;
+use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
@@ -192,6 +193,20 @@ impl SqliteStorage {
                 .execute(&mut *tx)
                 .await
                 .map_err(|err| Error::Database(err.into()))?;
+
+            // insert data into Embedding table
+            query_builder
+                .reset()
+                .push("Embedding (documentId, embedding) ")
+                .push_values(documents, |mut stm, doc| {
+                    stm.push_bind(&doc.id)
+                        .push_bind(doc.embedding.to_ne_bytes());
+                })
+                .build()
+                .persistent(false)
+                .execute(&mut *tx)
+                .await
+                .map_err(|err| Error::Database(err.into()))?;
         }
 
         Ok(())
@@ -300,12 +315,13 @@ impl FeedScope for SqliteStorage {
             "SELECT
                 fd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
-                ur.userReaction, po.inBatchIndex
+                ur.userReaction, po.inBatchIndex, em.embedding
             FROM FeedDocument           AS fd
             JOIN NewsResource           AS nr   USING(documentId)
             JOIN NewscatcherData        AS nc   USING(documentId)
             JOIN PresentationOrdering   AS po   USING(documentId)
             JOIN UserReaction           AS ur   USING(documentId)
+            JOIN Embedding              AS em   USING(documentId)
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
         )
         .persistent(false)
@@ -446,12 +462,13 @@ impl SearchScope for SqliteStorage {
             .push(
                 "sd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
-                ur.userReaction, po.inBatchIndex
+                ur.userReaction, po.inBatchIndex, em.embedding
             FROM SearchDocument         AS sd
             JOIN NewsResource           AS nr   USING(documentId)
             JOIN NewscatcherData        AS nc   USING(documentId)
             JOIN PresentationOrdering   AS po   USING(documentId)
             JOIN UserReaction           AS ur   USING(documentId)
+            JOIN Embedding              AS em   USING(documentId)
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
             )
             .build()
@@ -564,6 +581,7 @@ struct QueriedApiDocumentView {
     score: Option<f32>,
     user_reaction: Option<u32>,
     in_batch_index: u32,
+    embedding: Vec<u8>,
 }
 
 impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
@@ -606,10 +624,13 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             .user_reaction
             .map(|value| {
                 UserReaction::from_u32(value).ok_or_else(|| {
-                    Error::Database(format!("Failed to convert {value} to UserReaction",).into())
+                    Error::Database(format!("Failed to convert {value} to UserReaction").into())
                 })
             })
             .transpose()?;
+        let embedding = Embedding::from_ne_bytes(&doc.embedding).map_err(|err| {
+            Error::Database(format!("Failed to convert bytes to Embedding: {err}").into())
+        })?;
 
         Ok(ApiDocumentView {
             document_id: doc.document_id,
@@ -617,6 +638,7 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             newscatcher_data,
             user_reacted,
             in_batch_index: doc.in_batch_index,
+            embedding,
         })
     }
 }


### PR DESCRIPTION
**References**

- [TY-2978]
- requires #507
- followed by #510

**Summary**

- add native bytes conversion for `Embedding`
- add `Embedding` db migration & store the embedding in `SqliteStorage::store_new_documents()` & query it for `QueriedApiDocumentView`
- add `Engine::searched()` & corresponding ffi
- use new logic & remove corresponding db calls in `SearchManager.restoreActiveSearchRequested()` in dart


[TY-2978]: https://xainag.atlassian.net/browse/TY-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ