### PR TITLE
[Merged by Bors] - TY-2981 rust engine.user_reacted uses storage

### DIFF
--- a/discovery_engine/lib/src/api/models/document.dart
+++ b/discovery_engine/lib/src/api/models/document.dart
@@ -38,7 +38,9 @@ class Document with _$Document {
     required StackId stackId,
     required NewsResource resource,
     required UserReaction userReaction,
-    required int batchIndex,
+    @Deprecated('broken, will be removed from the public API')
+    @Default(0)
+        int batchIndex,
   }) = _Document;
 
   /// Converts json Map to [Document].
@@ -53,6 +55,5 @@ extension DocumentApiConversion on domain.Document {
         stackId: stackId,
         resource: resource,
         userReaction: userReaction,
-        batchIndex: batchIndex,
       );
 }

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -20,7 +20,7 @@ import 'package:xayn_discovery_engine/discovery_engine.dart'
         FeedMarket,
         StackId,
         UserReaction,
-        kCfgFeatureStorage;
+        cfgFeatureStorage;
 import 'package:xayn_discovery_engine/src/domain/changed_documents_reporter.dart'
     show ChangedDocumentsReporter;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
@@ -76,8 +76,8 @@ class DocumentManager {
     DocumentId id,
     UserReaction userReaction,
   ) async {
-    if (kCfgFeatureStorage) {
-      await _engine.userReacted(
+    if (cfgFeatureStorage) {
+      final document = await _engine.userReacted(
         null,
         //FIXME sources are not yet migrated
         await _sourceRepo.fetchAll(),
@@ -99,7 +99,7 @@ class DocumentManager {
       );
       await _engineStateRepo.save(await _engine.serialize());
       //TODO why do we send whole documents, instead of just ids
-      _changedDocsReporter.notifyChanged([/*doc is needed here*/]);
+      _changedDocsReporter.notifyChanged([document]);
       return;
     }
 

--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -82,8 +82,8 @@ class DocumentManager {
         //FIXME sources are not yet migrated
         await _sourceRepo.fetchAll(),
         // The engine will ignore all fields except the id and reaction,
-        // but while we have feature flags we will still have the other fields
-        // so we fill them with dummy data.
+        // but while we have feature flags we will still have to keep the
+        // other fields intact. But we can pass dummy data.
         UserReacted(
           id: id,
           stackId: StackId.nil(),
@@ -98,7 +98,6 @@ class DocumentManager {
         ),
       );
       await _engineStateRepo.save(await _engine.serialize());
-      //TODO why do we send whole documents, instead of just ids
       _changedDocsReporter.notifyChanged([document]);
       return;
     }

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -95,7 +95,7 @@ abstract class Engine {
   /// Process the user's reaction to a document.
   ///
   /// The history is only required if the reaction is positive and if
-/// `cfgFeatureStorage` is disabled.
+  /// `cfgFeatureStorage` is disabled.
   ///
   /// The returned `Document` will only be consistent if `cfgFeatureStorage`
   /// is enabled. The history and most fields of `UserReacted` can

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -23,6 +23,8 @@ import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
     show ActiveSearch;
 import 'package:xayn_discovery_engine/src/domain/models/configuration.dart'
     show Configuration;
+import 'package:xayn_discovery_engine/src/domain/models/document.dart'
+    show Document;
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
@@ -93,7 +95,11 @@ abstract class Engine {
   /// Process the user's reaction to a document.
   ///
   /// The history is only required for positive reactions.
-  Future<void> userReacted(
+  ///
+  /// The returned `Document` will only be consistent of `storage` feature is
+  /// enabled, the history and most fields of `UserReacted` can be empty/dummy
+  /// data if the `storage` feature is enabled.
+  Future<Document> userReacted(
     List<HistoricDocument>? history,
     List<SourceReacted> sources,
     UserReacted userReacted,

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -94,11 +94,12 @@ abstract class Engine {
 
   /// Process the user's reaction to a document.
   ///
-  /// The history is only required for positive reactions.
+  /// The history is only required if the reaction is positive and if
+/// `cfgFeatureStorage` is disabled.
   ///
-  /// The returned `Document` will only be consistent of `storage` feature is
-  /// enabled, the history and most fields of `UserReacted` can be empty/dummy
-  /// data if the `storage` feature is enabled.
+  /// The returned `Document` will only be consistent if `cfgFeatureStorage`
+  /// is enabled. The history and most fields of `UserReacted` can
+  /// be empty/dummy data if `cfgFeatureStorage` feature is enabled.
   Future<Document> userReacted(
     List<HistoricDocument>? history,
     List<SourceReacted> sources,

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -20,12 +20,16 @@ import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
     show ActiveSearch, SearchBy;
+import 'package:xayn_discovery_engine/src/domain/models/document.dart'
+    show Document;
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarket, FeedMarkets;
 import 'package:xayn_discovery_engine/src/domain/models/history.dart'
     show HistoricDocument;
+import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
+    show NewsResource;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
     show Source;
 import 'package:xayn_discovery_engine/src/domain/models/source_reacted.dart';
@@ -34,7 +38,7 @@ import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
     show TrendingTopic;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
-    show DocumentId;
+    show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 
@@ -140,12 +144,30 @@ class MockEngine implements Engine {
   }
 
   @override
-  Future<void> userReacted(
+  Future<Document> userReacted(
     List<HistoricDocument>? history,
     List<SourceReacted> sources,
     UserReacted userReacted,
   ) async {
     _incrementCount('userReacted');
+    return Document(
+      batchIndex: 0,
+      documentId: DocumentId(),
+      resource: NewsResource(
+        country: 'US',
+        datePublished: DateTime.now().toUtc(),
+        image: null,
+        language: '',
+        rank: 0,
+        score: null,
+        snippet: '',
+        sourceDomain: Source('foo.invalid'),
+        title: '',
+        topic: '',
+        url: Uri.parse('https://foo.invalid'),
+      ),
+      stackId: StackId(),
+    );
   }
 
   @override

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -108,8 +108,10 @@ class FeedManager {
                 doc.isSearched == false,
           )
           ..sort((doc1, doc2) {
+            // ignore: deprecated_member_use_from_same_package
             final timeOrd = doc1.timestamp.compareTo(doc2.timestamp);
             return timeOrd == 0
+                // ignore: deprecated_member_use_from_same_package
                 ? doc1.batchIndex.compareTo(doc2.batchIndex)
                 : timeOrd;
           });

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -48,6 +48,8 @@ class Document {
   @Deprecated('only available without `storage` enabled')
   @HiveField(6)
   DateTime timestamp;
+
+  /// Indicates if this [Document] was returned in response to active search.
   //soft deprecated, will be replaced with getter once we migrated to `storage`
   @HiveField(7)
   bool isSearched;

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -39,14 +39,16 @@ class Document {
   final NewsResource resource;
   @HiveField(3)
   UserReaction userReaction;
-  @HiveField(4)
-  final int batchIndex;
   @HiveField(5)
   bool isActive;
+
+  @Deprecated('only available without `storage` enabled')
+  @HiveField(4)
+  final int batchIndex;
+  @Deprecated('only available without `storage` enabled')
   @HiveField(6)
   DateTime timestamp;
-
-  /// Indicates if this [Document] was returned in response to active search.
+  //soft deprecated, will be replaced with getter once we migrated to `storage`
   @HiveField(7)
   bool isSearched;
 
@@ -61,11 +63,14 @@ class Document {
   Document({
     required this.stackId,
     required this.resource,
+    // ignore: deprecated_consistency
     required this.batchIndex,
     required this.documentId,
     this.userReaction = UserReaction.neutral,
     this.isActive = true,
+    // ignore: deprecated_consistency
     this.isSearched = false,
+    // ignore: deprecated_member_use_from_same_package
   }) : timestamp = DateTime.now().toUtc();
 }
 

--- a/discovery_engine/lib/src/domain/models/document.dart
+++ b/discovery_engine/lib/src/domain/models/document.dart
@@ -42,10 +42,10 @@ class Document {
   @HiveField(5)
   bool isActive;
 
-  @Deprecated('only available without `storage` enabled')
+  @Deprecated('only meaningful `cfgFeatureStorage` disabled')
   @HiveField(4)
   final int batchIndex;
-  @Deprecated('only available without `storage` enabled')
+  @Deprecated('only meaningful `cfgFeatureStorage` disabled')
   @HiveField(6)
   DateTime timestamp;
 

--- a/discovery_engine/lib/src/domain/models/unique_id.dart
+++ b/discovery_engine/lib/src/domain/models/unique_id.dart
@@ -15,7 +15,6 @@
 import 'dart:typed_data' show UnmodifiableUint8ListView, Uint8List;
 
 import 'package:equatable/equatable.dart' show EquatableMixin;
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:uuid/uuid.dart' show Uuid;
 
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
@@ -80,6 +79,5 @@ class StackId extends UniqueId {
   StackId() : super();
   StackId.fromBytes(Uint8List bytes) : super.fromBytes(bytes);
   StackId.fromJson(Map<String, Object> json) : super.fromJson(json);
-  @visibleForTesting
   StackId.nil() : super.fromBytes(Uint8List(16));
 }

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -250,8 +250,10 @@ class SearchManager {
     }
 
     searchDocs.sort((doc1, doc2) {
+      // ignore: deprecated_member_use_from_same_package
       final timeOrd = doc1.timestamp.compareTo(doc2.timestamp);
       return timeOrd == 0
+          // ignore: deprecated_member_use_from_same_package
           ? doc1.batchIndex.compareTo(doc2.batchIndex)
           : timeOrd;
     });

--- a/discovery_engine/lib/src/ffi/types/document/document.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document.dart
@@ -18,7 +18,7 @@ import 'package:equatable/equatable.dart' show EquatableMixin;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show ActiveDocumentData;
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
-    show Document;
+    show Document, UserReaction;
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/news_resource.dart'
@@ -30,6 +30,8 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/news_resource.dart'
     show NewsResourceFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/document/user_reaction.dart'
+    show OptionUserReactionFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/embedding.dart'
     show EmbeddingFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
@@ -40,16 +42,18 @@ class DocumentFfi with EquatableMixin {
   final StackId stackId;
   final Embedding smbertEmbedding;
   final NewsResource resource;
+  final UserReaction? reaction;
 
   DocumentFfi({
     required this.id,
     required this.stackId,
     required this.smbertEmbedding,
     required this.resource,
+    this.reaction,
   });
 
   @override
-  List<Object?> get props => [id, stackId, smbertEmbedding, resource];
+  List<Object?> get props => [id, stackId, smbertEmbedding, resource, reaction];
 
   factory DocumentFfi.readNative(final Pointer<RustDocument> place) {
     return DocumentFfi(
@@ -60,6 +64,9 @@ class DocumentFfi with EquatableMixin {
       ),
       resource:
           NewsResourceFfi.readNative(ffi.document_place_of_resource(place)),
+      reaction: OptionUserReactionFfi.readNative(
+        ffi.document_place_of_reaction(place),
+      ),
     );
   }
 
@@ -68,6 +75,7 @@ class DocumentFfi with EquatableMixin {
     stackId.writeNative(ffi.document_place_of_stack_id(place));
     smbertEmbedding.writeNative(ffi.document_place_of_smbert_embedding(place));
     resource.writeNative(ffi.document_place_of_resource(place));
+    reaction.writeNative(ffi.document_place_of_reaction(place));
   }
 
   Document toDocument({
@@ -81,6 +89,7 @@ class DocumentFfi with EquatableMixin {
         resource: resource,
         batchIndex: batchIndex,
         isSearched: isSearched,
+        userReaction: reaction ?? UserReaction.neutral,
       );
 
   ActiveDocumentData toActiveDocumentData() =>

--- a/discovery_engine/lib/src/ffi/types/document/document.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document.dart
@@ -71,7 +71,8 @@ class DocumentFfi with EquatableMixin {
   }
 
   Document toDocument({
-    required int batchIndex,
+    @Deprecated('only meaningful `cfgFeatureStorage` disabled')
+        int batchIndex = 0,
     bool isSearched = false,
   }) =>
       Document(

--- a/discovery_engine/lib/src/ffi/types/document/document_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/document/document_vec.dart
@@ -76,6 +76,7 @@ extension DocumentSliceFfi on List<DocumentFfi> {
           .entries
           .map(
             (e) => DocumentWithActiveData(
+              // ignore: deprecated_member_use_from_same_package
               e.value.toDocument(batchIndex: e.key, isSearched: isSearched),
               e.value.toActiveDocumentData(),
             ),

--- a/discovery_engine/lib/src/ffi/types/document/user_reaction.dart
+++ b/discovery_engine/lib/src/ffi/types/document/user_reaction.dart
@@ -12,12 +12,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show Pointer, Uint8Pointer;
+import 'dart:ffi' show Pointer, Uint8Pointer, nullptr;
 
 import 'package:xayn_discovery_engine/src/domain/models/document.dart'
     show UserReaction, UserReactionIntConversion;
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
-    show RustUserReaction1;
+    show RustOptionUserReaction, RustUserReaction1;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart';
 
 extension UserReactionFfi on UserReaction {
   void writeNative(final Pointer<RustUserReaction1> place) {
@@ -28,4 +29,30 @@ extension UserReactionFfi on UserReaction {
     final Pointer<RustUserReaction1> place,
   ) =>
       UserReactionIntConversion.fromIntRepr(place.value);
+}
+
+extension OptionUserReactionFfi on UserReaction? {
+  void writeNative(final Pointer<RustOptionUserReaction> place) {
+    final repr = this?.toIntRepr();
+    if (repr == null) {
+      ffi.init_option_user_reaction_none_at(place);
+    } else {
+      if (ffi.init_option_user_reaction_some_at(place, repr) != 1) {
+        throw ArgumentError(
+          'dart UserReaction incompatible with rust UserReaction',
+        );
+      }
+    }
+  }
+
+  static UserReaction? readNative(
+    final Pointer<RustOptionUserReaction> place,
+  ) {
+    final innerPlace = ffi.get_option_user_reaction_some_ptr(place);
+    if (innerPlace == nullptr) {
+      return null;
+    } else {
+      return UserReactionFfi.readNative(innerPlace);
+    }
+  }
 }

--- a/discovery_engine/lib/src/ffi/types/document/user_reaction.dart
+++ b/discovery_engine/lib/src/ffi/types/document/user_reaction.dart
@@ -48,11 +48,11 @@ extension OptionUserReactionFfi on UserReaction? {
   static UserReaction? readNative(
     final Pointer<RustOptionUserReaction> place,
   ) {
-    final innerPlace = ffi.get_option_user_reaction_some_ptr(place);
-    if (innerPlace == nullptr) {
+    final pointer = ffi.get_option_user_reaction_some(place);
+    if (pointer == nullptr) {
       return null;
     } else {
-      return UserReactionFfi.readNative(innerPlace);
+      return UserReactionFfi.readNative(pointer);
     }
   }
 }

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -21,6 +21,7 @@ import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
     show ActiveSearch;
+import 'package:xayn_discovery_engine/src/domain/models/document.dart';
 import 'package:xayn_discovery_engine/src/domain/models/embedding.dart'
     show Embedding;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
@@ -62,6 +63,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
     show Uint8ListFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/result.dart'
     show
+        resultDocumentStringFfiAdapter,
         resultSearchStringFfiAdapter,
         resultSharedEngineStringFfiAdapter,
         resultVecDocumentStringFfiAdapter,
@@ -230,7 +232,7 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
-  Future<void> userReacted(
+  Future<Document> userReacted(
     final List<HistoricDocument>? history,
     final List<SourceReacted> sources,
     final UserReacted userReacted,
@@ -243,7 +245,11 @@ class DiscoveryEngineFfi implements Engine {
       boxedUserReacted.move(),
     );
 
-    return resultVoidStringFfiAdapter.consumeNative(result);
+    return resultDocumentStringFfiAdapter
+        .consumeNative(result)
+        //TODO[pmk] we need to return the batchIndex, timestamp and isSearched
+        // this is wrong in other places, too
+        .toDocument(batchIndex: 0);
   }
 
   @override

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -36,7 +36,7 @@ import 'package:xayn_discovery_engine/src/domain/models/time_spent.dart'
 import 'package:xayn_discovery_engine/src/domain/models/trending_topic.dart'
     show TrendingTopic;
 import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
-    show DocumentId;
+    show DocumentId, StackId;
 import 'package:xayn_discovery_engine/src/domain/models/user_reacted.dart'
     show UserReacted;
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
@@ -245,11 +245,9 @@ class DiscoveryEngineFfi implements Engine {
       boxedUserReacted.move(),
     );
 
-    return resultDocumentStringFfiAdapter
-        .consumeNative(result)
-        //TODO[pmk] we need to return the batchIndex, timestamp and isSearched
-        // this is wrong in other places, too
-        .toDocument(batchIndex: 0);
+    final doc = resultDocumentStringFfiAdapter.consumeNative(result);
+
+    return doc.toDocument(isSearched: doc.stackId == StackId.nil());
   }
 
   @override

--- a/discovery_engine/lib/src/ffi/types/result.dart
+++ b/discovery_engine/lib/src/ffi/types/result.dart
@@ -18,6 +18,7 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustSharedEngine;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show asyncFfi, ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart';
 import 'package:xayn_discovery_engine/src/ffi/types/document/document_vec.dart'
     show DocumentSliceFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
@@ -182,6 +183,15 @@ final resultVecU8StringFfiAdapter = ConsumeResultFfiAdapter(
   readNativeErr: StringFfi.readNative,
   throwErr: _throwStringErr,
   freeResult: ffi.drop_result_vec_u8_string,
+);
+
+final resultDocumentStringFfiAdapter = ConsumeResultFfiAdapter(
+  getOk: ffi.get_result_document_string_ok,
+  getErr: ffi.get_result_document_string_err,
+  readNativeOk: DocumentFfi.readNative,
+  readNativeErr: StringFfi.readNative,
+  throwErr: _throwStringErr,
+  freeResult: ffi.drop_result_document_string,
 );
 
 final resultVecDocumentStringFfiAdapter = ConsumeResultFfiAdapter(

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -166,10 +166,14 @@ Future<void> main() async {
     test('restore feed', () async {
       final earlier = DateTime.utc(1969, 7, 20);
       final later = DateTime.utc(1989, 11, 9);
+      // ignore: deprecated_member_use_from_same_package
       await docRepo.update(doc2..timestamp = earlier);
+      // ignore: deprecated_member_use_from_same_package
       await docRepo.update(doc3..timestamp = later);
+      // ignore: deprecated_member_use_from_same_package
       await docRepo.update(engine.feedDocuments[0].document..timestamp = later);
       await docRepo
+          // ignore: deprecated_member_use_from_same_package
           .update(engine.feedDocuments[1].document..timestamp = earlier);
 
       expect(docRepo.box, hasLength(4));
@@ -184,15 +188,12 @@ Future<void> main() async {
         feed![0].documentId,
         equals(engine.feedDocuments[1].document.documentId),
       );
-      expect(feed[0].batchIndex, equals(1));
       expect(feed[1].documentId, equals(doc2.documentId));
-      expect(feed[1].batchIndex, equals(2));
       // doc0 has the later timestamp
       expect(
         feed[2].documentId,
         equals(engine.feedDocuments[0].document.documentId),
       );
-      expect(feed[2].batchIndex, equals(0));
       // doc3 is excluded since it is inactive
     });
   });

--- a/discovery_engine/test/ffi/types/document/document_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_test.dart
@@ -27,10 +27,11 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/document.dart'
     show DocumentFfi;
 
-DocumentFfi arbitraryDocumentFfi() => DocumentFfi(
+DocumentFfi arbitraryDocumentFfi({UserReaction? reaction}) => DocumentFfi(
       id: DocumentId(),
       stackId: StackId(),
       smbertEmbedding: Embedding.fromList([0.9, 0.1]),
+      reaction: reaction,
       resource: NewsResource(
         title: 'fun',
         snippet: 'fun is fun',
@@ -56,6 +57,15 @@ void main() {
     expect(res, equals(document));
   });
 
+  test('reading and written a document with UserReaction', () {
+    final document = arbitraryDocumentFfi(reaction: UserReaction.positive);
+    final place = ffi.alloc_uninitialized_document();
+    document.writeNative(place);
+    final res = DocumentFfi.readNative(place);
+    ffi.drop_document(place);
+    expect(res, equals(document));
+  });
+
   test('conversion to Document works', () {
     final ffiDocument = arbitraryDocumentFfi();
     // ignore: deprecated_member_use_from_same_package
@@ -66,6 +76,19 @@ void main() {
     // ignore: deprecated_member_use_from_same_package
     expect(document.batchIndex, equals(12));
     expect(document.userReaction, equals(UserReaction.neutral));
+    expect(document.isActive, isTrue);
+  });
+
+  test('conversion to Document works with reaction', () {
+    final ffiDocument = arbitraryDocumentFfi(reaction: UserReaction.positive);
+    // ignore: deprecated_member_use_from_same_package
+    final document = ffiDocument.toDocument(batchIndex: 12);
+    expect(document.documentId, equals(ffiDocument.id));
+    expect(document.stackId, equals(ffiDocument.stackId));
+    expect(document.resource, equals(ffiDocument.resource));
+    // ignore: deprecated_member_use_from_same_package
+    expect(document.batchIndex, equals(12));
+    expect(document.userReaction, equals(UserReaction.positive));
     expect(document.isActive, isTrue);
   });
 

--- a/discovery_engine/test/ffi/types/document/document_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_test.dart
@@ -62,7 +62,6 @@ void main() {
     expect(document.documentId, equals(ffiDocument.id));
     expect(document.stackId, equals(ffiDocument.stackId));
     expect(document.resource, equals(ffiDocument.resource));
-    expect(document.batchIndex, equals(12));
     expect(document.userReaction, equals(UserReaction.neutral));
     expect(document.isActive, isTrue);
   });

--- a/discovery_engine/test/ffi/types/document/document_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_test.dart
@@ -58,10 +58,13 @@ void main() {
 
   test('conversion to Document works', () {
     final ffiDocument = arbitraryDocumentFfi();
+    // ignore: deprecated_member_use_from_same_package
     final document = ffiDocument.toDocument(batchIndex: 12);
     expect(document.documentId, equals(ffiDocument.id));
     expect(document.stackId, equals(ffiDocument.stackId));
     expect(document.resource, equals(ffiDocument.resource));
+    // ignore: deprecated_member_use_from_same_package
+    expect(document.batchIndex, equals(12));
     expect(document.userReaction, equals(UserReaction.neutral));
     expect(document.isActive, isTrue);
   });

--- a/discovery_engine/test/ffi/types/document/document_vec_test.dart
+++ b/discovery_engine/test/ffi/types/document/document_vec_test.dart
@@ -85,7 +85,6 @@ void main() {
     expect(documents[0].document.documentId, equals(ffiDocuments[0].id));
     expect(documents[0].document.stackId, equals(ffiDocuments[0].stackId));
     expect(documents[0].document.resource, equals(ffiDocuments[0].resource));
-    expect(documents[0].document.batchIndex, equals(0));
     expect(documents[0].document.userReaction, equals(UserReaction.neutral));
     expect(documents[0].document.isActive, isTrue);
     expect(
@@ -96,7 +95,6 @@ void main() {
     expect(documents[1].document.documentId, equals(ffiDocuments[1].id));
     expect(documents[1].document.stackId, equals(ffiDocuments[1].stackId));
     expect(documents[1].document.resource, equals(ffiDocuments[1].resource));
-    expect(documents[1].document.batchIndex, equals(1));
     expect(documents[1].document.userReaction, equals(UserReaction.neutral));
     expect(documents[1].document.isActive, isTrue);
     expect(

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "async-once-cell",
  "async-trait",
  "bincode",
+ "cfg-if",
  "chrono",
  "derivative",
  "derive_more",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3860,6 +3860,7 @@ dependencies = [
  "heck 0.4.0",
  "itertools",
  "ndarray",
+ "num-traits",
  "tokio",
  "tracing",
  "tracing-android",

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { version = "0.4.19", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
 itertools = "0.10.3"
 ndarray = "0.15.6"
+num-traits = "0.2.15"
 tokio = { version = "1.20.1", features = ["sync"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -33,6 +33,7 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "Option_f32" = "RustOptionF32"
 "Option_String" = "RustOptionString"
 "Option_Url" = "RustOptionUrl"
+"Option_UserReaction" = "RustOptionUserReaction"
 "Result_Search__String" = "RustResultSearchString"
 "Result_SharedEngine__String" = "RustResultSharedEngineString"
 "Result_String" = "RustResultVoidString"

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -196,18 +196,15 @@ impl XaynDiscoveryEngineAsyncFfi {
         history: Option<Box<Vec<HistoricDocument>>>,
         sources: Box<Vec<WeightedSource>>,
         reacted: Box<UserReacted>,
-    ) -> Box<Result<(), String>> {
+    ) -> Box<Result<Box<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .user_reacted(
-                    history.as_deref().map(Vec::as_slice),
-                    &sources,
-                    reacted.as_ref(),
-                )
+                .user_reacted(history.as_deref().map(Vec::as_slice), &sources, *reacted)
                 .await
+                .map(Box::new)
                 .map_err(|error| error.to_string()),
         )
     }

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -196,7 +196,7 @@ impl XaynDiscoveryEngineAsyncFfi {
         history: Option<Box<Vec<HistoricDocument>>>,
         sources: Box<Vec<WeightedSource>>,
         reacted: Box<UserReacted>,
-    ) -> Box<Result<Box<Document>, String>> {
+    ) -> Box<Result<Document, String>> {
         Box::new(
             engine
                 .as_ref()
@@ -204,7 +204,6 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .await
                 .user_reacted(history.as_deref().map(Vec::as_slice), &sources, *reacted)
                 .await
-                .map(Box::new)
                 .map_err(|error| error.to_string()),
         )
     }

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -18,7 +18,7 @@ use std::ptr::addr_of_mut;
 
 use uuid::Uuid;
 
-use xayn_discovery_engine_core::document::{Document, Embedding, NewsResource};
+use xayn_discovery_engine_core::document::{Document, Embedding, NewsResource, UserReaction};
 
 /// Returns a pointer to the `id` field of a document.
 ///
@@ -53,6 +53,19 @@ pub unsafe extern "C" fn document_place_of_smbert_embedding(
     place: *mut Document,
 ) -> *mut Embedding {
     unsafe { addr_of_mut!((*place).smbert_embedding) }
+}
+
+/// Returns a pointer to the `smbert_embedding` field of a document.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`Document`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn document_place_of_reaction(
+    place: *mut Document,
+) -> *mut Option<UserReaction> {
+    unsafe { addr_of_mut!((*place).reaction) }
 }
 
 /// Returns a pointer to the `resource` field of a document.

--- a/discovery_engine_core/bindings/src/types/document/document.rs
+++ b/discovery_engine_core/bindings/src/types/document/document.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn document_place_of_smbert_embedding(
     unsafe { addr_of_mut!((*place).smbert_embedding) }
 }
 
-/// Returns a pointer to the `smbert_embedding` field of a document.
+/// Returns a pointer to the `reaction` field of a document.
 ///
 /// # Safety
 ///

--- a/discovery_engine_core/bindings/src/types/document/user_reaction.rs
+++ b/discovery_engine_core/bindings/src/types/document/user_reaction.rs
@@ -19,13 +19,13 @@ use std::ptr;
 use num_traits::FromPrimitive;
 use xayn_discovery_engine_core::document::UserReaction;
 
-/// Create a rust `Option<UserReaction>`  initialized to `None`.
+/// Create a rust `Option<UserReaction>` initialized to `Some(reaction)`.
 ///
-/// Return `0` if the discriminant it was out-of-range `1` otherwise.
+/// Return `0` if the discriminant was out-of-range and `1` otherwise.
 ///
 /// # Safety
 ///
-/// - It must be valid to write a `Option<UserReaction>` instance to given pointer,
+/// - It must be valid to write an `Option<UserReaction>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 #[no_mangle]
 pub unsafe extern "C" fn init_option_user_reaction_some_at(
@@ -37,11 +37,11 @@ pub unsafe extern "C" fn init_option_user_reaction_some_at(
     u8::from(opt_reaction.is_some())
 }
 
-/// Create a rust `Option<UserReaction>`  initialized to `Some(reaction)`.
+/// Create a rust `Option<UserReaction>` initialized to `None`.
 ///
 /// # Safety
 ///
-/// - It must be valid to write a `Option<UserReaction>` instance to given pointer,
+/// - It must be valid to write an `Option<UserReaction>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 #[no_mangle]
 pub unsafe extern "C" fn init_option_user_reaction_none_at(place: *mut Option<UserReaction>) {
@@ -50,16 +50,16 @@ pub unsafe extern "C" fn init_option_user_reaction_none_at(place: *mut Option<Us
     }
 }
 
-/// Returns a ptr. to the `UserReaction` in the `Some`, or `nullptr` if the option is `None`.
+/// Returns a pointer to the `UserReaction` value or a nullptr.
 ///
 /// # Safety
 ///
-/// - Place must point to a sound instance of `Option<UserReaction>`
+/// - The pointer must point to a sound `Option<UserReaction>` instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_option_user_reaction_some_ptr(
-    place: &mut Option<UserReaction>,
+pub unsafe extern "C" fn get_option_user_reaction_some(
+    reaction: &mut Option<UserReaction>,
 ) -> *mut UserReaction {
-    match place {
+    match reaction {
         Some(reaction) => reaction,
         None => ptr::null_mut(),
     }

--- a/discovery_engine_core/bindings/src/types/document/user_reaction.rs
+++ b/discovery_engine_core/bindings/src/types/document/user_reaction.rs
@@ -14,7 +14,56 @@
 
 //! FFI functions for handling [`UserReaction`] fields.
 
+use std::ptr;
+
+use num_traits::FromPrimitive;
 use xayn_discovery_engine_core::document::UserReaction;
+
+/// Create a rust `Option<UserReaction>`  initialized to `None`.
+///
+/// Return `0` if the discriminant it was out-of-range `1` otherwise.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<UserReaction>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn init_option_user_reaction_some_at(
+    place: *mut Option<UserReaction>,
+    user_reaction: u8,
+) -> u8 {
+    let opt_reaction = UserReaction::from_u8(user_reaction);
+    unsafe { place.write(opt_reaction) }
+    u8::from(opt_reaction.is_some())
+}
+
+/// Create a rust `Option<UserReaction>`  initialized to `Some(reaction)`.
+///
+/// # Safety
+///
+/// - It must be valid to write a `Option<UserReaction>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+#[no_mangle]
+pub unsafe extern "C" fn init_option_user_reaction_none_at(place: *mut Option<UserReaction>) {
+    unsafe {
+        place.write(None);
+    }
+}
+
+/// Returns a ptr. to the `UserReaction` in the `Some`, or `nullptr` if the option is `None`.
+///
+/// # Safety
+///
+/// - Place must point to a sound instance of `Option<UserReaction>`
+#[no_mangle]
+pub unsafe extern "C" fn get_option_user_reaction_some_ptr(
+    place: &mut Option<UserReaction>,
+) -> *mut UserReaction {
+    match place {
+        Some(reaction) => reaction,
+        None => ptr::null_mut(),
+    }
+}
 
 /// Alloc an uninitialized `Box<UserReaction>`, mainly used for testing.
 #[no_mangle]

--- a/discovery_engine_core/bindings/src/types/result.rs
+++ b/discovery_engine_core/bindings/src/types/result.rs
@@ -90,6 +90,40 @@ pub unsafe extern "C" fn drop_result_vec_u8_string(res: *mut Result<Vec<u8>, Str
     unsafe { boxed::drop(res) }
 }
 
+/// Returns a pointer to the `Document` success value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Document, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_document_string_ok(
+    res: *mut Result<Document, String>,
+) -> *mut Document {
+    unsafe { get_result_ok(res) }
+}
+
+/// Returns a pointer to the `String` error value or a nullptr.
+///
+/// # Safety
+///
+/// - The pointer must point to a sound `Result<Document, String>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_document_string_err(
+    res: *mut Result<Document, String>,
+) -> *mut String {
+    unsafe { get_result_err(res) }
+}
+
+/// Drops a `Box<Result<Vec<Document>, String>>`.
+///
+/// # Safety
+///
+/// - The pointer must represent a valid `Box<Result<Document, String>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_result_document_string(res: *mut Result<Document, String>) {
+    unsafe { boxed::drop(res) }
+}
+
 /// Returns a pointer to the `Vec<Document>` success value or a nullptr.
 ///
 /// # Safety

--- a/discovery_engine_core/bindings/src/types/result.rs
+++ b/discovery_engine_core/bindings/src/types/result.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn get_result_document_string_err(
     unsafe { get_result_err(res) }
 }
 
-/// Drops a `Box<Result<Vec<Document>, String>>`.
+/// Drops a `Box<Result<Document, String>>`.
 ///
 /// # Safety
 ///

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.57"
 bincode = "1.3.3"
+cfg-if = "1.0.0"
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -17,6 +17,8 @@ futures = { version = "0.3.21", default-features = false, features = ["alloc"] }
 itertools = "0.10.3"
 kodama = "0.2.3"
 ndarray = "0.15.6"
+num-derive = "0.3.3"
+num-traits = "0.2.15"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = "1.5.3"
@@ -34,8 +36,6 @@ xayn-discovery-engine-providers = { path = "../providers" }
 xayn-discovery-engine-tokenizer = { path = "../ai/tokenizer" }
 
 # feature storage
-num-derive = { version = "0.3.3", optional = true }
-num-traits = { version = "0.2.15", optional = true }
 sqlx = { version = "0.6.1", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono"], optional = true }
 
 [dev-dependencies]
@@ -50,4 +50,4 @@ xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 
 [features]
 default = []
-storage = ["num-derive", "num-traits", "sqlx"]
+storage = ["sqlx"]

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -101,6 +101,9 @@ pub struct Document {
     /// Embedding from smbert.
     pub smbert_embedding: Embedding,
 
+    /// Reaction.
+    pub reaction: Option<UserReaction>,
+
     /// Resource this document refers to.
     pub resource: NewsResource,
 }
@@ -117,6 +120,7 @@ impl TryFrom<(GenericArticle, StackId, Embedding)> for Document {
             stack_id,
             smbert_embedding,
             resource,
+            reaction: None,
         })
     }
 }
@@ -194,9 +198,18 @@ impl From<GenericArticle> for NewsResource {
 
 /// Indicates user's "sentiment" towards the document,
 /// essentially if the user "liked" or "disliked" the document.
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Derivative,
+    Eq,
+    PartialEq,
+    Serialize_repr,
+    Deserialize_repr,
+    num_derive::FromPrimitive,
+)]
 #[derivative(Default)]
-#[cfg_attr(feature = "storage", derive(num_derive::FromPrimitive))]
 #[repr(u8)]
 pub enum UserReaction {
     /// No reaction from the user.

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -176,6 +176,17 @@ pub struct NewsResource {
     pub topic: String,
 }
 
+impl NewsResource {
+    /// Returns the title, if the title is empty it return the snippet instead.
+    pub fn title_or_snippet(&self) -> &str {
+        if self.title.is_empty() {
+            &self.snippet
+        } else {
+            &self.title
+        }
+    }
+}
+
 impl From<GenericArticle> for NewsResource {
     fn from(article: GenericArticle) -> Self {
         let source_domain = article.source_domain();

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -594,7 +594,7 @@ impl Engine {
             if #[cfg(feature="storage")] {
                 let document: Document = self.storage
                     .feedback()
-                    .update_user_reaction(reacted.id, reacted.reaction).await?
+                    .update_user_reaction(reacted.id, reaction).await?
                     .into();
             } else {
                 use chrono::Utc;
@@ -624,10 +624,7 @@ impl Engine {
             }
         }
 
-        let market = Market {
-            lang_code: document.resource.language.clone(),
-            country_code: document.resource.country.clone(),
-        };
+        let market = Market::new(&document.resource.language, &document.resource.country);
 
         let mut stacks = self.stacks.write().await;
 
@@ -664,13 +661,7 @@ impl Engine {
                     })
                     .map_or_else(
                         #[allow(clippy::if_not_else)]
-                        |_| {
-                            vec![if document.resource.title.is_empty() {
-                                document.resource.snippet.clone()
-                            } else {
-                                document.resource.title.clone()
-                            }]
-                        },
+                        |_| vec![document.resource.title_or_snippet().to_owned()],
                         Into::into,
                     );
                 self.coi.log_positive_user_reaction(

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -606,6 +606,7 @@ impl Engine {
                     id: reacted.id,
                     stack_id: reacted.stack_id,
                     smbert_embedding: reacted.smbert_embedding,
+                    reaction: None,
                     resource: NewsResource {
                         title: reacted.title,
                         snippet: reacted.snippet,

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -225,21 +225,12 @@ pub mod models {
 
     impl From<ApiDocumentView> for document::Document {
         fn from(view: ApiDocumentView) -> Self {
-            let ApiDocumentView {
-                document_id,
-                news_resource,
-                newscatcher_data,
-                user_reaction,
-                embedding,
-                stack_id,
-            } = view;
-
             document::Document {
-                id: document_id,
-                stack_id: stack_id.unwrap_or_default(),
-                smbert_embedding: embedding,
-                reaction: user_reaction,
-                resource: (news_resource, newscatcher_data).into(),
+                id: view.document_id,
+                stack_id: view.stack_id.unwrap_or_default(),
+                smbert_embedding: view.embedding,
+                reaction: view.user_reaction,
+                resource: (view.news_resource, view.newscatcher_data).into(),
             }
         }
     }

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -209,11 +209,7 @@ pub mod models {
         pub(crate) document_id: document::Id,
         pub(crate) news_resource: NewsResource,
         pub(crate) newscatcher_data: NewscatcherData,
-        #[allow(dead_code)]
         pub(crate) user_reacted: Option<UserReaction>,
-        // FIXME I don't think this is helpful as multiple documents in the vec can have the same value for this!
-        #[allow(dead_code)]
-        pub(crate) in_batch_index: u32,
         pub(crate) embedding: Embedding,
         pub(crate) stack_id: Option<stack::Id>,
     }

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -209,7 +209,7 @@ pub mod models {
         pub(crate) document_id: document::Id,
         pub(crate) news_resource: NewsResource,
         pub(crate) newscatcher_data: NewscatcherData,
-        pub(crate) user_reacted: Option<UserReaction>,
+        pub(crate) user_reaction: Option<UserReaction>,
         pub(crate) embedding: Embedding,
         pub(crate) stack_id: Option<stack::Id>,
     }
@@ -225,11 +225,21 @@ pub mod models {
 
     impl From<ApiDocumentView> for document::Document {
         fn from(view: ApiDocumentView) -> Self {
+            let ApiDocumentView {
+                document_id,
+                news_resource,
+                newscatcher_data,
+                user_reaction,
+                embedding,
+                stack_id,
+            } = view;
+
             document::Document {
-                id: view.document_id,
-                stack_id: view.stack_id.unwrap_or_default(),
-                smbert_embedding: view.embedding,
-                resource: (view.news_resource, view.newscatcher_data).into(),
+                id: document_id,
+                stack_id: stack_id.unwrap_or_default(),
+                smbert_embedding: embedding,
+                reaction: user_reaction,
+                resource: (news_resource, newscatcher_data).into(),
             }
         }
     }

--- a/discovery_engine_core/core/src/storage/migrations/20220628114905_feed.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220628114905_feed.sql
@@ -27,14 +27,14 @@ CREATE TABLE IF NOT EXISTS PresentationOrdering(
     -- unix epoch timestamp in seconds
     -- you can't use DEFAULT as it must be the same
     -- for all documents added in the same batch
-    timestamp INTEGER NOT NULL,
+    batchTimestamp INTEGER NOT NULL,
     -- index in the batch of document which where
     -- presented to the app (user) at the same time
     inBatchIndex INTEGER NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_presentation_ordering_sort
-  ON PresentationOrdering(timestamp, inBatchIndex);
+  ON PresentationOrdering(batchTimestamp, inBatchIndex);
 
 CREATE TABLE IF NOT EXISTS UserReaction (
     documentId BLOB NOT NULL

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -228,7 +228,6 @@ impl SqliteStorage {
                 nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market,
                 nc.domainRank, nc.score,
-                po.batchTimestamp, po.inBatchIndex,
                 em.embedding,
                 ur.userReaction,
                 st.stackId
@@ -410,7 +409,6 @@ impl FeedScope for SqliteStorage {
                 nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market,
                 nc.domainRank, nc.score,
-                po.batchTimestamp, po.inBatchIndex,
                 em.embedding,
                 ur.userReaction,
                 st.stackId
@@ -553,7 +551,6 @@ impl SearchScope for SqliteStorage {
                 nr.title, nr.snippet, nr.topic, nr.url, nr.image,
                 nr.datePublished, nr.source, nr.market,
                 nc.domainRank, nc.score,
-                po.batchTimestamp, po.inBatchIndex,
                 em.embedding,
                 ur.userReaction,
                 NULL AS stackId
@@ -701,8 +698,6 @@ struct QueriedApiDocumentView {
     market: String,
     domain_rank: i64,
     score: Option<f32>,
-    batch_timestamp: i64,
-    in_batch_index: u32,
     embedding: Vec<u8>,
     user_reaction: Option<u32>,
     stack_id: Option<stack::Id>,
@@ -761,7 +756,6 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             news_resource,
             newscatcher_data,
             user_reacted,
-            in_batch_index: doc.in_batch_index,
             embedding,
             stack_id: doc.stack_id,
         })
@@ -866,7 +860,6 @@ mod tests {
     use super::*;
 
     fn create_documents(n: u8) -> Vec<NewDocument> {
-        let timestamp = Utc::now();
         (0..n)
             .map(|i| {
                 document::Document {
@@ -884,10 +877,6 @@ mod tests {
                         topic: format!("topic-{i}"),
                         ..NewsResource::default()
                     },
-                    presentation_ordering: Some(PresentationOrdering {
-                        batch_timestamp: timestamp,
-                        in_batch_index: u32::from(i),
-                    }),
                     ..document::Document::default()
                 }
                 .into()
@@ -908,7 +897,7 @@ mod tests {
             .for_each(|((idx, api_docs), doc)| {
                 assert_eq!(api_docs.document_id, doc.id);
                 assert_eq!(api_docs.news_resource, doc.news_resource);
-                assert_eq!(api_docs.presentation_ordering.in_batch_index, idx as u32);
+                assert_eq!(api_docs.newscatcher_data.domain_rank, idx as u64);
             })
     }
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -739,7 +739,7 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             domain_rank: doc.domain_rank as u64,
             score: doc.score,
         };
-        let user_reacted: Option<UserReaction> = doc
+        let user_reaction: Option<UserReaction> = doc
             .user_reaction
             .map(|value| {
                 UserReaction::from_u32(value).ok_or_else(|| {
@@ -755,7 +755,7 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             document_id: doc.document_id,
             news_resource,
             newscatcher_data,
-            user_reaction: user_reacted,
+            user_reaction,
             embedding,
             stack_id: doc.stack_id,
         })

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -890,8 +890,8 @@ mod tests {
 
     macro_rules! assert_eq_of_documents {
         ($left:expr, $right:expr) => {{
-            let api_docs: &[ApiDocumentView] = $left;
-            let docs: &[NewDocument] = $right;
+            let api_docs: &[ApiDocumentView] = &*$left;
+            let docs: &[NewDocument] = &*$right;
 
             assert_eq!(api_docs.len(), docs.len());
             api_docs
@@ -952,7 +952,7 @@ mod tests {
             .unwrap();
 
         let feed = storage.feed().fetch().await.unwrap();
-        assert_eq_of_documents!(&feed, &docs[..]);
+        assert_eq_of_documents!(feed, &docs[..]);
         for doc in feed {
             assert_eq!(doc.stack_id, Some(stack_id));
         }
@@ -994,7 +994,7 @@ mod tests {
 
         let (search, search_docs) = storage.search().fetch().await.unwrap();
         assert_eq!(search, new_search);
-        assert_eq_of_documents!(&search_docs, &first_docs);
+        assert_eq_of_documents!(search_docs, first_docs);
 
         // FIXME the current design of PresentationOrdering has a problem:
         // if you in the same second add multiple batches of documents
@@ -1019,8 +1019,8 @@ mod tests {
                 ..new_search
             }
         );
-        assert_eq_of_documents!(&search_docs[..10], &first_docs);
-        assert_eq_of_documents!(&search_docs[10..], &second_docs);
+        assert_eq_of_documents!(&search_docs[..10], first_docs);
+        assert_eq_of_documents!(&search_docs[10..], second_docs);
         assert!(storage.search().clear().await.unwrap());
     }
 
@@ -1070,7 +1070,7 @@ mod tests {
             .get_document(documents[0].id)
             .await
             .unwrap();
-        assert_eq_of_documents!(&[document], &documents);
+        assert_eq_of_documents!(&[document], documents);
 
         let id = document::Id::new();
         assert!(matches!(
@@ -1214,7 +1214,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq_of_documents!(&[reacted_doc], &docs);
+        assert_eq_of_documents!(&[reacted_doc], docs);
     }
 
     #[tokio::test]

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -188,12 +188,12 @@ impl SqliteStorage {
             // insert data into PresentationOrdering table
             query_builder
                 .reset()
-                .push("PresentationOrdering (documentId, timestamp, inBatchIndex) ")
+                .push("PresentationOrdering (documentId, batchTimestamp, inBatchIndex) ")
                 .push_values(documents.iter().enumerate(), |mut stm, (idx, doc)| {
                     // we won't have so many documents that idx > u32
                     #[allow(clippy::cast_possible_truncation)]
                     stm.push_bind(&doc.id)
-                        .push_bind(timestamp)
+                        .push_bind(timestamp.timestamp())
                         .push_bind(idx as u32);
                 })
                 .build()
@@ -224,9 +224,14 @@ impl SqliteStorage {
     ) -> Result<ApiDocumentView, Error> {
         let document = sqlx::query_as::<_, QueriedApiDocumentView>(&format!(
             "SELECT
-                documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
-                nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
-                po.inBatchIndex, em.embedding, ur.userReaction, st.stackId
+                documentId,
+                nr.title, nr.snippet, nr.topic, nr.url, nr.image,
+                nr.datePublished, nr.source, nr.market,
+                nc.domainRank, nc.score,
+                po.batchTimestamp, po.inBatchIndex,
+                em.embedding,
+                ur.userReaction,
+                st.stackId
             FROM {base_table}
             JOIN NewsResource           AS nr   USING (documentId)
             JOIN NewscatcherData        AS nc   USING (documentId)
@@ -401,17 +406,22 @@ impl FeedScope for SqliteStorage {
 
         let documents = sqlx::query_as::<_, QueriedApiDocumentView>(
             "SELECT
-                fd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
-                nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
-                ur.userReaction, po.inBatchIndex, em.embedding, st.stackId
-            FROM FeedDocument           AS fd
+                documentId,
+                nr.title, nr.snippet, nr.topic, nr.url, nr.image,
+                nr.datePublished, nr.source, nr.market,
+                nc.domainRank, nc.score,
+                po.batchTimestamp, po.inBatchIndex,
+                em.embedding,
+                ur.userReaction,
+                st.stackId
+            FROM FeedDocument
             JOIN NewsResource           AS nr   USING (documentId)
             JOIN NewscatcherData        AS nc   USING (documentId)
             JOIN PresentationOrdering   AS po   USING (documentId)
             JOIN Embedding              AS em   USING (documentId)
             JOIN StackDocument          As st   USING (documentId)
             LEFT JOIN UserReaction      AS ur   USING (documentId)
-            ORDER BY po.timestamp, po.inBatchIndex ASC;",
+            ORDER BY po.batchTimestamp, po.inBatchIndex ASC;",
         )
         .fetch_all(&mut tx)
         .await?;
@@ -538,16 +548,22 @@ impl SearchScope for SqliteStorage {
         .on_row_not_found(Error::NoSearch)?;
 
         let documents = sqlx::query_as::<_, QueriedApiDocumentView>(
-            "SELECT sd.documentId, nr.title, nr.snippet, nr.topic, nr.url, nr.image,
-                nr.datePublished, nr.source, nr.market, nc.domainRank, nc.score,
-                ur.userReaction, po.inBatchIndex, em.embedding, NULL AS stackId
+            "SELECT
+                documentId,
+                nr.title, nr.snippet, nr.topic, nr.url, nr.image,
+                nr.datePublished, nr.source, nr.market,
+                nc.domainRank, nc.score,
+                po.batchTimestamp, po.inBatchIndex,
+                em.embedding,
+                ur.userReaction,
+                NULL AS stackId
             FROM SearchDocument         AS sd
             JOIN NewsResource           AS nr   USING (documentId)
             JOIN NewscatcherData        AS nc   USING (documentId)
             JOIN PresentationOrdering   AS po   USING (documentId)
             JOIN Embedding              AS em   USING (documentId)
             LEFT JOIN UserReaction      AS ur   USING (documentId)
-            ORDER BY po.timestamp, po.inBatchIndex ASC;",
+            ORDER BY po.batchTimestamp, po.inBatchIndex ASC;",
         )
         .fetch_all(&mut tx)
         .await?;
@@ -685,9 +701,10 @@ struct QueriedApiDocumentView {
     market: String,
     domain_rank: i64,
     score: Option<f32>,
-    user_reaction: Option<u32>,
+    batch_timestamp: i64,
     in_batch_index: u32,
     embedding: Vec<u8>,
+    user_reaction: Option<u32>,
     stack_id: Option<stack::Id>,
 }
 
@@ -842,13 +859,14 @@ impl SourcePreferenceScope for SqliteStorage {
 #[cfg(test)]
 mod tests {
     use maplit::hashset;
-    use std::collections::HashSet;
+    use std::{collections::HashSet, time::Duration};
 
     use crate::{document::NewsResource, stack, storage::models::NewDocument};
 
     use super::*;
 
-    fn create_documents(n: u64) -> Vec<NewDocument> {
+    fn create_documents(n: u8) -> Vec<NewDocument> {
+        let timestamp = Utc::now();
         (0..n)
             .map(|i| {
                 document::Document {
@@ -861,14 +879,15 @@ mod tests {
                         source_domain: format!("example-{i}.com"),
                         image: (i != 0)
                             .then(|| Url::parse(&format!("http://example-image-{i}.com")).unwrap()),
-                        rank: i,
-                        score: (i != 0).then(
-                            #[allow(clippy::cast_precision_loss)] // index small enough
-                            || i as f32,
-                        ),
+                        rank: u64::from(i),
+                        score: (i != 0).then(|| f32::from(i)),
                         topic: format!("topic-{i}"),
                         ..NewsResource::default()
                     },
+                    presentation_ordering: Some(PresentationOrdering {
+                        batch_timestamp: timestamp,
+                        in_batch_index: u32::from(i),
+                    }),
                     ..document::Document::default()
                 }
                 .into()
@@ -880,16 +899,17 @@ mod tests {
         doc.iter().map(|doc| (doc.id, stack_id)).collect()
     }
 
-    fn check_eq_of_documents(api_docs: &[ApiDocumentView], docs: &[NewDocument]) -> bool {
-        api_docs.len() == docs.len()
-            && api_docs.iter().enumerate().zip(docs.iter()).all(
-                #[allow(clippy::cast_possible_truncation)] // index small enough
-                |((idx, api_docs), doc)| {
-                    api_docs.document_id == doc.id
-                        && api_docs.news_resource == doc.news_resource
-                        && api_docs.in_batch_index == idx as u32
-                },
-            )
+    fn assert_eq_of_documents(api_docs: &[ApiDocumentView], docs: &[NewDocument]) {
+        assert_eq!(api_docs.len(), docs.len());
+        api_docs
+            .iter()
+            .enumerate()
+            .zip(docs.iter())
+            .for_each(|((idx, api_docs), doc)| {
+                assert_eq!(api_docs.document_id, doc.id);
+                assert_eq!(api_docs.news_resource, doc.news_resource);
+                assert_eq!(api_docs.presentation_ordering.in_batch_index, idx as u32);
+            })
     }
 
     async fn create_memory_storage() -> impl Storage {
@@ -938,7 +958,7 @@ mod tests {
             .unwrap();
 
         let feed = storage.feed().fetch().await.unwrap();
-        assert!(check_eq_of_documents(&feed, &docs));
+        assert_eq_of_documents(&feed, &docs);
         for doc in feed {
             assert_eq!(doc.stack_id, Some(stack_id));
         }
@@ -980,7 +1000,12 @@ mod tests {
 
         let (search, search_docs) = storage.search().fetch().await.unwrap();
         assert_eq!(search, new_search);
-        assert!(check_eq_of_documents(&search_docs, &first_docs));
+        assert_eq_of_documents(&search_docs, &first_docs);
+
+        // FIXME the current design of PresentationOrdering has a problem:
+        // if you in the same second add multiple batches of documents
+        // they don't have a proper order anymore :=(
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         let second_docs = create_documents(5);
         storage
@@ -1000,8 +1025,8 @@ mod tests {
                 ..new_search
             }
         );
-        assert!(check_eq_of_documents(&search_docs[..10], &first_docs));
-        assert!(check_eq_of_documents(&search_docs[10..], &second_docs));
+        assert_eq_of_documents(&search_docs[..10], &first_docs);
+        assert_eq_of_documents(&search_docs[10..], &second_docs);
         assert!(storage.search().clear().await.unwrap());
     }
 
@@ -1051,7 +1076,7 @@ mod tests {
             .get_document(documents[0].id)
             .await
             .unwrap();
-        assert!(check_eq_of_documents(&[document], &documents));
+        assert_eq_of_documents(&[document], &documents);
 
         let id = document::Id::new();
         assert!(matches!(
@@ -1195,7 +1220,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(check_eq_of_documents(&[reacted_doc], &docs));
+        assert_eq_of_documents(&[reacted_doc], &docs);
     }
 
     #[tokio::test]

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -755,7 +755,7 @@ impl TryFrom<QueriedApiDocumentView> for ApiDocumentView {
             document_id: doc.document_id,
             news_resource,
             newscatcher_data,
-            user_reacted,
+            user_reaction: user_reacted,
             embedding,
             stack_id: doc.stack_id,
         })
@@ -1180,15 +1180,15 @@ mod tests {
 
         let feed = storage.feed().fetch().await.unwrap();
         assert_eq!(feed[0].document_id, doc0);
-        assert_eq!(feed[0].user_reacted, Some(UserReaction::Positive));
+        assert_eq!(feed[0].user_reaction, Some(UserReaction::Positive));
         assert_eq!(feed[1].document_id, doc1);
-        assert_eq!(feed[1].user_reacted, Some(UserReaction::Negative));
+        assert_eq!(feed[1].user_reaction, Some(UserReaction::Negative));
         assert_eq!(feed[2].document_id, doc2);
-        assert_eq!(feed[2].user_reacted, Some(UserReaction::Neutral));
+        assert_eq!(feed[2].user_reaction, Some(UserReaction::Neutral));
         assert_eq!(feed[3].document_id, doc3);
-        assert_eq!(feed[3].user_reacted, Some(UserReaction::Neutral));
+        assert_eq!(feed[3].user_reaction, Some(UserReaction::Neutral));
         for doc in &feed[4..] {
-            assert_eq!(doc.user_reacted, None);
+            assert_eq!(doc.user_reaction, None);
         }
     }
 


### PR DESCRIPTION
Use the db code for the user reaction in rust.

**References:**
- [TY-2981]

**Based On:**
- #504 
- #523 
- #509 

[TY-2981]: https://xainag.atlassian.net/browse/TY-2981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ