### PR TITLE
[Merged by Bors] - TY-3018 cleanup

### DIFF
--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -33,16 +33,14 @@ pub(crate) type BoxedStorage = Box<dyn Storage + Send + Sync>;
 
 #[derive(Error, Debug, Display)]
 pub enum Error {
-    /// Engine doesn't have a document with id {0}
-    InvalidDocumentId(document::Id),
     /// Database error: {0}
     Database(#[source] GenericError),
     /// Search request failed: open search
     OpenSearch,
     /// Search request failed: no search
     NoSearch,
-    /// Search request failed: no document
-    NoDocument,
+    /// Search request failed: no document with id {0}
+    NoDocument(document::Id),
 }
 
 impl From<sqlx::Error> for Error {

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -379,8 +379,7 @@ impl FeedScope for SqliteStorage {
             .execute(&mut tx)
             .await?;
 
-        tx.commit().await?;
-        Ok(())
+        tx.commit().await.map_err(Into::into)
     }
 }
 
@@ -404,8 +403,7 @@ impl SearchScope for SqliteStorage {
             .await?;
 
         if documents.is_empty() {
-            tx.commit().await?;
-            return Ok(());
+            return tx.commit().await.map_err(Into::into);
         };
 
         SqliteStorage::store_new_documents(&mut tx, documents).await?;
@@ -419,8 +417,7 @@ impl SearchScope for SqliteStorage {
             .execute(&mut tx)
             .await?;
 
-        tx.commit().await?;
-        Ok(())
+        tx.commit().await.map_err(Into::into)
     }
 
     async fn store_next_page(
@@ -446,8 +443,7 @@ impl SearchScope for SqliteStorage {
             .execute(&mut tx)
             .await?;
 
-        tx.commit().await?;
-        Ok(())
+        tx.commit().await.map_err(Into::into)
     }
 
     async fn fetch(&self) -> Result<(Search, Vec<ApiDocumentView>), Error> {

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -520,7 +520,7 @@ impl SearchScope for SqliteStorage {
         .bind(id)
         .fetch_one(&mut tx)
         .await
-        .on_row_not_found(Error::NoDocument)?;
+        .on_row_not_found(Error::NoDocument(id))?;
 
         tx.commit().await?;
 
@@ -853,7 +853,7 @@ mod tests {
         let id = document::Id::new();
         assert!(matches!(
             storage.search().get_document(id).await.unwrap_err(),
-            Error::NoDocument
+            Error::NoDocument(bad_id) if bad_id == id
         ));
 
         let documents = create_documents(1);
@@ -873,7 +873,7 @@ mod tests {
         let id = document::Id::new();
         assert!(matches!(
             storage.search().get_document(id).await.unwrap_err(),
-            Error::NoDocument,
+            Error::NoDocument(bad_id) if bad_id == id,
         ));
     }
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{borrow::Cow, collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, Utc};

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -52,29 +52,6 @@ use crate::storage::utils::SqlxPushTupleExt;
 // Sqlite bind limit
 const BIND_LIMIT: usize = 32766;
 
-trait SqlxSqliteErrorExt<V> {
-    /// Use this on the result of a sqlite query which might have failed a foreign
-    /// key constraint when an illegal document was passed in.
-    ///
-    /// For example it can be used in `.user_reacted` to handle it being
-    /// called with a random document id.
-    ///
-    /// If there is an error and it is a fk violation an appropriate error variant is
-    /// used instead of the default generic database error.
-    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error>;
-}
-
-impl<V> SqlxSqliteErrorExt<V> for Result<V, sqlx::Error> {
-    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error> {
-        if let Err(sqlx::Error::Database(db_err)) = &self {
-            if db_err.code() == Some(Cow::Borrowed("787")) {
-                return Err(Error::InvalidDocumentId(id));
-            }
-        }
-        self.map_err(Into::into)
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct SqliteStorage {
     pool: Pool<Sqlite>,
@@ -941,38 +918,6 @@ mod tests {
             feed[0].newscatcher_data.domain_rank,
             docs[0].newscatcher_data.domain_rank
         );
-    }
-
-    #[tokio::test]
-    async fn test_fk_violation_is_invalid_document() {
-        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
-
-        sqlx::query("CREATE TABLE Foo(x INTEGER PRIMARY KEY);")
-            .execute(&storage.pool)
-            .await
-            .unwrap();
-
-        sqlx::query("CREATE TABLE Bar(x INTEGER PRIMARY KEY REFERENCES Foo(x));")
-            .execute(&storage.pool)
-            .await
-            .unwrap();
-
-        let document_id = document::Id::new();
-
-        let res = sqlx::query("INSERT INTO Bar(x) VALUES (?);")
-            .bind(10)
-            .execute(&storage.pool)
-            .await
-            .fk_violation_is_invalid_document_id(document_id);
-
-        assert!(matches!(res, Err(Error::InvalidDocumentId(id)) if id == document_id));
-
-        let res = sqlx::query("malformed;")
-            .execute(&storage.pool)
-            .await
-            .fk_violation_is_invalid_document_id(document_id);
-
-        assert!(!matches!(res, Err(Error::InvalidDocumentId(_))));
     }
 
     #[tokio::test]

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -838,11 +838,8 @@ mod tests {
             .await
             .unwrap();
 
-        let search = storage.search().fetch().await.unwrap();
-        assert!(search.1.is_empty());
-
-        let a_search_was_closed = storage.search().clear().await.unwrap();
-        assert!(a_search_was_closed);
+        assert!(storage.search().fetch().await.unwrap().1.is_empty());
+        assert!(storage.search().clear().await.unwrap());
     }
 
     #[tokio::test]

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -19,7 +19,10 @@ use chrono::{NaiveDateTime, Utc};
 use num_traits::FromPrimitive;
 use sqlx::{
     sqlite::{Sqlite, SqliteConnectOptions, SqlitePoolOptions},
-    FromRow, Pool, QueryBuilder, Transaction,
+    FromRow,
+    Pool,
+    QueryBuilder,
+    Transaction,
 };
 use url::Url;
 use xayn_discovery_engine_providers::Market;
@@ -29,13 +32,26 @@ use crate::{
     stack,
     storage::{
         models::{
-            ApiDocumentView, NewDocument, NewsResource, NewscatcherData, Paging, Search, SearchBy,
+            ApiDocumentView,
+            NewDocument,
+            NewsResource,
+            NewscatcherData,
+            Paging,
+            Search,
+            SearchBy,
         },
-        Error, FeedScope, SearchScope, Storage,
+        Error,
+        FeedScope,
+        SearchScope,
+        Storage,
     },
 };
 
-use crate::storage::utils::{SqlxPushTupleExt, SqlxSqliteErrorExt};
+use crate::storage::utils::SqlxPushTupleExt;
+
+use self::utils::SqlxSqliteResultExt;
+
+mod utils;
 
 // Sqlite bind limit
 const BIND_LIMIT: usize = 32766;

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -295,7 +295,6 @@ impl Storage for SqliteStorage {
             FROM HistoricDocument   AS hd
             JOIN NewsResource       AS nr   USING (documentId);",
         )
-        .persistent(false)
         .fetch_all(&mut tx)
         .await?;
 
@@ -354,7 +353,6 @@ impl FeedScope for SqliteStorage {
             JOIN StackDocument          As st   USING (documentId)
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
         )
-        .persistent(false)
         .fetch_all(&mut tx)
         .await?;
 
@@ -420,7 +418,6 @@ impl SearchScope for SqliteStorage {
                 "Search (rowid, searchBy, searchTerm, pageSize, pageNumber) VALUES (1, ?, ?, ?, ?)",
             )
             .build()
-            .persistent(false)
             .bind(search.search_by as u8)
             .bind(&search.search_term)
             .bind(search.paging.size)
@@ -472,7 +469,6 @@ impl SearchScope for SqliteStorage {
             .reset()
             .push("UPDATE Search SET pageNumber = ? WHERE rowid = 1;")
             .build()
-            .persistent(false)
             .bind(page_number)
             .execute(&mut tx)
             .await?;
@@ -492,7 +488,6 @@ impl SearchScope for SqliteStorage {
             WHERE rowid = 1;",
             )
             .build()
-            .persistent(false)
             .try_map(|row| QueriedSearch::from_row(&row))
             .fetch_one(&mut tx)
             .await
@@ -519,7 +514,6 @@ impl SearchScope for SqliteStorage {
             ORDER BY po.timestamp, po.inBatchIndex ASC;",
             )
             .build()
-            .persistent(false)
             .try_map(|row| QueriedApiDocumentView::from_row(&row))
             .fetch_all(&mut tx)
             .await?;
@@ -548,7 +542,6 @@ impl SearchScope for SqliteStorage {
                 WHERE ur.userReaction = ?;",
             )
             .build()
-            .persistent(false)
             .bind(UserReaction::Neutral as u32)
             .try_map(|row| document::Id::from_row(&row))
             .fetch_all(&mut tx)
@@ -561,7 +554,6 @@ impl SearchScope for SqliteStorage {
             .reset()
             .push("DELETE FROM SearchDocument;")
             .build()
-            .persistent(false)
             .execute(&mut tx)
             .await?;
 
@@ -570,7 +562,6 @@ impl SearchScope for SqliteStorage {
             .reset()
             .push("DELETE FROM Search;")
             .build()
-            .persistent(false)
             .execute(&mut tx)
             .await?;
 
@@ -595,7 +586,6 @@ impl SearchScope for SqliteStorage {
             JOIN Embedding              AS em   USING (documentId)
             WHERE documentId = ?;",
         )
-        .persistent(false)
         .bind(id)
         .fetch_one(&mut tx)
         .await
@@ -1025,7 +1015,6 @@ mod tests {
 
         let random_id = stack::Id::new_random();
         sqlx::query("INSERT INTO Stack(stackId) VALUES (?), (?);")
-            .persistent(false)
             .bind(stack::PersonalizedNews::id())
             .bind(random_id)
             .execute(&mut tx)
@@ -1040,7 +1029,6 @@ mod tests {
         tx.commit().await.unwrap();
 
         let ids = sqlx::query_as::<_, stack::Id>("SELECT stackId FROM Stack;")
-            .persistent(false)
             .fetch_all(&storage.pool)
             .await
             .unwrap();

--- a/discovery_engine_core/core/src/storage/sqlite/utils.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/utils.rs
@@ -1,0 +1,89 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Module containing sqlite specific utilities.
+
+use std::borrow::Cow;
+
+use crate::storage::Error;
+
+pub(crate) trait SqlxSqliteResultExt<T> {
+    /// In case of a foreign key violation return given error.
+    ///
+    /// Converts other `sqlx::Error`s to `storage::Error`s.
+    fn on_fk_violation(self, error: Error) -> Result<T, Error>;
+
+    /// In case of a row not found error return given error.
+    ///
+    /// Converts other `sqlx::Error`s to `storage::Error`s.
+    fn on_row_not_found(self, error: Error) -> Result<T, Error>;
+}
+
+impl<T> SqlxSqliteResultExt<T> for Result<T, sqlx::Error> {
+    fn on_fk_violation(self, error: Error) -> Result<T, Error> {
+        if let Err(sqlx::Error::Database(db_err)) = &self {
+            if db_err.code() == Some(Cow::Borrowed("787")) {
+                return Err(error);
+            }
+        }
+        self.map_err(Into::into)
+    }
+
+    fn on_row_not_found(self, error: Error) -> Result<T, Error> {
+        if let Err(sqlx::Error::RowNotFound) = &self {
+            Err(error)
+        } else {
+            self.map_err(Into::into)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{document, storage::sqlite::SqliteStorage};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_fk_violation_is_invalid_document() {
+        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query("CREATE TABLE Foo(x INTEGER PRIMARY KEY);")
+            .execute(&storage.pool)
+            .await
+            .unwrap();
+
+        sqlx::query("CREATE TABLE Bar(x INTEGER PRIMARY KEY REFERENCES Foo(x));")
+            .execute(&storage.pool)
+            .await
+            .unwrap();
+
+        let document_id = document::Id::new();
+
+        let res = sqlx::query("INSERT INTO Bar(x) VALUES (?);")
+            .bind(10u32)
+            .execute(&storage.pool)
+            .await
+            .on_fk_violation(Error::NoDocument(document_id));
+
+        assert!(matches!(res, Err(Error::NoDocument(id)) if id == document_id));
+
+        let res = sqlx::query("malformed;")
+            .execute(&storage.pool)
+            .await
+            .on_fk_violation(Error::NoDocument(document_id));
+
+        assert!(!matches!(res, Err(Error::NoDocument(_))));
+    }
+}

--- a/discovery_engine_core/core/src/storage/utils.rs
+++ b/discovery_engine_core/core/src/storage/utils.rs
@@ -100,15 +100,15 @@ mod tests {
             .bind(10u32)
             .execute(&storage.pool)
             .await
-            .on_fk_violation(Error::InvalidDocumentId(document_id));
+            .on_fk_violation(Error::NoDocument(document_id));
 
-        assert!(matches!(res, Err(Error::InvalidDocumentId(id)) if id == document_id));
+        assert!(matches!(res, Err(Error::NoDocument(id)) if id == document_id));
 
         let res = sqlx::query("malformed;")
             .execute(&storage.pool)
             .await
-            .on_fk_violation(Error::InvalidDocumentId(document_id));
+            .on_fk_violation(Error::NoDocument(document_id));
 
-        assert!(!matches!(res, Err(Error::InvalidDocumentId(_))));
+        assert!(!matches!(res, Err(Error::NoDocument(_))));
     }
 }

--- a/discovery_engine_core/core/src/storage/utils.rs
+++ b/discovery_engine_core/core/src/storage/utils.rs
@@ -12,11 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::borrow::Cow;
+//! Module containing non-database specific sqlx utilities.
 
 use sqlx::{Database, Encode, QueryBuilder, Type};
-
-use crate::storage::Error;
 
 pub(super) trait SqlxPushTupleExt<'args, DB: Database> {
     fn push_tuple<I>(&mut self, values: I) -> &mut Self
@@ -40,75 +38,5 @@ where
         }
         separated.push_unseparated(")");
         self
-    }
-}
-
-pub(crate) trait SqlxSqliteResultExt<T> {
-    /// In case of a foreign key violation return given error.
-    ///
-    /// Converts other `sqlx::Error`s to `storage::Error`s.
-    fn on_fk_violation(self, error: Error) -> Result<T, Error>;
-
-    /// In case of a row not found error return given error.
-    ///
-    /// Converts other `sqlx::Error`s to `storage::Error`s.
-    fn on_row_not_found(self, error: Error) -> Result<T, Error>;
-}
-
-impl<T> SqlxSqliteResultExt<T> for Result<T, sqlx::Error> {
-    fn on_fk_violation(self, error: Error) -> Result<T, Error> {
-        if let Err(sqlx::Error::Database(db_err)) = &self {
-            if db_err.code() == Some(Cow::Borrowed("787")) {
-                return Err(error);
-            }
-        }
-        self.map_err(Into::into)
-    }
-
-    fn on_row_not_found(self, error: Error) -> Result<T, Error> {
-        if let Err(sqlx::Error::RowNotFound) = &self {
-            Err(error)
-        } else {
-            self.map_err(Into::into)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{document, storage::sqlite::SqliteStorage};
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_fk_violation_is_invalid_document() {
-        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
-
-        sqlx::query("CREATE TABLE Foo(x INTEGER PRIMARY KEY);")
-            .execute(&storage.pool)
-            .await
-            .unwrap();
-
-        sqlx::query("CREATE TABLE Bar(x INTEGER PRIMARY KEY REFERENCES Foo(x));")
-            .execute(&storage.pool)
-            .await
-            .unwrap();
-
-        let document_id = document::Id::new();
-
-        let res = sqlx::query("INSERT INTO Bar(x) VALUES (?);")
-            .bind(10u32)
-            .execute(&storage.pool)
-            .await
-            .on_fk_violation(Error::NoDocument(document_id));
-
-        assert!(matches!(res, Err(Error::NoDocument(id)) if id == document_id));
-
-        let res = sqlx::query("malformed;")
-            .execute(&storage.pool)
-            .await
-            .on_fk_violation(Error::NoDocument(document_id));
-
-        assert!(!matches!(res, Err(Error::NoDocument(_))));
     }
 }

--- a/discovery_engine_core/core/src/storage/utils.rs
+++ b/discovery_engine_core/core/src/storage/utils.rs
@@ -43,20 +43,20 @@ where
     }
 }
 
-pub(crate) trait SqlxSqliteErrorExt<V> {
+pub(crate) trait SqlxSqliteResultExt<T> {
     /// In case of a foreign key violation return given error.
     ///
     /// Converts other `sqlx::Error`s to `storage::Error`s.
-    fn on_fk_violation(self, error: Error) -> Result<V, Error>;
+    fn on_fk_violation(self, error: Error) -> Result<T, Error>;
 
     /// In case of a row not found error return given error.
     ///
     /// Converts other `sqlx::Error`s to `storage::Error`s.
-    fn on_row_not_found(self, error: Error) -> Result<V, Error>;
+    fn on_row_not_found(self, error: Error) -> Result<T, Error>;
 }
 
-impl<V> SqlxSqliteErrorExt<V> for Result<V, sqlx::Error> {
-    fn on_fk_violation(self, error: Error) -> Result<V, Error> {
+impl<T> SqlxSqliteResultExt<T> for Result<T, sqlx::Error> {
+    fn on_fk_violation(self, error: Error) -> Result<T, Error> {
         if let Err(sqlx::Error::Database(db_err)) = &self {
             if db_err.code() == Some(Cow::Borrowed("787")) {
                 return Err(error);
@@ -65,7 +65,7 @@ impl<V> SqlxSqliteErrorExt<V> for Result<V, sqlx::Error> {
         self.map_err(Into::into)
     }
 
-    fn on_row_not_found(self, error: Error) -> Result<V, Error> {
+    fn on_row_not_found(self, error: Error) -> Result<T, Error> {
         if let Err(sqlx::Error::RowNotFound) = &self {
             Err(error)
         } else {

--- a/discovery_engine_core/core/src/storage/utils.rs
+++ b/discovery_engine_core/core/src/storage/utils.rs
@@ -12,7 +12,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::borrow::Cow;
+
 use sqlx::{Database, Encode, QueryBuilder, Type};
+
+use crate::{document, storage::Error};
 
 pub(super) trait SqlxPushTupleExt<'args, DB: Database> {
     fn push_tuple<I>(&mut self, values: I) -> &mut Self
@@ -36,5 +40,67 @@ where
         }
         separated.push_unseparated(")");
         self
+    }
+}
+
+trait SqlxSqliteErrorExt<V> {
+    /// Use this on the result of a sqlite query which might have failed a foreign
+    /// key constraint when an illegal document was passed in.
+    ///
+    /// For example it can be used in `.user_reacted` to handle it being
+    /// called with a random document id.
+    ///
+    /// If there is an error and it is a fk violation an appropriate error variant is
+    /// used instead of the default generic database error.
+    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error>;
+}
+
+impl<V> SqlxSqliteErrorExt<V> for Result<V, sqlx::Error> {
+    fn fk_violation_is_invalid_document_id(self, id: document::Id) -> Result<V, Error> {
+        if let Err(sqlx::Error::Database(db_err)) = &self {
+            if db_err.code() == Some(Cow::Borrowed("787")) {
+                return Err(Error::InvalidDocumentId(id));
+            }
+        }
+        self.map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::sqlite::SqliteStorage;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_fk_violation_is_invalid_document() {
+        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query("CREATE TABLE Foo(x INTEGER PRIMARY KEY);")
+            .execute(&storage.pool)
+            .await
+            .unwrap();
+
+        sqlx::query("CREATE TABLE Bar(x INTEGER PRIMARY KEY REFERENCES Foo(x));")
+            .execute(&storage.pool)
+            .await
+            .unwrap();
+
+        let document_id = document::Id::new();
+
+        let res = sqlx::query("INSERT INTO Bar(x) VALUES (?);")
+            .bind(10)
+            .execute(&storage.pool)
+            .await
+            .fk_violation_is_invalid_document_id(document_id);
+
+        assert!(matches!(res, Err(Error::InvalidDocumentId(id)) if id == document_id));
+
+        let res = sqlx::query("malformed;")
+            .execute(&storage.pool)
+            .await
+            .fk_violation_is_invalid_document_id(document_id);
+
+        assert!(!matches!(res, Err(Error::InvalidDocumentId(_))));
     }
 }


### PR DESCRIPTION
- cleans up error handling
- Fix incorrect `NoRowFound` error handling.

  A `NoRowFound` error can only be returned by methods which require a  row to be returned. E.g. by `fetch_one` but not `fetch_all` or   `fetch_optional`.
- Removed premature usage of `.persitent(false)`

  In general this should only be set in cases where a "dynamic"  query is build (i.e. using `push_{values,tuple}`) is used. Even   in some cases where `push_{values,tuple}` is used it might make  sense to not set it to false (potentially conditionally).

  Every non-dynamic  use of `.persistent(false)` is at best a premature optimization we should avoid for now AFIK.
- Remove `QueryBuilder` misuse

  Only use `QueryBuilder` if a query needs to be dynamically build,  e.g. `push_values` or `push_tuple` is used or conditionally `push`  is called. Using it with a static query has no benefits at all.
 - Move `SqlxSqliteErrorExt` to sqlite/utils.rs.
 - Added `.on_row_not_found` `Result<V, sqlx::Error>` extension.

**Based On:**
- #521 