### PR TITLE
[Merged by Bors] - TY-3029 align clear methods return type

### DIFF
--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -46,7 +46,7 @@ pub(crate) trait Storage {
 pub(crate) trait FeedScope {
     async fn close_document(&self, document: &document::Id) -> Result<(), Error>;
 
-    async fn clear(&self) -> Result<(), Error>;
+    async fn clear(&self) -> Result<bool, Error>;
 
     async fn fetch(&self) -> Result<Vec<ApiDocumentView>, Error>;
 


### PR DESCRIPTION
**References**

- [TY-3029]
- https://github.com/xaynetwork/xayn_discovery_engine/pull/483#discussion_r924309401

**Summary**

- return `bool` in all storage trait `clear()` methods
- update confluence docs


[TY-3029]: https://xainag.atlassian.net/browse/TY-3029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ