### PR TITLE
[Merged by Bors] - TY-3018-fk-violation-error-helper

### DIFF
--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -12,8 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use displaydoc::Display;
 use thiserror::Error;
@@ -38,22 +36,6 @@ pub enum Error {
 impl From<sqlx::Error> for Error {
     fn from(generic: sqlx::Error) -> Self {
         Error::Database(generic.into())
-    }
-}
-
-trait SqlxSqliteErrorExt<V> {
-    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error>;
-}
-
-impl<V> SqlxSqliteErrorExt<V> for Result<V, sqlx::Error> {
-    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error> {
-        if let Err(sqlx::Error::Database(db_err)) = &self {
-            if db_err.code() == Some(Cow::Borrowed("787")) {
-                return Err(Error::InvalidDocumentId(id));
-            }
-        }
-        self.map_err(Into::into)
-
     }
 }
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -50,8 +50,8 @@ use crate::{
 const BIND_LIMIT: usize = 32766;
 
 trait SqlxSqliteErrorExt<V> {
-    /// Use this on the result of an sqlite query which might have failed a foreign
-    /// key constraint if a illegal document if was passed in.
+    /// Use this on the result of a sqlite query which might have failed a foreign
+    /// key constraint when an illegal document was passed in.
     ///
     /// For example it can be used in `.user_reacted` to handle it being
     /// called with a random document id.
@@ -831,10 +831,7 @@ mod tests {
             .await
             .fk_violation_is_invalid_document_id(document_id);
 
-        assert!(matches!(res, Err(Error::InvalidDocumentId(_))));
-        if let Err(Error::InvalidDocumentId(id)) = res {
-            assert_eq!(id, document_id);
-        }
+        assert!(matches!(res, Err(Error::InvalidDocumentId(id)) if id == document_id));
 
         let res = sqlx::query("malformed;")
             .execute(&storage.pool)


### PR DESCRIPTION
Adds two helper:

- `From<sqlx::Error>` for `storage::Error` so that we don't have to write `.await.map(|err| Error::Database(err.into()))?` all the time
- a `.fk_violation_is_invalid_document()` extension on `Result<V, sqlx::Errror>` which will convert the (potential) error to a `storage::Error` like using `into()` but if there is a fk violation error it will produce an `Error::InvalidDocumentId` variant instead of an `Error::Database`.