### PR TITLE
[Merged by Bors] - TY-2978 move active search logic to rust (5): deepSearchRequested

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -36,6 +36,8 @@ import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
     show TrendingTopic;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 
@@ -97,6 +99,12 @@ abstract class Engine {
     int page,
     int pageSize,
   );
+
+  /// Performs an active search by document id (aka deep search).
+  ///
+  /// The documents are sorted in descending order wrt their cosine similarity towards the
+  /// original search term embedding.
+  Future<List<DocumentWithActiveData>> searchById(DocumentId id);
 
   /// Gets the next batch of the current active search.
   Future<List<DocumentWithActiveData>> searchNextBatch();

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -33,6 +33,8 @@ import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
     show TrendingTopic;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 
@@ -141,6 +143,12 @@ class MockEngine implements Engine {
   ) async {
     _incrementCount('searchByTopic');
     return activeSearchDocuments.take(pageSize).toList(growable: false);
+  }
+
+  @override
+  Future<List<DocumentWithActiveData>> searchById(DocumentId id) async {
+    _incrementCount('searchById');
+    return deepSearchDocuments;
   }
 
   @override

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -34,6 +34,8 @@ import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
     show TimeSpent;
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
     show TrendingTopic;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
@@ -70,6 +72,8 @@ import 'package:xayn_discovery_engine/src/ffi/types/string.dart'
     show StringFfi, StringListFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/trending_topic_vec.dart'
     show TrendingTopicSliceFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
+    show DocumentIdFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/weighted_source_vec.dart'
     show WeightedSourceListFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
@@ -242,6 +246,16 @@ class DiscoveryEngineFfi implements Engine {
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)
         .toDocumentListWithActiveData(isSearched: true);
+  }
+
+  @override
+  Future<List<DocumentWithActiveData>> searchById(DocumentId id) async {
+    final result =
+        await asyncFfi.searchById(_engine.ref, id.allocNative().move());
+
+    return resultVecDocumentStringFfiAdapter
+        .consumeNative(result)
+        .toDocumentListWithActiveData();
   }
 
   @override

--- a/discovery_engine/lib/src/ffi/types/uuid.dart
+++ b/discovery_engine/lib/src/ffi/types/uuid.dart
@@ -20,6 +20,7 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustUuid;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 
 extension DocumentIdFfi on DocumentId {
   void writeNative(final Pointer<RustUuid> place) {
@@ -28,6 +29,12 @@ extension DocumentIdFfi on DocumentId {
 
   static DocumentId readNative(final Pointer<RustUuid> place) {
     return DocumentId.fromBytes(_readUuid(place));
+  }
+
+  Boxed<RustUuid> allocNative() {
+    final place = ffi.alloc_uninitialized_uuid();
+    writeNative(place);
+    return Boxed(place, ffi.drop_uuid);
   }
 }
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -40,6 +40,8 @@ use std::path::Path;
 use xayn_discovery_engine_core::Engine;
 
 #[async_bindgen::api(
+    use uuid::Uuid;
+
     use xayn_discovery_engine_ai::Embedding;
     use xayn_discovery_engine_core::{
         document::{Document, HistoricDocument, TimeSpent, TrendingTopic, UserReacted, WeightedSource},
@@ -190,6 +192,25 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .lock()
                 .await
                 .search_by_topic(topic.as_ref(), page, page_size)
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
+    /// Performs an active search by document id (aka deep search).
+    ///
+    /// The documents are sorted in descending order wrt their cosine similarity towards the
+    /// original search term embedding.
+    pub async fn search_by_id(
+        engine: &SharedEngine,
+        id: Box<Uuid>,
+    ) -> Box<Result<Vec<Document>, String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .search_by_id((*id).into())
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -49,5 +49,4 @@ xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 
 [features]
 default = []
-
-storage = ["sqlx", "num-traits", "num-derive"]
+storage = ["num-derive", "num-traits", "sqlx"]

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -33,6 +33,8 @@ pub enum Error {
     OpenSearch,
     /// Search request failed: no search
     NoSearch,
+    /// Search request failed: no document
+    NoDocument,
 }
 
 #[async_trait]
@@ -75,6 +77,8 @@ pub(crate) trait SearchScope {
     async fn fetch(&self) -> Result<(Search, Vec<ApiDocumentView>), Error>;
 
     async fn clear(&self) -> Result<bool, Error>;
+
+    async fn get_document(&self, id: document::Id) -> Result<ApiDocumentView, Error>;
 }
 
 pub mod models {
@@ -167,6 +171,13 @@ pub mod models {
                 smbert_embedding: self.embedding,
                 resource: (self.news_resource, self.newscatcher_data).into(),
             }
+        }
+
+        /// Gets the snippet or falls back to the title if the snippet is empty.
+        pub(crate) fn snippet_or_title(&self) -> &str {
+            (!self.news_resource.snippet.is_empty())
+                .then(|| &self.news_resource.snippet)
+                .unwrap_or(&self.news_resource.title)
         }
     }
 

--- a/discovery_engine_core/providers/src/models/content.rs
+++ b/discovery_engine_core/providers/src/models/content.rs
@@ -87,8 +87,8 @@ impl GenericArticle {
         self.url.domain().to_string()
     }
 
-    /// Gets the excerpt or falls back to the title if the excerpt is empty.
-    pub fn excerpt_or_title(&self) -> &str {
+    /// Gets the snippet or falls back to the title if the snippet is empty.
+    pub fn snippet_or_title(&self) -> &str {
         (!self.snippet.is_empty())
             .then(|| &self.snippet)
             .unwrap_or(&self.title)


### PR DESCRIPTION
**References**

- [TY-2978]
- requires #510

**Summary**

- add `Engine::search_by_id()` & corresponding ffi
- use new logic & remove corresponding db calls in `SearchManager.deepSearchRequested()` in dart


[TY-2978]: https://xainag.atlassian.net/browse/TY-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ