### PR TITLE
[Merged by Bors] - TY-2979 move feed logic to rust (0): nextFeedBatch

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -67,6 +67,12 @@ abstract class Engine {
     Set<Source> trusted,
   );
 
+  /// Gets the next batch of feed documents.
+  Future<List<DocumentWithActiveData>> feedNextBatch(
+    List<SourceReacted> sources,
+    int maxDocuments,
+  );
+
   /// Retrieves at most [maxDocuments] feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     List<HistoricDocument> history,

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -102,6 +102,15 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> feedNextBatch(
+    List<SourceReacted> sources,
+    int maxDocuments,
+  ) async {
+    _incrementCount('feedNextBatch');
+    return feedDocuments.take(maxDocuments).toList(growable: false);
+  }
+
+  @override
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     List<HistoricDocument> history,
     List<SourceReacted> sources,

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -170,6 +170,22 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
+  Future<List<DocumentWithActiveData>> feedNextBatch(
+    final List<SourceReacted> sources,
+    final int maxDocuments,
+  ) async {
+    final result = await asyncFfi.feedNextBatch(
+      _engine.ref,
+      sources.allocVec().move(),
+      maxDocuments,
+    );
+
+    return resultVecDocumentStringFfiAdapter
+        .consumeNative(result)
+        .toDocumentListWithActiveData();
+  }
+
+  @override
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     final List<HistoricDocument> history,
     final List<SourceReacted> sources,

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -107,6 +107,24 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
+    /// Gets the next batch of feed documents.
+    #[allow(clippy::box_collection)]
+    pub async fn feed_next_batch(
+        engine: &SharedEngine,
+        sources: Box<Vec<WeightedSource>>,
+        max_documents: u32,
+    ) -> Box<Result<Vec<Document>, String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .feed_next_batch(&sources, max_documents)
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
     /// Gets feed documents.
     #[allow(clippy::box_collection)]
     pub async fn get_feed_documents(


### PR DESCRIPTION
**References**

- [TY-2979]
- followed by #518

**Summary**

- add `Engine::feed_next_batch()` & corresponding ffi
- use new logic & remove corresponding db calls in `FeedManager.nextFeedBatch()` in dart


[TY-2979]: https://xainag.atlassian.net/browse/TY-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ