### PR TITLE
[Merged by Bors] - TY-2979 move feed logic to rust (2): deactivateDocuments

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -83,8 +83,8 @@ abstract class Engine {
   /// Restores the feed documents, ordered by their global rank (timestamp & local rank).
   Future<List<DocumentWithActiveData>> restoreFeed();
 
-  /// Clears the feed documents.
-  Future<void> clearFeedDocuments(Set<DocumentId> ids);
+  /// Deletes the feed documents.
+  Future<void> deleteFeedDocuments(Set<DocumentId> ids);
 
   /// Process the feedback about the user spending some time on a document.
   Future<void> timeSpent(TimeSpent timeSpent);

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -83,6 +83,9 @@ abstract class Engine {
   /// Restores the feed documents, ordered by their global rank (timestamp & local rank).
   Future<List<DocumentWithActiveData>> restoreFeed();
 
+  /// Clears the feed documents.
+  Future<void> clearFeedDocuments(Set<DocumentId> ids);
+
   /// Process the feedback about the user spending some time on a document.
   Future<void> timeSpent(TimeSpent timeSpent);
 

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -127,8 +127,8 @@ class MockEngine implements Engine {
   }
 
   @override
-  Future<void> clearFeedDocuments(Set<DocumentId> ids) async {
-    _incrementCount('clearFeedDocuments');
+  Future<void> deleteFeedDocuments(Set<DocumentId> ids) async {
+    _incrementCount('deleteFeedDocuments');
   }
 
   @override

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -127,6 +127,11 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<void> clearFeedDocuments(Set<DocumentId> ids) async {
+    _incrementCount('clearFeedDocuments');
+  }
+
+  @override
   Future<void> timeSpent(TimeSpent timeSpent) async {
     _incrementCount('timeSpent');
   }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -187,7 +187,7 @@ class FeedManager {
   Future<EngineEvent> deactivateDocuments(Set<DocumentId> ids) async {
     if (cfgFeatureStorage) {
       try {
-        await _engine.clearFeedDocuments(ids);
+        await _engine.deleteFeedDocuments(ids);
       } on Exception catch (e) {
         return EngineEvent.engineExceptionRaised(
           EngineExceptionReason.genericError,

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -17,7 +17,7 @@ import 'package:xayn_discovery_engine/discovery_engine.dart'
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show FeedClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
-    show EngineEvent, FeedFailureReason;
+    show EngineEvent, EngineExceptionReason, FeedFailureReason;
 import 'package:xayn_discovery_engine/src/api/models/document.dart'
     show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
@@ -185,6 +185,19 @@ class FeedManager {
 
   /// Deactivate the given documents.
   Future<EngineEvent> deactivateDocuments(Set<DocumentId> ids) async {
+    if (cfgFeatureStorage) {
+      try {
+        await _engine.clearFeedDocuments(ids);
+      } on Exception catch (e) {
+        return EngineEvent.engineExceptionRaised(
+          EngineExceptionReason.genericError,
+          message: '$e',
+        );
+      }
+
+      return const EngineEvent.clientEventSucceeded();
+    }
+
     await _activeRepo.removeByIds(ids);
 
     final docs = await _docRepo.fetchByIds(ids);

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -74,6 +74,8 @@ import 'package:xayn_discovery_engine/src/ffi/types/trending_topic_vec.dart'
     show TrendingTopicSliceFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
     show DocumentIdFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid_vec.dart'
+    show DocumentIdSetFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/weighted_source_vec.dart'
     show WeightedSourceListFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
@@ -210,6 +212,16 @@ class DiscoveryEngineFfi implements Engine {
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)
         .toDocumentListWithActiveData();
+  }
+
+  @override
+  Future<void> clearFeedDocuments(Set<DocumentId> ids) async {
+    final result = await asyncFfi.clearFeedDocuments(
+      _engine.ref,
+      ids.allocNative().move(),
+    );
+
+    return resultVoidStringFfiAdapter.consumeNative(result);
   }
 
   @override

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -215,8 +215,8 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
-  Future<void> clearFeedDocuments(Set<DocumentId> ids) async {
-    final result = await asyncFfi.clearFeedDocuments(
+  Future<void> deleteFeedDocuments(Set<DocumentId> ids) async {
+    final result = await asyncFfi.deleteFeedDocuments(
       _engine.ref,
       ids.allocNative().move(),
     );

--- a/discovery_engine/lib/src/ffi/types/uuid_vec.dart
+++ b/discovery_engine/lib/src/ffi/types/uuid_vec.dart
@@ -1,0 +1,50 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:meta/meta.dart' show visibleForTesting;
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart'
+    show DocumentId;
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustUuid, RustVecUuid;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+import 'package:xayn_discovery_engine/src/ffi/types/list.dart'
+    show ListFfiAdapter;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
+    show DocumentIdFfi;
+
+final _adapter = ListFfiAdapter<DocumentId, RustUuid, RustVecUuid>(
+  alloc: ffi.alloc_uninitialized_uuid_slice,
+  next: ffi.next_uuid,
+  writeNative: (id, place) => id.writeNative(place),
+  readNative: DocumentIdFfi.readNative,
+  getVecLen: ffi.get_uuid_vec_len,
+  getVecBuffer: ffi.get_uuid_vec_buffer,
+  writeNativeVec: ffi.init_uuid_vec_at,
+);
+
+extension DocumentIdSetFfi on Set<DocumentId> {
+  Boxed<RustVecUuid> allocNative() {
+    final place = ffi.alloc_uninitialized_uuid_vec();
+    _adapter.writeVec(toList(), place);
+    return Boxed(place, ffi.drop_uuid_vec);
+  }
+
+  @visibleForTesting
+  static Set<DocumentId> consumeNative(Boxed<RustVecUuid> boxed) {
+    final result = _adapter.readVec(boxed.ref);
+    boxed.free();
+    return result.toSet();
+  }
+}

--- a/discovery_engine/test/ffi/types/uuid_test.dart
+++ b/discovery_engine/test/ffi/types/uuid_test.dart
@@ -18,6 +18,8 @@ import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/uuid.dart'
     show DocumentIdFfi, StackIdFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/uuid_vec.dart'
+    show DocumentIdSetFfi;
 
 void main() {
   test('reading written document id yields same result', () {
@@ -36,5 +38,15 @@ void main() {
     final res = StackIdFfi.readNative(place);
     ffi.drop_uuid(place);
     expect(res, equals(uuid));
+  });
+
+  test('reading written Vec<DocumentId> works', () {
+    final ids = List.generate(
+      10,
+      (_) => DocumentId.fromBytes(Uuid.parseAsByteList(const Uuid().v4())),
+    ).toSet();
+    final boxed = ids.allocNative();
+    final result = DocumentIdSetFfi.consumeNative(boxed);
+    expect(result, equals(ids));
   });
 }

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3874,6 +3874,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "heck 0.4.0",
+ "itertools",
  "ndarray",
  "tokio",
  "tracing",

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -9,6 +9,7 @@ async-bindgen = { path = "../async-bindgen/async-bindgen" }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.19", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
+itertools = "0.10.3"
 ndarray = "0.15.4"
 tokio = { version = "1.19.2", features = ["sync"] }
 tracing = "0.1.35"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -54,5 +54,6 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "Vec_String" = "RustVecString"
 "Vec_TrendingTopic" = "RustVecTrendingTopic"
 "Vec_u8" = "RustVecU8"
+"Vec_Uuid" = "RustVecUuid"
 "Vec_WeightedSource" = "RustVecWeightedSource"
 "WeightedSource" = "RustWeightedSource"

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -158,8 +158,8 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
-    /// Clears the feed documents.
-    pub async fn clear_feed_documents(
+    /// Deletes the feed documents.
+    pub async fn delete_feed_documents(
         engine: &SharedEngine,
         ids: Box<Vec<Uuid>>,
     ) -> Box<Result<(), String>> {
@@ -168,7 +168,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .clear_feed_documents(&ids.into_iter().map_into().collect_vec())
+                .delete_feed_documents(&ids.into_iter().map_into().collect_vec())
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -37,6 +37,7 @@ pub mod types;
 
 use std::path::Path;
 
+use itertools::Itertools;
 use xayn_discovery_engine_core::Engine;
 
 #[async_bindgen::api(
@@ -152,6 +153,22 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .lock()
                 .await
                 .restore_feed()
+                .await
+                .map_err(|error| error.to_string()),
+        )
+    }
+
+    /// Clears the feed documents.
+    pub async fn clear_feed_documents(
+        engine: &SharedEngine,
+        ids: Box<Vec<Uuid>>,
+    ) -> Box<Result<(), String>> {
+        Box::new(
+            engine
+                .as_ref()
+                .lock()
+                .await
+                .clear_feed_documents(&ids.into_iter().map_into().collect_vec())
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -38,6 +38,7 @@ pub mod trending_topic;
 pub mod trending_topic_vec;
 pub mod url;
 pub mod uuid;
+pub mod uuid_vec;
 pub mod vec;
 pub mod weighted_source;
 pub mod weighted_source_vec;

--- a/discovery_engine_core/bindings/src/types/document/document_vec.rs
+++ b/discovery_engine_core/bindings/src/types/document/document_vec.rs
@@ -25,14 +25,14 @@ use crate::types::{
 /// Initializes a `Vec<Document>` at given place.
 ///
 /// This moves the passed in slice into the vector,
-/// i.e. `slice_ptr, len` map to `Box<[Document]>`.
+/// i.e. `slice_ptr, slice_len` map to `Box<[Document]>`.
 ///
 /// # Safety
 ///
 /// - It must be valid to write a `Vec<Document>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 /// - It must be valid to construct a `Box<[Document]>` from given `slice_ptr`
-///   and `len`.
+///   and `slice_len`.
 #[no_mangle]
 pub unsafe extern "C" fn init_document_vec_at(
     place: *mut Vec<Document>,

--- a/discovery_engine_core/bindings/src/types/history_vec.rs
+++ b/discovery_engine_core/bindings/src/types/history_vec.rs
@@ -26,7 +26,7 @@ use super::{boxed::alloc_uninitialized, primitives::FfiUsize};
 /// Initializes a `Vec<HistoricDocument>` at given place.
 ///
 /// This moves the passed in slice into the vector,
-/// i.e. `slice_ptr, len` map to `Box<[HistoricDocument]>`.
+/// i.e. `slice_ptr, slice_len` map to `Box<[HistoricDocument]>`.
 ///
 /// # Safety
 ///

--- a/discovery_engine_core/bindings/src/types/market_vec.rs
+++ b/discovery_engine_core/bindings/src/types/market_vec.rs
@@ -29,22 +29,22 @@ use super::{
 /// Initializes a `Vec<Market>` at given place.
 ///
 /// This moves the passed in slice into the vector,
-/// i.e. `slice_ptr, len` map to `Box<[Market]>`.
+/// i.e. `slice_ptr, slice_len` map to `Box<[Market]>`.
 ///
 /// # Safety
 ///
-/// - It must be valid to write an `Option<Vec<Market>>` instance to given pointer,
+/// - It must be valid to write an `Vec<Market>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 /// - It must be valid to construct a `Box<[Market]>` from given `slice_ptr`
-///   and `len`.
+///   and `slice_len`.
 #[no_mangle]
 pub unsafe extern "C" fn init_market_vec_at(
     place: *mut Vec<Market>,
     slice_ptr: *mut Market,
-    len: FfiUsize,
+    slice_len: FfiUsize,
 ) {
     unsafe {
-        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, len)));
+        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
     }
 }
 

--- a/discovery_engine_core/bindings/src/types/string_vec.rs
+++ b/discovery_engine_core/bindings/src/types/string_vec.rs
@@ -27,22 +27,22 @@ use super::{
 /// Initializes a `Vec<String>` at given place.
 ///
 /// This moves the passed in slice into the vector,
-/// i.e. `slice_ptr, len` map to `Box<[String]>`.
+/// i.e. `slice_ptr, slice_len` map to `Box<[String]>`.
 ///
 /// # Safety
 ///
 /// - It must be valid to write an `Option<Vec<String>>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 /// - It must be valid to construct a `Box<[String]>` from given `slice_ptr`
-///   and `len`.
+///   and `slice_len`.
 #[no_mangle]
 pub unsafe extern "C" fn init_string_vec_at(
     place: *mut Vec<String>,
     slice_ptr: *mut String,
-    len: FfiUsize,
+    slice_len: FfiUsize,
 ) {
     unsafe {
-        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, len)));
+        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
     }
 }
 

--- a/discovery_engine_core/bindings/src/types/trending_topic_vec.rs
+++ b/discovery_engine_core/bindings/src/types/trending_topic_vec.rs
@@ -25,14 +25,14 @@ use crate::types::{
 /// Initializes a `Vec<TrendingTopic>` at given place.
 ///
 /// This moves the passed in slice into the vector,
-/// i.e. `slice_ptr, len` map to `Box<[TrendingTopic]>`.
+/// i.e. `slice_ptr, slice_len` map to `Box<[TrendingTopic]>`.
 ///
 /// # Safety
 ///
 /// - It must be valid to write a `Vec<TrendingTopic>` instance to given pointer,
 ///   the pointer is expected to point to uninitialized memory.
 /// - It must be valid to construct a `Box<[TrendingTopic]>` from given `slice_ptr`
-///   and `len`.
+///   and `slice_len`.
 #[no_mangle]
 pub unsafe extern "C" fn init_trending_topic_vec_at(
     place: *mut Vec<TrendingTopic>,

--- a/discovery_engine_core/bindings/src/types/uuid_vec.rs
+++ b/discovery_engine_core/bindings/src/types/uuid_vec.rs
@@ -1,0 +1,117 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! FFI functions for handling slices and vectors of [`Uuid`] instance.
+
+use uuid::Uuid;
+
+use crate::types::{
+    slice::{alloc_uninitialized_slice, boxed_slice_from_raw_parts, next_element},
+    vec::{get_vec_buffer, get_vec_len},
+};
+
+use super::{
+    boxed::{self, alloc_uninitialized},
+    primitives::FfiUsize,
+};
+
+/// Initializes a `Vec<Uuid>` at given place.
+///
+/// This moves the passed in slice into the vector,
+/// i.e. `slice_ptr, slice_len` map to `Box<[Uuid]>`.
+///
+/// # Safety
+///
+/// - It must be valid to write an `Vec<Uuid>` instance to given pointer,
+///   the pointer is expected to point to uninitialized memory.
+/// - It must be valid to construct a `Box<[Uuid]>` from given `slice_ptr`
+///   and `slice_len`.
+#[no_mangle]
+pub unsafe extern "C" fn init_uuid_vec_at(
+    place: *mut Vec<Uuid>,
+    slice_ptr: *mut Uuid,
+    slice_len: FfiUsize,
+) {
+    unsafe {
+        place.write(Vec::from(boxed_slice_from_raw_parts(slice_ptr, slice_len)));
+    }
+}
+
+/// Alloc an uninitialized `Box<[Uuid]>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_uuid_slice(len: FfiUsize) -> *mut Uuid {
+    alloc_uninitialized_slice(len)
+}
+
+/// Drop a `Box<[Uuid]>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<[Uuid]>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_uuid_slice(ids: *mut Uuid, len: FfiUsize) {
+    drop(unsafe { boxed_slice_from_raw_parts(ids, len) });
+}
+
+/// Alloc an uninitialized `Box<Vec<Uuid>>`.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_uuid_vec() -> *mut Vec<Uuid> {
+    alloc_uninitialized()
+}
+
+/// Drop a `Box<Vec<Uuid>>`.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<Vec<Uuid>>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_uuid_vec(ids: *mut Vec<Uuid>) {
+    unsafe {
+        boxed::drop(ids);
+    }
+}
+
+/// Given a pointer to a [`Uuid`] in a slice return the pointer to the next [`Uuid`].
+///
+/// This also works if the slice is uninitialized.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Uuid` memory object, it might
+/// be uninitialized. If it's the last object in an array the returned pointer
+/// must not be dereferenced.
+#[no_mangle]
+pub unsafe extern "C" fn next_uuid(place: *mut Uuid) -> *mut Uuid {
+    unsafe { next_element(place) }
+}
+
+/// Returns the length of a `Box<Vec<Uuid>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<Uuid>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_uuid_vec_len(ids: *mut Vec<Uuid>) -> FfiUsize {
+    unsafe { get_vec_len(ids) }
+}
+
+/// Returns the `*mut Uuid` to the beginning of the buffer of a `Box<Vec<Uuid>>`.
+///
+/// # Safety
+///
+/// The pointer must point to a valid `Vec<Uuid>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn get_uuid_vec_buffer(ids: *mut Vec<Uuid>) -> *mut Uuid {
+    unsafe { get_vec_buffer(ids) }
+}

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -509,6 +509,20 @@ impl Engine {
         unimplemented!("requires 'storage' feature")
     }
 
+    /// Clears the feed documents.
+    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    pub async fn clear_feed_documents(&self, ids: &[document::Id]) -> Result<(), Error> {
+        #[cfg(feature = "storage")]
+        {
+            self.storage.feed().clear_documents(ids).await?;
+
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "storage"))]
+        unimplemented!("requires 'storage' feature")
+    }
+
     /// Process the feedback about the user spending some time on a document.
     pub async fn time_spent(&mut self, time_spent: &TimeSpent) {
         if let UserReaction::Positive | UserReaction::Neutral = time_spent.reaction {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -509,12 +509,12 @@ impl Engine {
         unimplemented!("requires 'storage' feature")
     }
 
-    /// Clears the feed documents.
+    /// Deletes the feed documents.
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
-    pub async fn clear_feed_documents(&self, ids: &[document::Id]) -> Result<(), Error> {
+    pub async fn delete_feed_documents(&self, ids: &[document::Id]) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
-            self.storage.feed().clear_documents(ids).await?;
+            self.storage.feed().delete_documents(ids).await?;
 
             return Ok(());
         }

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -64,7 +64,7 @@ pub(crate) trait Storage {
 
 #[async_trait]
 pub(crate) trait FeedScope {
-    async fn clear_documents(&self, ids: &[document::Id]) -> Result<bool, Error>;
+    async fn delete_documents(&self, ids: &[document::Id]) -> Result<bool, Error>;
 
     async fn clear(&self) -> Result<bool, Error>;
 

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -64,7 +64,7 @@ pub(crate) trait Storage {
 
 #[async_trait]
 pub(crate) trait FeedScope {
-    async fn close_document(&self, document: &document::Id) -> Result<(), Error>;
+    async fn clear_documents(&self, ids: &[document::Id]) -> Result<bool, Error>;
 
     async fn clear(&self) -> Result<bool, Error>;
 

--- a/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220627125903_init.sql
@@ -13,20 +13,20 @@
 --  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 CREATE TABLE IF NOT EXISTS Document (
-    id BLOB NOT NULL
+    documentId BLOB NOT NULL
         PRIMARY KEY
 );
 
 CREATE TABLE IF NOT EXISTS HistoricDocument (
     documentId BLOB NOT NULL
         PRIMARY KEY
-        REFERENCES Document(id) ON DELETE CASCADE
+        REFERENCES Document(documentId) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS NewsResource (
     documentId BLOB NOT NULL
         PRIMARY KEY
-        REFERENCES Document(id) ON DELETE CASCADE,
+        REFERENCES Document(documentId) ON DELETE CASCADE,
     title TEXT NOT NULL,
     snippet TEXT NOT NULL,
     topic TEXT NOT NULL,
@@ -54,6 +54,6 @@ CREATE TABLE IF NOT EXISTS NewscatcherData (
 CREATE TABLE IF NOT EXISTS Embedding(
     documentId BLOB NOT NULL
         PRIMARY KEY
-        REFERENCES Document(id) ON DELETE CASCADE,
+        REFERENCES Document(documentId) ON DELETE CASCADE,
     embedding BLOB NOT NULL
 );

--- a/discovery_engine_core/core/src/storage/migrations/20220628114905_feed.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220628114905_feed.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS FeedDocument (
 CREATE TABLE IF NOT EXISTS PresentationOrdering(
     documentId BLOB NOT NULL
         PRIMARY KEY
-        REFERENCES Document(id) ON DELETE CASCADE,
+        REFERENCES Document(documentId) ON DELETE CASCADE,
     -- unix epoch timestamp in seconds
     -- you can't use DEFAULT as it must be the same
     -- for all documents added in the same batch

--- a/discovery_engine_core/core/src/storage/migrations/20220727110259_stack_id.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220727110259_stack_id.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS Stack(
 CREATE TABLE IF NOT EXISTS StackDocument(
     documentId BLOB NOT NULL
         PRIMARY KEY
-        REFERENCES Document(id) ON DELETE CASCADE,
+        REFERENCES Document(documentId) ON DELETE CASCADE,
     stackId BLOB NOT NULL
         REFERENCES Stack(stackId) ON DELETE CASCADE
     -- additional fields will be added when the serialized state is turned into the db


### PR DESCRIPTION
**References**

- [TY-2979]
- requires #518
- followed by #524

**Summary**

- rename `FeedScope::close_document()` to `FeedScope::delete_documents()` to align the naming and process the ids batch-wise to match the dart code
- rename `id` key of the `Document` table to `documentId` for easier usage (eg with `USING`)
- add `Engine::delete_feed_documents()` & corresponding ffi
- use new logic & remove corresponding db calls in `FeedManager.deactivateDocuments()` in dart
- fix some ffi documentation


[TY-2979]: https://xainag.atlassian.net/browse/TY-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ