### PR TITLE
[Merged by Bors] - TY-2978 move active search logic to rust (4): activeSearchClosed

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -107,6 +107,9 @@ abstract class Engine {
   /// Gets the current active search mode and term.
   Future<ActiveSearch> searchedBy();
 
+  /// Closes the current active search.
+  Future<void> closeSearch();
+
   /// Performs a deep search by term and market.
   ///
   /// The documents are sorted in descending order wrt their cosine similarity towards the

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -167,6 +167,11 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<void> closeSearch() async {
+    _incrementCount('closeSearch');
+  }
+
+  @override
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
     FeedMarket market,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -360,6 +360,21 @@ class SearchManager {
 
   /// Clear the active search and deactivate interacted search documents.
   Future<EngineEvent> activeSearchClosed() async {
+    if (cfgFeatureStorage) {
+      try {
+        await _engine.closeSearch();
+      } on Exception catch (e) {
+        if (e.toString().contains('Search request failed: no search')) {
+          return const EngineEvent.activeSearchTermRequestFailed(
+            SearchFailureReason.noActiveSearch,
+          );
+        }
+        rethrow;
+      }
+
+      return const EngineEvent.activeSearchClosedSucceeded();
+    }
+
     if (await _searchRepo.getCurrent() == null) {
       const reason = SearchFailureReason.noActiveSearch;
       return const EngineEvent.activeSearchClosedFailed(reason);

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -270,6 +270,13 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
+  Future<void> closeSearch() async {
+    final result = await asyncFfi.closeSearch(_engine.ref);
+
+    return resultVoidStringFfiAdapter.consumeNative(result);
+  }
+
+  @override
   Future<List<DocumentWithActiveData>> deepSearch(
     String term,
     FeedMarket market,

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -235,6 +235,19 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
+    /// Closes the current active search.
+    pub async fn close_search(engine: &SharedEngine) -> Box<Result<(), String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .close_search()
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
     /// Performs a deep search by term and market.
     ///
     /// The documents are sorted in descending order wrt their cosine similarity towards the

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -736,6 +736,21 @@ impl Engine {
         unimplemented!("requires 'storage' feature")
     }
 
+    /// Closes the current active search.
+    pub async fn close_search(&self) -> Result<(), Error> {
+        #[cfg(feature = "storage")]
+        {
+            return if self.storage.search().clear().await? {
+                Ok(())
+            } else {
+                Err(Error::Storage(storage::Error::NoSearch))
+            };
+        }
+
+        #[cfg(not(feature = "storage"))]
+        unimplemented!("requires 'storage' feature")
+    }
+
     async fn active_search(
         &self,
         by: SearchBy<'_>,


### PR DESCRIPTION
**References**

- [TY-2978]
- requires #509
- followed by #514

**Summary**

- add `Engine::close_search()` & corresponding ffi
- use new logic & remove corresponding db calls in `SearchManager.activeSearchClosed()` in dart


[TY-2978]: https://xainag.atlassian.net/browse/TY-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ