### PR TITLE
[Merged by Bors] - TY-3082 More flexible json structure

### DIFF
--- a/discovery_engine_core/web-api/src/db.rs
+++ b/discovery_engine_core/web-api/src/db.rs
@@ -69,8 +69,20 @@ pub(crate) fn init_db(config: &InitConfig) -> Result<Db, Box<dyn std::error::Err
     let documents = articles
         .into_iter()
         .map(|article| {
-            let embedding = smbert.run(&article.description).unwrap();
-            let document = Document::new((article, embedding));
+            let id = article
+                .get("id")
+                .expect("Article needs to have an 'id' field")
+                .as_str()
+                .expect("The 'id' field needs to be represented as String")
+                .try_into()
+                .expect("The 'id' field needs to be a valid UUID");
+            let description = article
+                .get("description")
+                .expect("Article needs to have a 'description' field")
+                .as_str()
+                .expect("The 'description' field needs to be represented as String");
+            let embedding = smbert.run(description).unwrap();
+            let document = Document::new((id, article, embedding));
             (document.id, document)
         })
         .collect();

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle_ranked_documents(
 
     let articles = documents
         .into_iter()
-        .map(Article::from)
+        .map(|doc| doc.article)
         .collect::<Vec<Article>>();
 
     Ok(warp::reply::json(&articles))

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle_ranked_documents(
 
     let articles = documents
         .into_iter()
-        .map(|doc| doc.article)
+        .map(Article::from)
         .collect::<Vec<Article>>();
 
     Ok(warp::reply::json(&articles))

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -61,6 +61,12 @@ impl AiDocument for Document {
 /// Represents an article that is stored and loaded from local json file.
 pub(crate) type Article = HashMap<String, serde_json::Value>;
 
+impl From<Document> for Article {
+    fn from(doc: Document) -> Self {
+        doc.article
+    }
+}
+
 /// Represents user interaction request body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct InteractionRequestBody {

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -15,7 +15,7 @@
 use chrono::{NaiveDateTime, Utc};
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use uuid::Uuid;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, DocumentId, Embedding};
@@ -30,15 +30,15 @@ pub(crate) struct Document {
     /// Embedding from smbert.
     pub(crate) smbert_embedding: Embedding,
 
-    /// Snippet of the resource.
-    pub(crate) snippet: String,
+    /// Contents of the article.
+    pub(crate) article: Article,
 }
 
 impl Document {
-    pub(crate) fn new((article, smbert_embedding): (Article, Embedding)) -> Self {
+    pub(crate) fn new((id, article, smbert_embedding): (Uuid, Article, Embedding)) -> Self {
         Self {
-            id: article.id.into(),
-            snippet: article.description,
+            id: id.into(),
+            article,
             smbert_embedding,
         }
     }
@@ -59,20 +59,7 @@ impl AiDocument for Document {
 }
 
 /// Represents an article that is stored and loaded from local json file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Article {
-    pub(crate) id: Uuid,
-    pub(crate) description: String,
-}
-
-impl From<Document> for Article {
-    fn from(doc: Document) -> Self {
-        Self {
-            id: doc.id.into(),
-            description: doc.snippet,
-        }
-    }
-}
+pub(crate) type Article = HashMap<String, serde_json::Value>;
 
 /// Represents user interaction request body.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
**Summary:**
- changed `Article` type to be more flexible, but still required to contain at least `id` and `description` fields

**References:**
- [TY-3082]

[TY-3082]: https://xainag.atlassian.net/browse/TY-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ