### PR TITLE
[Merged by Bors] - TY-3018 improve justfile for db

### DIFF
--- a/discovery_engine_core/.gitignore
+++ b/discovery_engine_core/.gitignore
@@ -1,1 +1,2 @@
 target/
+.env.db.dev

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -108,6 +108,7 @@ impl SqliteStorage {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn store_new_documents(
         tx: &mut Transaction<'_, Sqlite>,
         documents: &[NewDocument],
@@ -974,7 +975,9 @@ mod tests {
                 })
         }};
     }
-
+//TODO[pmk]
+//     && api_docs.in_batch_index == u32::try_from(idx).unwrap()
+// })
     async fn create_memory_storage() -> impl Storage {
         let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
         storage.init_database().await.unwrap();

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -975,9 +975,7 @@ mod tests {
                 })
         }};
     }
-//TODO[pmk]
-//     && api_docs.in_batch_index == u32::try_from(idx).unwrap()
-// })
+
     async fn create_memory_storage() -> impl Storage {
         let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
         storage.init_database().await.unwrap();

--- a/justfile
+++ b/justfile
@@ -115,6 +115,7 @@ _codegen-order-workaround:
 # Checks rust code, fails on warnings on CI
 rust-check: _codegen-order-workaround
     cd "$RUST_WORKSPACE"; \
+    cargo clippy --all-targets --features="storage" --locked; \
     cargo clippy --all-targets --locked; \
     cargo clippy --all-targets --features storage --locked; \
     cargo check -p xayn-discovery-engine-bindings


### PR DESCRIPTION
- adds a easy way to setup a temp-file sqlite db for usage with sqlx-cli, and a easy way to calling `sqlx migrate` on it
- run clippy with storage feature enabled
- fix missed clippy lints