### PR TITLE
[Merged by Bors] - TY-2979 move feed logic to rust (3): changeConfiguration

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -46,6 +46,9 @@ abstract class Engine {
   /// Serializes the state of the [Engine].
   Future<Uint8List> serialize();
 
+  /// Configures the running engine.
+  Future<void> configure(String deConfig);
+
   /// Changes the currently supported markets.
   Future<void> setMarkets(
     List<HistoricDocument> history,
@@ -70,14 +73,12 @@ abstract class Engine {
   /// Gets the next batch of feed documents.
   Future<List<DocumentWithActiveData>> feedNextBatch(
     List<SourceReacted> sources,
-    int maxDocuments,
   );
 
-  /// Retrieves at most [maxDocuments] feed documents.
+  /// Gets the next batch of feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     List<HistoricDocument> history,
     List<SourceReacted> sources,
-    int maxDocuments,
   );
 
   /// Restores the feed documents, ordered by their global rank (timestamp & local rank).
@@ -99,18 +100,10 @@ abstract class Engine {
   );
 
   /// Perform an active search by query.
-  Future<List<DocumentWithActiveData>> searchByQuery(
-    String query,
-    int page,
-    int pageSize,
-  );
+  Future<List<DocumentWithActiveData>> searchByQuery(String query, int page);
 
   /// Perform an active search by topic.
-  Future<List<DocumentWithActiveData>> searchByTopic(
-    String topic,
-    int page,
-    int pageSize,
-  );
+  Future<List<DocumentWithActiveData>> searchByTopic(String topic, int page);
 
   /// Performs an active search by document id (aka deep search).
   ///

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -67,6 +67,11 @@ class MockEngine implements Engine {
   }
 
   @override
+  Future<void> configure(String deConfig) async {
+    _incrementCount('configure');
+  }
+
+  @override
   Future<Uint8List> serialize() async {
     _incrementCount('serialize');
     return Uint8List(0);
@@ -104,26 +109,24 @@ class MockEngine implements Engine {
   @override
   Future<List<DocumentWithActiveData>> feedNextBatch(
     List<SourceReacted> sources,
-    int maxDocuments,
   ) async {
     _incrementCount('feedNextBatch');
-    return feedDocuments.take(maxDocuments).toList(growable: false);
+    return feedDocuments.take(2).toList(growable: false);
   }
 
   @override
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     List<HistoricDocument> history,
     List<SourceReacted> sources,
-    int maxDocuments,
   ) async {
     _incrementCount('getFeedDocuments');
-    return feedDocuments.take(maxDocuments).toList(growable: false);
+    return feedDocuments.take(2).toList(growable: false);
   }
 
   @override
   Future<List<DocumentWithActiveData>> restoreFeed() async {
     _incrementCount('restoreFeed');
-    return feedDocuments.take(10).toList(growable: false);
+    return feedDocuments.take(2).toList(growable: false);
   }
 
   @override
@@ -149,20 +152,18 @@ class MockEngine implements Engine {
   Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
     int page,
-    int pageSize,
   ) async {
-    _incrementCount('activeSearch');
-    return activeSearchDocuments.take(pageSize).toList(growable: false);
+    _incrementCount('searchByQuery');
+    return activeSearchDocuments.take(20).toList(growable: false);
   }
 
   @override
   Future<List<DocumentWithActiveData>> searchByTopic(
     String topic,
     int page,
-    int pageSize,
   ) async {
     _incrementCount('searchByTopic');
-    return activeSearchDocuments.take(pageSize).toList(growable: false);
+    return activeSearchDocuments.take(20).toList(growable: false);
   }
 
   @override
@@ -174,13 +175,13 @@ class MockEngine implements Engine {
   @override
   Future<List<DocumentWithActiveData>> searchNextBatch() async {
     _incrementCount('searchNextBatch');
-    return activeSearchDocuments.take(10).toList(growable: false);
+    return activeSearchDocuments.take(20).toList(growable: false);
   }
 
   @override
   Future<List<DocumentWithActiveData>> restoreSearch() async {
-    _incrementCount('searched');
-    return activeSearchDocuments.take(10).toList(growable: false);
+    _incrementCount('restoreSearch');
+    return activeSearchDocuments.take(20).toList(growable: false);
   }
 
   @override

--- a/discovery_engine/lib/src/domain/event_handler.dart
+++ b/discovery_engine/lib/src/domain/event_handler.dart
@@ -105,17 +105,6 @@ import 'package:xayn_discovery_engine/src/infrastructure/type_adapters/hive_uri_
     show UriAdapter;
 import 'package:xayn_discovery_engine/src/logger.dart' show logger;
 
-class EventConfig {
-  int maxFeedDocs;
-  int maxSearchDocs;
-
-  EventConfig({
-    required this.maxFeedDocs,
-    required this.maxSearchDocs,
-  })  : assert(maxFeedDocs > 0),
-        assert(maxSearchDocs > 0);
-}
-
 class EventHandler {
   Engine? _engine;
   final AssetReporter _assetReporter;
@@ -271,10 +260,6 @@ class EventHandler {
     }
 
     // init managers
-    final eventConfig = EventConfig(
-      maxFeedDocs: config.maxItemsPerFeedBatch,
-      maxSearchDocs: config.maxItemsPerSearchBatch,
-    );
     _documentManager = DocumentManager(
       engine,
       documentRepository,
@@ -285,7 +270,6 @@ class EventHandler {
     );
     _feedManager = FeedManager(
       engine,
-      eventConfig,
       documentRepository,
       activeDataRepository,
       engineStateRepository,
@@ -295,7 +279,6 @@ class EventHandler {
     );
     _searchManager = SearchManager(
       engine,
-      eventConfig,
       activeSearchRepository,
       documentRepository,
       activeDataRepository,
@@ -303,7 +286,6 @@ class EventHandler {
     );
     _systemManager = SystemManager(
       engine,
-      eventConfig,
       documentRepository,
       sourceReactedRepository,
       clearAiState,

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -22,8 +22,6 @@ import 'package:xayn_discovery_engine/src/api/models/document.dart'
     show DocumentApiConversion;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
-import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
-    show EventConfig;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/source.dart'
@@ -45,7 +43,6 @@ import 'package:xayn_discovery_engine/src/domain/repository/source_reacted_repo.
 /// Business logic concerning the management of the feed.
 class FeedManager {
   final Engine _engine;
-  final EventConfig _config;
   final DocumentRepository _docRepo;
   final ActiveDocumentDataRepository _activeRepo;
   final EngineStateRepository _engineStateRepo;
@@ -55,7 +52,6 @@ class FeedManager {
 
   FeedManager(
     this._engine,
-    this._config,
     this._docRepo,
     this._activeRepo,
     this._engineStateRepo,
@@ -130,7 +126,7 @@ class FeedManager {
       final sources = await _sourceReactedRepo.fetchAll();
       final List<DocumentWithActiveData> docs;
       try {
-        docs = await _engine.feedNextBatch(sources, _config.maxFeedDocs);
+        docs = await _engine.feedNextBatch(sources);
       } on Exception catch (e) {
         return EngineEvent.nextFeedBatchRequestFailed(
           FeedFailureReason.stacksOpsError,
@@ -155,8 +151,7 @@ class FeedManager {
     final sources = await _sourceReactedRepo.fetchAll();
     final List<DocumentWithActiveData> feedDocs;
     try {
-      feedDocs =
-          await _engine.getFeedDocuments(history, sources, _config.maxFeedDocs);
+      feedDocs = await _engine.getFeedDocuments(history, sources);
     } catch (e) {
       return EngineEvent.nextFeedBatchRequestFailed(
         FeedFailureReason.stacksOpsError,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -23,8 +23,6 @@ import 'package:xayn_discovery_engine/src/api/models/active_search.dart'
 import 'package:xayn_discovery_engine/src/api/models/document.dart' as api;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
-import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
-    show EventConfig;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show DocumentWithActiveData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
@@ -49,7 +47,6 @@ typedef DocsByReaction = Map<UserReaction, List<Document>>;
 /// Business logic concerning the management of the active search.
 class SearchManager {
   final Engine _engine;
-  final EventConfig _config;
   final ActiveSearchRepository _searchRepo;
   final DocumentRepository _docRepo;
   final ActiveDocumentDataRepository _activeRepo;
@@ -57,7 +54,6 @@ class SearchManager {
 
   SearchManager(
     this._engine,
-    this._config,
     this._searchRepo,
     this._docRepo,
     this._activeRepo,
@@ -90,14 +86,12 @@ class SearchManager {
         searchDocs = await _engine.searchByQuery(
           search.searchTerm,
           search.requestedPageNb,
-          search.pageSize,
         );
         break;
       case SearchBy.topic:
         searchDocs = await _engine.searchByTopic(
           search.searchTerm,
           search.requestedPageNb,
-          search.pageSize,
         );
         break;
     }
@@ -123,17 +117,14 @@ class SearchManager {
     if (cfgFeatureStorage) {
       final search = ActiveSearch(searchBy: by, searchTerm: term);
       const page = 1;
-      final pageSize = _config.maxSearchDocs;
       final List<DocumentWithActiveData> docs;
       try {
         switch (search.searchBy) {
           case SearchBy.query:
-            docs =
-                await _engine.searchByQuery(search.searchTerm, page, pageSize);
+            docs = await _engine.searchByQuery(search.searchTerm, page);
             break;
           case SearchBy.topic:
-            docs =
-                await _engine.searchByTopic(search.searchTerm, page, pageSize);
+            docs = await _engine.searchByTopic(search.searchTerm, page);
             break;
         }
       } on Exception catch (e) {
@@ -161,7 +152,7 @@ class SearchManager {
       searchBy: by,
       searchTerm: term,
       requestedPageNb: 1,
-      pageSize: _config.maxSearchDocs,
+      pageSize: -1, // unused
     );
     final docs = await _getActiveSearchDocuments(search);
     await _searchRepo.save(search);

--- a/discovery_engine/lib/src/domain/system_manager.dart
+++ b/discovery_engine/lib/src/domain/system_manager.dart
@@ -12,15 +12,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:meta/meta.dart' show visibleForTesting;
+import 'dart:convert' show jsonEncode;
+
 import 'package:xayn_discovery_engine/src/api/events/client_events.dart'
     show SystemClientEvent;
 import 'package:xayn_discovery_engine/src/api/events/engine_events.dart'
     show EngineEvent, EngineExceptionReason;
 import 'package:xayn_discovery_engine/src/domain/engine/engine.dart'
     show Engine;
-import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
-    show EventConfig;
 import 'package:xayn_discovery_engine/src/domain/models/feed_market.dart'
     show FeedMarkets;
 import 'package:xayn_discovery_engine/src/domain/repository/document_repo.dart'
@@ -30,24 +29,16 @@ import 'package:xayn_discovery_engine/src/domain/repository/source_reacted_repo.
 /// Business logic concerning the management of the engine system.
 class SystemManager {
   final Engine _engine;
-  final EventConfig _config;
   final DocumentRepository _docRepo;
   final SourceReactedRepository _sourceReactedRepo;
   final Future<void> Function() _clearAiState;
 
   SystemManager(
     this._engine,
-    this._config,
     this._docRepo,
     this._sourceReactedRepo,
     this._clearAiState,
   );
-
-  @visibleForTesting
-  int get maxFeedDocs => _config.maxFeedDocs;
-
-  @visibleForTesting
-  int get maxSearchDocs => _config.maxSearchDocs;
 
   /// Handle the given system client event.
   ///
@@ -79,12 +70,14 @@ class SystemManager {
         );
       }
     }
+    final deConfig = <String, dynamic>{};
     if (maxItemsPerFeedBatch != null) {
-      _config.maxFeedDocs = maxItemsPerFeedBatch;
+      deConfig['feed'] = {'max_docs_per_batch': maxItemsPerFeedBatch};
     }
     if (maxItemsPerSearchBatch != null) {
-      _config.maxSearchDocs = maxItemsPerSearchBatch;
+      deConfig['search'] = {'max_docs_per_batch': maxItemsPerSearchBatch};
     }
+    await _engine.configure(jsonEncode(deConfig));
 
     return const EngineEvent.clientEventSucceeded();
   }

--- a/discovery_engine/lib/src/ffi/types/embedding.dart
+++ b/discovery_engine/lib/src/ffi/types/embedding.dart
@@ -21,14 +21,14 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
-    show checkFfiUsize;
+    show FfiUsizeFfi;
 
 extension EmbeddingFfi on Embedding {
   void writeNative(
     final Pointer<RustEmbedding> place,
   ) {
     final len = values.length;
-    checkFfiUsize(len, 'Embedding.length');
+    len.checkFfiUsize('Embedding.length');
     final buffer = ffi.alloc_uninitialized_f32_slice(len);
     buffer.asTypedList(len).setAll(0, values);
     ffi.init_embedding_at(place, buffer, len);

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -117,6 +117,11 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
+  Future<void> configure(String deConfig) async {
+    await asyncFfi.configure(_engine.ref, deConfig.allocNative().move());
+  }
+
+  @override
   Future<Uint8List> serialize() async {
     final result = await asyncFfi.serialize(_engine.ref);
 
@@ -174,13 +179,9 @@ class DiscoveryEngineFfi implements Engine {
   @override
   Future<List<DocumentWithActiveData>> feedNextBatch(
     final List<SourceReacted> sources,
-    final int maxDocuments,
   ) async {
-    final result = await asyncFfi.feedNextBatch(
-      _engine.ref,
-      sources.allocVec().move(),
-      maxDocuments,
-    );
+    final result =
+        await asyncFfi.feedNextBatch(_engine.ref, sources.allocVec().move());
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)
@@ -191,13 +192,11 @@ class DiscoveryEngineFfi implements Engine {
   Future<List<DocumentWithActiveData>> getFeedDocuments(
     final List<HistoricDocument> history,
     final List<SourceReacted> sources,
-    final int maxDocuments,
   ) async {
     final result = await asyncFfi.getFeedDocuments(
       _engine.ref,
       history.allocNative().move(),
       sources.allocVec().move(),
-      maxDocuments,
     );
 
     return resultVecDocumentStringFfiAdapter
@@ -251,14 +250,11 @@ class DiscoveryEngineFfi implements Engine {
   Future<List<DocumentWithActiveData>> searchByQuery(
     String query,
     int page,
-    int pageSize,
   ) async {
-    final boxedQuery = query.allocNative();
     final result = await asyncFfi.searchByQuery(
       _engine.ref,
-      boxedQuery.move(),
+      query.allocNative().move(),
       page,
-      pageSize,
     );
 
     return resultVecDocumentStringFfiAdapter
@@ -270,14 +266,11 @@ class DiscoveryEngineFfi implements Engine {
   Future<List<DocumentWithActiveData>> searchByTopic(
     String topic,
     int page,
-    int pageSize,
   ) async {
-    final boxedTopic = topic.allocNative();
     final result = await asyncFfi.searchByTopic(
       _engine.ref,
-      boxedTopic.move(),
+      topic.allocNative().move(),
       page,
-      pageSize,
     );
 
     return resultVecDocumentStringFfiAdapter

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -28,6 +28,8 @@ import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
+import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
+    show FfiUsizeFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart'
     show OptionStringFfi, StringFfi, StringListFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
@@ -36,17 +38,19 @@ import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_prov
 class InitConfigFfi with EquatableMixin {
   final String apiKey;
   final String apiBaseUrl;
+  final String newsProviderPath;
+  final String headlinesProviderPath;
   final List<FeedMarket> feedMarkets;
   final List<String> trustedSources;
   final List<String> excludedSources;
-  final String newsProviderPath;
-  final String headlinesProviderPath;
   final String smbertVocab;
   final String smbertModel;
   final String kpeVocab;
   final String kpeModel;
   final String kpeCnn;
   final String kpeClassifier;
+  final int maxDocsPerFeedBatch;
+  final int maxDocsPerSearchBatch;
   final String? deConfig;
   final String? logFile;
 
@@ -54,17 +58,19 @@ class InitConfigFfi with EquatableMixin {
   List<Object?> get props => [
         apiKey,
         apiBaseUrl,
+        newsProviderPath,
+        headlinesProviderPath,
         feedMarkets,
         trustedSources,
         excludedSources,
-        newsProviderPath,
-        headlinesProviderPath,
         smbertVocab,
         smbertModel,
         kpeVocab,
         kpeModel,
         kpeCnn,
         kpeClassifier,
+        maxDocsPerFeedBatch,
+        maxDocsPerSearchBatch,
         deConfig,
         logFile,
       ];
@@ -79,17 +85,19 @@ class InitConfigFfi with EquatableMixin {
       InitConfigFfi.fromParts(
         apiKey: configuration.apiKey,
         apiBaseUrl: configuration.apiBaseUrl,
+        newsProviderPath: configuration.newsProviderPath,
+        headlinesProviderPath: configuration.headlinesProviderPath,
         feedMarkets: configuration.feedMarkets.toList(),
         trustedSources: trustedSources.toStringList(),
         excludedSources: excludedSources.toStringList(),
-        newsProviderPath: configuration.newsProviderPath,
-        headlinesProviderPath: configuration.headlinesProviderPath,
         smbertVocab: setupData.smbertVocab,
         smbertModel: setupData.smbertModel,
         kpeVocab: setupData.kpeVocab,
         kpeModel: setupData.kpeModel,
         kpeCnn: setupData.kpeCnn,
         kpeClassifier: setupData.kpeClassifier,
+        maxDocsPerFeedBatch: configuration.maxItemsPerFeedBatch,
+        maxDocsPerSearchBatch: configuration.maxItemsPerSearchBatch,
         deConfig: deConfig,
         logFile: configuration.logFile,
       );
@@ -97,17 +105,19 @@ class InitConfigFfi with EquatableMixin {
   InitConfigFfi.fromParts({
     required this.apiKey,
     required this.apiBaseUrl,
+    required this.newsProviderPath,
+    required this.headlinesProviderPath,
     required this.feedMarkets,
     required this.trustedSources,
     required this.excludedSources,
-    required this.newsProviderPath,
-    required this.headlinesProviderPath,
     required this.smbertVocab,
     required this.smbertModel,
     required this.kpeVocab,
     required this.kpeModel,
     required this.kpeCnn,
     required this.kpeClassifier,
+    required this.maxDocsPerFeedBatch,
+    required this.maxDocsPerSearchBatch,
     this.deConfig,
     this.logFile,
   });
@@ -122,20 +132,24 @@ class InitConfigFfi with EquatableMixin {
   void writeNative(Pointer<RustInitConfig> place) {
     apiKey.writeNative(ffi.init_config_place_of_api_key(place));
     apiBaseUrl.writeNative(ffi.init_config_place_of_api_base_url(place));
-    feedMarkets.writeVec(ffi.init_config_place_of_markets(place));
-    trustedSources.writeNative(ffi.init_config_place_of_trusted_sources(place));
-    excludedSources
-        .writeNative(ffi.init_config_place_of_excluded_sources(place));
     newsProviderPath
         .writeNative(ffi.init_config_place_of_news_provider_path(place));
     headlinesProviderPath
         .writeNative(ffi.init_config_place_of_headlines_provider_path(place));
+    feedMarkets.writeVec(ffi.init_config_place_of_markets(place));
+    trustedSources.writeNative(ffi.init_config_place_of_trusted_sources(place));
+    excludedSources
+        .writeNative(ffi.init_config_place_of_excluded_sources(place));
     smbertVocab.writeNative(ffi.init_config_place_of_smbert_vocab(place));
     smbertModel.writeNative(ffi.init_config_place_of_smbert_model(place));
     kpeVocab.writeNative(ffi.init_config_place_of_kpe_vocab(place));
     kpeModel.writeNative(ffi.init_config_place_of_kpe_model(place));
     kpeCnn.writeNative(ffi.init_config_place_of_kpe_cnn(place));
     kpeClassifier.writeNative(ffi.init_config_place_of_kpe_classifier(place));
+    maxDocsPerFeedBatch
+        .writeNative(ffi.init_config_place_of_max_docs_per_feed_batch(place));
+    maxDocsPerSearchBatch
+        .writeNative(ffi.init_config_place_of_max_docs_per_search_batch(place));
     deConfig.writeNative(ffi.init_config_place_of_de_config(place));
     logFile.writeNative(ffi.init_config_place_of_log_file(place));
   }
@@ -146,6 +160,12 @@ class InitConfigFfi with EquatableMixin {
       apiKey: StringFfi.readNative(ffi.init_config_place_of_api_key(config)),
       apiBaseUrl:
           StringFfi.readNative(ffi.init_config_place_of_api_base_url(config)),
+      newsProviderPath: StringFfi.readNative(
+        ffi.init_config_place_of_news_provider_path(config),
+      ),
+      headlinesProviderPath: StringFfi.readNative(
+        ffi.init_config_place_of_headlines_provider_path(config),
+      ),
       feedMarkets:
           FeedMarketSliceFfi.readVec(ffi.init_config_place_of_markets(config)),
       trustedSources: StringListFfi.readNative(
@@ -153,12 +173,6 @@ class InitConfigFfi with EquatableMixin {
       ),
       excludedSources: StringListFfi.readNative(
         ffi.init_config_place_of_excluded_sources(config),
-      ),
-      newsProviderPath: StringFfi.readNative(
-        ffi.init_config_place_of_news_provider_path(config),
-      ),
-      headlinesProviderPath: StringFfi.readNative(
-        ffi.init_config_place_of_headlines_provider_path(config),
       ),
       smbertVocab:
           StringFfi.readNative(ffi.init_config_place_of_smbert_vocab(config)),
@@ -171,6 +185,12 @@ class InitConfigFfi with EquatableMixin {
       kpeCnn: StringFfi.readNative(ffi.init_config_place_of_kpe_cnn(config)),
       kpeClassifier:
           StringFfi.readNative(ffi.init_config_place_of_kpe_classifier(config)),
+      maxDocsPerFeedBatch: FfiUsizeFfi.readNative(
+        ffi.init_config_place_of_max_docs_per_feed_batch(config),
+      ),
+      maxDocsPerSearchBatch: FfiUsizeFfi.readNative(
+        ffi.init_config_place_of_max_docs_per_search_batch(config),
+      ),
       deConfig: OptionStringFfi.readNative(
         ffi.init_config_place_of_de_config(config),
       ),

--- a/discovery_engine/lib/src/ffi/types/list.dart
+++ b/discovery_engine/lib/src/ffi/types/list.dart
@@ -15,7 +15,7 @@
 import 'dart:ffi' show NativeType, Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
-    show checkFfiUsize;
+    show FfiUsizeFfi;
 
 class ListFfiAdapter<Type, RustType extends NativeType,
     RustVecType extends NativeType> {
@@ -40,7 +40,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
 
   /// Allocates a slice of `RustType` containing all items of this list.
   Pointer<RustType> createSlice(List<Type> list) {
-    checkFfiUsize(list.length, 'List.length');
+    list.length.checkFfiUsize('List.length');
     final slice = alloc(list.length);
     list.fold<Pointer<RustType>>(slice, (nextElement, market) {
       writeNative(market, nextElement);
@@ -54,7 +54,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final Pointer<RustType> ptr,
     final int len,
   ) {
-    checkFfiUsize(len, 'List.length');
+    len.checkFfiUsize('List.length');
     final out = <Type>[];
     Iterable<int>.generate(len).fold<Pointer<RustType>>(ptr, (nextElement, _) {
       out.add(readNative(nextElement));
@@ -68,7 +68,7 @@ class ListFfiAdapter<Type, RustType extends NativeType,
     final List<Type> list,
     final Pointer<RustVecType> place,
   ) {
-    checkFfiUsize(list.length, 'List.length');
+    list.length.checkFfiUsize('List.length');
     final slice = createSlice(list);
     writeNativeVec(place, slice, list.length);
   }

--- a/discovery_engine/lib/src/ffi/types/string.dart
+++ b/discovery_engine/lib/src/ffi/types/string.dart
@@ -22,7 +22,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/list.dart'
     show ListFfiAdapter;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
-    show checkFfiUsize;
+    show FfiUsizeFfi;
 
 extension StringFfi on String {
   void writeNative(final Pointer<RustString> place) {
@@ -70,14 +70,14 @@ class BoxedStr {
   final int len;
 
   BoxedStr.fromRawParts(this.ptr, this.len) {
-    checkFfiUsize(len, 'BoxedStr.len');
+    len.checkFfiUsize('BoxedStr.len');
   }
 
   /// Creates a `Box<str>` based on given dart string.
   factory BoxedStr.create(String string) {
     final utf8Bytes = utf8.encode(string);
     final len = utf8Bytes.length;
-    checkFfiUsize(len, 'String.len');
+    len.checkFfiUsize('String.len');
     final ptr = ffi.alloc_uninitialized_bytes(len);
     ptr.asTypedList(len).setAll(0, utf8Bytes);
     return BoxedStr.fromRawParts(ptr, len);

--- a/discovery_engine/test/feed_manager_test.dart
+++ b/discovery_engine/test/feed_manager_test.dart
@@ -20,7 +20,7 @@ import 'package:xayn_discovery_engine/src/api/api.dart' hide Document;
 import 'package:xayn_discovery_engine/src/domain/engine/mock_engine.dart'
     show MockEngine;
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
-    show EventConfig, EventHandler;
+    show EventHandler;
 import 'package:xayn_discovery_engine/src/domain/feed_manager.dart'
     show FeedManager;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
@@ -55,7 +55,6 @@ Future<void> main() async {
   late FeedManager mgr;
 
   final engine = MockEngine()..feedDocuments = mockDocuments(StackId(), false);
-  final config = EventConfig(maxFeedDocs: 5, maxSearchDocs: 20);
 
   EventHandler.registerHiveAdapters();
 
@@ -76,7 +75,6 @@ Future<void> main() async {
       sourcePreferenceRepo = HiveSourcePreferenceRepository();
       mgr = FeedManager(
         engine,
-        config,
         docRepo,
         activeRepo,
         engineStateRepo,
@@ -211,7 +209,6 @@ Future<void> main() async {
       sourcePreferenceRepo = HiveSourcePreferenceRepository();
       mgr = FeedManager(
         engine,
-        config,
         docRepo,
         activeRepo,
         engineStateRepo,

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -23,6 +23,8 @@ void main() {
     final config = InitConfigFfi.fromParts(
       apiKey: 'hjlsdfhjfdhjk',
       apiBaseUrl: 'https://foo.example/api/v1',
+      headlinesProviderPath: '/newscatcher/v1/latest-headlines',
+      newsProviderPath: '/newscatcher/v1/search-news',
       feedMarkets: [
         const FeedMarket(langCode: 'de', countryCode: 'DE'),
         const FeedMarket(langCode: 'en', countryCode: 'US'),
@@ -35,8 +37,8 @@ void main() {
       kpeModel: 'yo.lo',
       kpeCnn: 'abc',
       kpeClassifier: 'magic',
-      headlinesProviderPath: '/newscatcher/v1/latest-headlines',
-      newsProviderPath: '/newscatcher/v1/search-news',
+      maxDocsPerFeedBatch: 2,
+      maxDocsPerSearchBatch: 20,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);
@@ -48,6 +50,8 @@ void main() {
     final config = InitConfigFfi.fromParts(
       apiKey: 'hjlsdfhjfdhjk',
       apiBaseUrl: 'https://foo.example/api/v1',
+      headlinesProviderPath: '/newscatcher/v1/latest-headlines',
+      newsProviderPath: '/newscatcher/v1/search-news',
       feedMarkets: [
         const FeedMarket(langCode: 'de', countryCode: 'DE'),
         const FeedMarket(langCode: 'en', countryCode: 'US'),
@@ -60,9 +64,9 @@ void main() {
       kpeModel: 'yo.lo',
       kpeCnn: 'abc',
       kpeClassifier: 'magic',
+      maxDocsPerFeedBatch: 2,
+      maxDocsPerSearchBatch: 20,
       deConfig: '{ "key": "value" }',
-      headlinesProviderPath: '/newscatcher/v1/latest-headlines',
-      newsProviderPath: '/newscatcher/v1/search-news',
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -37,7 +37,7 @@ import 'package:xayn_discovery_engine/src/api/models/document.dart'
 import 'package:xayn_discovery_engine/src/domain/engine/mock_engine.dart'
     show MockEngine, mockTrendingTopic;
 import 'package:xayn_discovery_engine/src/domain/event_handler.dart'
-    show EventConfig, EventHandler;
+    show EventHandler;
 import 'package:xayn_discovery_engine/src/domain/models/active_data.dart'
     show ActiveDocumentData;
 import 'package:xayn_discovery_engine/src/domain/models/active_search.dart'
@@ -77,7 +77,6 @@ Future<void> main() async {
 
     final engine = MockEngine()
       ..activeSearchDocuments = mockDocuments(StackId.nil(), true);
-    final config = EventConfig(maxFeedDocs: 5, maxSearchDocs: 20);
     final data = ActiveDocumentData(Embedding.fromList([44]));
     final stackId = StackId.fromBytes(Uint8List.fromList(List.filled(16, 0)));
     var doc1 = Document(
@@ -107,7 +106,6 @@ Future<void> main() async {
       engineStateRepo = HiveEngineStateRepository();
       mgr = SearchManager(
         engine,
-        config,
         searchRepo,
         docRepo,
         activeRepo,
@@ -145,7 +143,7 @@ Future<void> main() async {
           searchBy: SearchBy.query,
           searchTerm: 'example query',
           requestedPageNb: 1,
-          pageSize: config.maxSearchDocs,
+          pageSize: -1,
         );
 
         await searchRepo.clear();
@@ -178,7 +176,7 @@ Future<void> main() async {
           activeRepo.box.get('${response.items.last.documentId}'),
           isNotNull,
         );
-        expect(engine.getCallCount('activeSearch'), equals(1));
+        expect(engine.getCallCount('searchByQuery'), equals(1));
         expect(engine.getCallCount('serialize'), equals(1));
       });
     });
@@ -230,7 +228,7 @@ Future<void> main() async {
           activeRepo.box.get('${response.items.last.documentId}'),
           isNotNull,
         );
-        expect(engine.getCallCount('activeSearch'), equals(1));
+        expect(engine.getCallCount('searchByQuery'), equals(1));
         expect(engine.getCallCount('serialize'), equals(1));
       });
     });
@@ -329,7 +327,6 @@ Future<void> main() async {
         final engine = _NoTrendingTopicsMockEngine();
         final mgr = SearchManager(
           engine,
-          config,
           searchRepo,
           docRepo,
           activeRepo,

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -24,6 +24,7 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "Document" = "RustDocument"
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
+"FfiUsize" = "RustFfiUsize"
 "HistoricDocument" = "RustHistoricDocument"
 "InitConfig" = "RustInitConfig"
 "Market" = "RustMarket"

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -76,6 +76,11 @@ impl XaynDiscoveryEngineAsyncFfi {
         )
     }
 
+    /// Configures the running engine.
+    pub async fn configure(engine: &SharedEngine, de_config: Box<String>) {
+        engine.as_ref().lock().await.configure(&de_config);
+    }
+
     /// Serializes the engine.
     pub async fn serialize(engine: &SharedEngine) -> Box<Result<Vec<u8>, String>> {
         Box::new(
@@ -113,14 +118,13 @@ impl XaynDiscoveryEngineAsyncFfi {
     pub async fn feed_next_batch(
         engine: &SharedEngine,
         sources: Box<Vec<WeightedSource>>,
-        max_documents: u32,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .feed_next_batch(&sources, max_documents)
+                .feed_next_batch(&sources)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -132,14 +136,13 @@ impl XaynDiscoveryEngineAsyncFfi {
         engine: &SharedEngine,
         history: Box<Vec<HistoricDocument>>,
         sources: Box<Vec<WeightedSource>>,
-        max_documents: u32,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .get_feed_documents(&history, &sources, max_documents)
+                .get_feed_documents(&history, &sources)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -214,14 +217,13 @@ impl XaynDiscoveryEngineAsyncFfi {
         engine: &SharedEngine,
         query: Box<String>,
         page: u32,
-        page_size: u32,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .search_by_query(query.as_ref(), page, page_size)
+                .search_by_query(query.as_ref(), page)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -232,14 +234,13 @@ impl XaynDiscoveryEngineAsyncFfi {
         engine: &SharedEngine,
         topic: Box<String>,
         page: u32,
-        page_size: u32,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .search_by_topic(topic.as_ref(), page, page_size)
+                .search_by_topic(topic.as_ref(), page)
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -19,6 +19,8 @@ use std::ptr::addr_of_mut;
 use xayn_discovery_engine_core::InitConfig;
 use xayn_discovery_engine_providers::Market;
 
+use super::primitives::FfiUsize;
+
 /// Returns a pointer to the `api_key` field of a configuration.
 ///
 /// # Safety
@@ -39,6 +41,32 @@ pub unsafe extern "C" fn init_config_place_of_api_key(place: *mut InitConfig) ->
 #[no_mangle]
 pub unsafe extern "C" fn init_config_place_of_api_base_url(place: *mut InitConfig) -> *mut String {
     unsafe { addr_of_mut!((*place).api_base_url) }
+}
+
+/// Returns a pointer to the `news_provider_path` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_news_provider_path(
+    place: *mut InitConfig,
+) -> *mut String {
+    unsafe { addr_of_mut!((*place).news_provider_path) }
+}
+
+/// Returns a pointer to the `headlines_provider_path` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_headlines_provider_path(
+    place: *mut InitConfig,
+) -> *mut String {
+    unsafe { addr_of_mut!((*place).headlines_provider_path) }
 }
 
 /// Returns a pointer to the `markets` field of a configuration.
@@ -146,30 +174,30 @@ pub unsafe extern "C" fn init_config_place_of_kpe_classifier(
     unsafe { addr_of_mut!((*place).kpe_classifier) }
 }
 
-/// Returns a pointer to the `news_provider_path` field of a configuration.
+/// Returns a pointer to the `max_docs_per_feed_batch` field of a configuration.
 ///
 /// # Safety
 ///
 /// The pointer must point to a valid [`InitConfig`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn init_config_place_of_news_provider_path(
+pub unsafe extern "C" fn init_config_place_of_max_docs_per_feed_batch(
     place: *mut InitConfig,
-) -> *mut String {
-    unsafe { addr_of_mut!((*place).news_provider_path) }
+) -> *mut FfiUsize {
+    unsafe { addr_of_mut!((*place).max_docs_per_feed_batch) }.cast()
 }
 
-/// Returns a pointer to the `headlines_provider_path` field of a configuration.
+/// Returns a pointer to the `max_docs_per_search_batch` field of a configuration.
 ///
 /// # Safety
 ///
 /// The pointer must point to a valid [`InitConfig`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn init_config_place_of_headlines_provider_path(
+pub unsafe extern "C" fn init_config_place_of_max_docs_per_search_batch(
     place: *mut InitConfig,
-) -> *mut String {
-    unsafe { addr_of_mut!((*place).headlines_provider_path) }
+) -> *mut FfiUsize {
+    unsafe { addr_of_mut!((*place).max_docs_per_search_batch) }.cast()
 }
 
 /// Returns a pointer to the `de_config` field of a configuration.

--- a/discovery_engine_core/bindings/src/types/primitives.rs
+++ b/discovery_engine_core/bindings/src/types/primitives.rs
@@ -24,8 +24,8 @@ use super::{
 /// Type to represent "length" in FFI.
 ///
 /// Be aware that values returned are bounded
-/// by 2**32, e.g. for `Vec` the extern interface will
-/// only expose the first 2**32 elements of a
+/// by `2**32`, e.g. for `Vec` the extern interface will
+/// only expose the first `2**32` elements of a
 /// `Vec`.
 // FIXME[dart >1.16]: Use AbiSpecificInteger.
 #[derive(Clone, Copy)]

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -213,14 +213,6 @@ impl FeedConfig {
     }
 }
 
-impl Default for FeedConfig {
-    fn default() -> Self {
-        Self {
-            max_docs_per_batch: 2,
-        }
-    }
-}
-
 /// Configurations for the search.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct SearchConfig {
@@ -233,14 +225,6 @@ impl SearchConfig {
     pub(crate) fn merge(&mut self, de_config: &Figment) {
         if let Ok(max_docs_per_batch) = de_config.extract_inner("search.max_docs_per_batch") {
             self.max_docs_per_batch = max_docs_per_batch;
-        }
-    }
-}
-
-impl Default for SearchConfig {
-    fn default() -> Self {
-        Self {
-            max_docs_per_batch: 20,
         }
     }
 }
@@ -273,6 +257,22 @@ mod tests {
 
     // the f32 fields are never NaN by construction
     impl Eq for CoreConfig {}
+
+    impl Default for FeedConfig {
+        fn default() -> Self {
+            Self {
+                max_docs_per_batch: 2,
+            }
+        }
+    }
+
+    impl Default for SearchConfig {
+        fn default() -> Self {
+            Self {
+                max_docs_per_batch: 20,
+            }
+        }
+    }
 
     #[test]
     fn test_de_config_from_json_default() -> Result<(), GenericError> {

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -57,6 +57,10 @@ pub struct InitConfig {
     pub kpe_cnn: String,
     /// KPE classifier path.
     pub kpe_classifier: String,
+    /// The maximum number of documents per feed batch.
+    pub max_docs_per_feed_batch: u32,
+    /// The maximum number of documents per search batch.
+    pub max_docs_per_search_batch: u32,
     /// DE config in JSON format.
     pub de_config: Option<String>,
     /// Log file path.
@@ -94,7 +98,7 @@ pub(crate) struct EndpointConfig {
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub(crate) excluded_sources: Arc<RwLock<Vec<String>>>,
     /// The maximum number of requests to try to reach the number of `min_articles`.
-    pub(crate) max_requests: u32,
+    pub(crate) max_requests: usize,
     /// The minimum number of new articles to try to return when updating the stack.
     pub(crate) min_articles: usize,
     /// The maximum age of a headline, in days, after which we no longer
@@ -193,9 +197,62 @@ impl Default for ExplorationConfig {
     }
 }
 
-/// Reads the DE configurations from json and sets defaults for missing fields (if possible).
+/// Configurations for the feed.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct FeedConfig {
+    /// The maximum number of documents per feed batch.
+    pub(crate) max_docs_per_batch: usize,
+}
+
+impl FeedConfig {
+    /// Merges existent values from the DE configuration into this configuration.
+    pub(crate) fn merge(&mut self, de_config: &Figment) {
+        if let Ok(max_docs_per_batch) = de_config.extract_inner("feed.max_docs_per_batch") {
+            self.max_docs_per_batch = max_docs_per_batch;
+        }
+    }
+}
+
+impl Default for FeedConfig {
+    fn default() -> Self {
+        Self {
+            max_docs_per_batch: 2,
+        }
+    }
+}
+
+/// Configurations for the search.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct SearchConfig {
+    /// The maximum number of documents per search batch.
+    pub(crate) max_docs_per_batch: usize,
+}
+
+impl SearchConfig {
+    /// Merges existent values from the DE configuration into this configuration
+    pub(crate) fn merge(&mut self, de_config: &Figment) {
+        if let Ok(max_docs_per_batch) = de_config.extract_inner("search.max_docs_per_batch") {
+            self.max_docs_per_batch = max_docs_per_batch;
+        }
+    }
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            max_docs_per_batch: 20,
+        }
+    }
+}
+
+/// Reads the DE configurations from json.
 pub(crate) fn de_config_from_json(json: &str) -> Figment {
     Figment::from(Json::string(json))
+}
+
+/// Reads the DE configurations from json and sets defaults for missing fields (if possible).
+pub(crate) fn de_config_from_json_with_defaults(json: &str) -> Figment {
+    de_config_from_json(json)
         .join(Serialized::default("kpe.token_size", 150))
         .join(Serialized::default("smbert.token_size", 150))
         .join(Serialized::defaults(CoiSystemConfig::default()))
@@ -219,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_de_config_from_json_default() -> Result<(), GenericError> {
-        let de_config = de_config_from_json("{}");
+        let de_config = de_config_from_json_with_defaults("{}");
         assert_eq!(de_config.extract_inner::<usize>("kpe.token_size")?, 150);
         assert_eq!(de_config.extract_inner::<usize>("smbert.token_size")?, 150);
         assert_eq!(
@@ -244,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_de_config_from_json_modified() -> Result<(), GenericError> {
-        let de_config = de_config_from_json(
+        let de_config = de_config_from_json_with_defaults(
             r#"{
                 "coi": {
                     "threshold": 0.42

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -288,14 +288,12 @@ impl Engine {
         let providers = Providers::new(&config.clone().into()).map_err(Error::ProviderError)?;
 
         // read the configs
-        let mut feed_config = FeedConfig {
+        let feed_config = FeedConfig {
             max_docs_per_batch: config.max_docs_per_feed_batch as usize,
         };
-        feed_config.merge(&de_config);
-        let mut search_config = SearchConfig {
+        let search_config = SearchConfig {
             max_docs_per_batch: config.max_docs_per_search_batch as usize,
         };
-        search_config.merge(&de_config);
         let endpoint_config = de_config
             .extract_inner::<EndpointConfig>("endpoint")
             .map_err(|err| Error::Ranker(err.into()))?

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -58,7 +58,16 @@ use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 #[cfg(feature = "storage")]
 use crate::storage::{self, sqlite::SqliteStorage, BoxedStorage, Storage};
 use crate::{
-    config::{de_config_from_json, CoreConfig, EndpointConfig, ExplorationConfig, InitConfig},
+    config::{
+        de_config_from_json,
+        de_config_from_json_with_defaults,
+        CoreConfig,
+        EndpointConfig,
+        ExplorationConfig,
+        FeedConfig,
+        InitConfig,
+        SearchConfig,
+    },
     document::{
         self,
         Document,
@@ -146,6 +155,8 @@ pub struct Engine {
     // configs
     endpoint_config: EndpointConfig,
     core_config: CoreConfig,
+    feed_config: FeedConfig,
+    search_config: SearchConfig,
     request_after: usize,
 
     // systems
@@ -172,6 +183,8 @@ impl Engine {
         endpoint_config: EndpointConfig,
         core_config: CoreConfig,
         exploration_config: ExplorationConfig,
+        feed_config: FeedConfig,
+        search_config: SearchConfig,
         smbert: SMBert,
         coi: CoiSystem,
         kpe: KPE,
@@ -204,6 +217,8 @@ impl Engine {
         let mut engine = Self {
             endpoint_config,
             core_config,
+            feed_config,
+            search_config,
             request_after: 0,
             smbert,
             coi,
@@ -232,7 +247,8 @@ impl Engine {
         history: &[HistoricDocument],
         sources: &[WeightedSource],
     ) -> Result<Self, Error> {
-        let de_config = de_config_from_json(config.de_config.as_deref().unwrap_or("{}"));
+        let de_config =
+            de_config_from_json_with_defaults(config.de_config.as_deref().unwrap_or("{}"));
 
         // build the systems
         let smbert = SMBertConfig::from_files(&config.smbert_vocab, &config.smbert_model)
@@ -272,6 +288,16 @@ impl Engine {
         let providers = Providers::new(&config.clone().into()).map_err(Error::ProviderError)?;
 
         // read the configs
+        let feed_config = FeedConfig {
+            max_docs_per_batch: de_config
+                .extract_inner("feed.max_docs_per_batch")
+                .unwrap_or(config.max_docs_per_feed_batch as usize),
+        };
+        let search_config = SearchConfig {
+            max_docs_per_batch: de_config
+                .extract_inner("search.max_docs_per_batch")
+                .unwrap_or(config.max_docs_per_search_batch as usize),
+        };
         let endpoint_config = de_config
             .extract_inner::<EndpointConfig>("endpoint")
             .map_err(|err| Error::Ranker(err.into()))?
@@ -327,6 +353,8 @@ impl Engine {
             endpoint_config,
             core_config,
             exploration_config,
+            feed_config,
+            search_config,
             smbert,
             coi,
             kpe,
@@ -340,6 +368,13 @@ impl Engine {
             providers,
         )
         .await
+    }
+
+    /// Configures the running engine.
+    pub fn configure(&mut self, de_config: &str) {
+        let de_config = de_config_from_json(de_config);
+        self.feed_config.merge(&de_config);
+        self.search_config.merge(&de_config);
     }
 
     async fn update_stacks_for_all_markets(
@@ -427,29 +462,25 @@ impl Engine {
     pub async fn feed_next_batch(
         &mut self,
         sources: &[WeightedSource],
-        max_documents: u32,
     ) -> Result<Vec<Document>, Error> {
         #[cfg(feature = "storage")]
         {
             let history = self.storage.fetch_history().await?;
 
             // TODO: merge `get_feed_documents()` into this method after DB migration
-            return self
-                .get_feed_documents(&history, sources, max_documents)
-                .await;
+            return self.get_feed_documents(&history, sources).await;
         }
 
         #[cfg(not(feature = "storage"))]
         unimplemented!("requires 'storage' feature")
     }
 
-    /// Returns at most `max_documents` [`Document`]s for the feed.
+    /// Gets the next batch of feed documents.
     #[instrument(skip(self, history))]
     pub async fn get_feed_documents(
         &mut self,
         history: &[HistoricDocument],
         sources: &[WeightedSource],
-        max_documents: u32,
     ) -> Result<Vec<Document>, Error> {
         let request_new = (self.request_after < self.core_config.request_after)
             .then(|| self.core_config.request_new)
@@ -468,8 +499,8 @@ impl Engine {
             once(&mut self.exploration_stack as _),
         );
 
-        let documents =
-            SelectionIter::new(BetaSampler, all_stacks).select(max_documents as usize)?;
+        let documents = SelectionIter::new(BetaSampler, all_stacks)
+            .select(self.feed_config.max_docs_per_batch)?;
         for document in &documents {
             debug!(
                 document = %document.id,
@@ -635,12 +666,7 @@ impl Engine {
     }
 
     /// Perform an active search by query.
-    pub async fn search_by_query(
-        &self,
-        query: &str,
-        page: u32,
-        page_size: u32,
-    ) -> Result<Vec<Document>, Error> {
+    pub async fn search_by_query(&self, query: &str, page: u32) -> Result<Vec<Document>, Error> {
         let query = clean_query(query);
         if query.trim().is_empty() {
             return Err(Error::InvalidTerm);
@@ -655,7 +681,11 @@ impl Engine {
 
         let filter = Filter::default().add_keyword(&query);
         let documents = self
-            .active_search(SearchBy::Query(Cow::Owned(filter)), page, page_size)
+            .active_search(
+                SearchBy::Query(Cow::Owned(filter)),
+                page,
+                self.search_config.max_docs_per_batch,
+            )
             .await?;
 
         #[cfg(feature = "storage")]
@@ -664,7 +694,7 @@ impl Engine {
                 search_by: storage::models::SearchBy::Query,
                 search_term: query,
                 paging: storage::models::Paging {
-                    size: page_size,
+                    size: self.search_config.max_docs_per_batch as u32,
                     next_page: page,
                 },
             };
@@ -679,12 +709,7 @@ impl Engine {
     }
 
     /// Perform an active search by topic.
-    pub async fn search_by_topic(
-        &self,
-        topic: &str,
-        page: u32,
-        page_size: u32,
-    ) -> Result<Vec<Document>, Error> {
+    pub async fn search_by_topic(&self, topic: &str, page: u32) -> Result<Vec<Document>, Error> {
         if topic.trim().is_empty() {
             return Err(Error::InvalidTerm);
         }
@@ -697,7 +722,11 @@ impl Engine {
         };
 
         let documents = self
-            .active_search(SearchBy::Topic(topic.into()), page, page_size)
+            .active_search(
+                SearchBy::Topic(topic.into()),
+                page,
+                self.search_config.max_docs_per_batch,
+            )
             .await?;
 
         #[cfg(feature = "storage")]
@@ -706,7 +735,7 @@ impl Engine {
                 search_by: storage::models::SearchBy::Topic,
                 search_term: topic.into(),
                 paging: storage::models::Paging {
-                    size: page_size,
+                    size: self.search_config.max_docs_per_batch as u32,
                     next_page: page,
                 },
             };
@@ -757,7 +786,7 @@ impl Engine {
             };
             let page_number = search.paging.next_page + 1;
             let documents = self
-                .active_search(by, page_number, search.paging.size)
+                .active_search(by, page_number, search.paging.size as usize)
                 .await?;
 
             self.storage
@@ -833,13 +862,13 @@ impl Engine {
         &self,
         by: SearchBy<'_>,
         page: u32,
-        page_size: u32,
+        page_size: usize,
     ) -> Result<Vec<Document>, Error> {
         let mut errors = Vec::new();
         let mut articles = Vec::new();
 
         let markets = self.endpoint_config.markets.read().await;
-        let scaled_page_size = page_size as usize / markets.len() + 1;
+        let scaled_page_size = page_size / markets.len() + 1;
         let excluded_sources = self.endpoint_config.excluded_sources.read().await.clone();
         for market in markets.iter() {
             let query_result = match &by {
@@ -889,7 +918,7 @@ impl Engine {
         if documents.is_empty() && !errors.is_empty() {
             Err(Error::Errors(errors))
         } else {
-            documents.truncate(page_size as usize);
+            documents.truncate(page_size);
             Ok(documents)
         }
     }
@@ -1401,6 +1430,8 @@ pub(crate) mod tests {
             let config = InitConfig {
                 api_key: "test-token".into(),
                 api_base_url: server.uri(),
+                news_provider_path: "newscatcher/news-endpoint-name".into(),
+                headlines_provider_path: "newscatcher/headlines-endpoint-name".into(),
                 markets: vec![Market::new("en", "US")],
                 // This triggers the trusted sources stack to also fetch articles
                 trusted_sources: vec!["example.com".into()],
@@ -1411,10 +1442,16 @@ pub(crate) mod tests {
                 kpe_model: format!("{asset_base}/kpe_v0001/bert-mocked.onnx"),
                 kpe_cnn: format!("{asset_base}/kpe_v0001/cnn.binparams"),
                 kpe_classifier: format!("{asset_base}/kpe_v0001/classifier.binparams"),
+                max_docs_per_feed_batch: FeedConfig::default()
+                    .max_docs_per_batch
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+                max_docs_per_search_batch: SearchConfig::default()
+                    .max_docs_per_batch
+                    .try_into()
+                    .unwrap_or(u32::MAX),
                 de_config: None,
                 log_file: None,
-                news_provider_path: "newscatcher/news-endpoint-name".into(),
-                headlines_provider_path: "newscatcher/headlines-endpoint-name".into(),
             };
 
             // Now we can initialize the engine with no previous history or state. This should
@@ -1675,7 +1712,7 @@ pub(crate) mod tests {
 
         // Finally, we instruct the engine to fetch some articles and check whether or not
         // the expected articles from the mock show up in the results.
-        let res = engine.get_feed_documents(&[], &[], 2).await.unwrap();
+        let res = engine.get_feed_documents(&[], &[]).await.unwrap();
 
         assert_eq!(1, res.len());
         assert_eq!(

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -288,16 +288,14 @@ impl Engine {
         let providers = Providers::new(&config.clone().into()).map_err(Error::ProviderError)?;
 
         // read the configs
-        let feed_config = FeedConfig {
-            max_docs_per_batch: de_config
-                .extract_inner("feed.max_docs_per_batch")
-                .unwrap_or(config.max_docs_per_feed_batch as usize),
+        let mut feed_config = FeedConfig {
+            max_docs_per_batch: config.max_docs_per_feed_batch as usize,
         };
-        let search_config = SearchConfig {
-            max_docs_per_batch: de_config
-                .extract_inner("search.max_docs_per_batch")
-                .unwrap_or(config.max_docs_per_search_batch as usize),
+        feed_config.merge(&de_config);
+        let mut search_config = SearchConfig {
+            max_docs_per_batch: config.max_docs_per_search_batch as usize,
         };
+        search_config.merge(&de_config);
         let endpoint_config = de_config
             .extract_inner::<EndpointConfig>("endpoint")
             .map_err(|err| Error::Ranker(err.into()))?

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -43,7 +43,7 @@ pub(crate) struct BreakingNews {
     client: Arc<dyn HeadlinesProvider>,
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
-    max_requests: u32,
+    max_requests: usize,
     min_articles: usize,
     max_headline_age_days: usize,
 }
@@ -105,7 +105,7 @@ impl Ops for BreakingNews {
                     self.client.clone(),
                     market.clone(),
                     self.page_size,
-                    request_num as usize + 1,
+                    request_num + 1,
                     excluded_sources.clone(),
                     self.max_headline_age_days,
                 )

--- a/discovery_engine_core/core/src/stack/ops/common.rs
+++ b/discovery_engine_core/core/src/stack/ops/common.rs
@@ -19,10 +19,10 @@ type ItemsResult<I> = Result<Vec<I>, GenericError>;
 type Request<I> = JoinHandle<ItemsResult<I>>;
 
 pub(super) async fn request_min_new_items<I: Send>(
-    max_requests: u32,
+    max_requests: usize,
     min_articles: usize,
     page_size: usize,
-    request_fn: impl Fn(u32) -> Request<I> + Send + Sync,
+    request_fn: impl Fn(usize) -> Request<I> + Send + Sync,
     filter_fn: impl Fn(Vec<I>) -> ItemsResult<I> + Send + Sync,
 ) -> ItemsResult<I> {
     let mut items = Vec::with_capacity(min_articles);
@@ -66,10 +66,10 @@ pub(super) async fn request_min_new_items<I: Send>(
 mod tests {
     use super::*;
 
-    struct Response(ItemsResult<u32>);
+    struct Response(ItemsResult<usize>);
 
     impl Response {
-        fn ok(items: &[u32]) -> Self {
+        fn ok(items: &[usize]) -> Self {
             Self(Ok(items.to_owned()))
         }
 
@@ -77,7 +77,7 @@ mod tests {
             Self(Err(GenericError::from(msg)))
         }
 
-        fn request(self) -> Request<u32> {
+        fn request(self) -> Request<usize> {
             tokio::spawn(async { self.0 })
         }
     }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -44,7 +44,7 @@ pub(crate) struct PersonalizedNews {
     client: Arc<dyn NewsProvider>,
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
-    max_requests: u32,
+    max_requests: usize,
     min_articles: usize,
     max_article_age_days: usize,
 }
@@ -114,7 +114,7 @@ impl Ops for PersonalizedNews {
                     market.clone(),
                     filter.clone(),
                     self.page_size,
-                    request_num as usize + 1,
+                    request_num + 1,
                     excluded_sources.clone(),
                     self.max_article_age_days,
                 )

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -43,7 +43,7 @@ pub(crate) struct TrustedNews {
     client: Arc<dyn TrustedHeadlinesProvider>,
     sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
-    max_requests: u32,
+    max_requests: usize,
     min_articles: usize,
     max_headline_age_days: usize,
 }
@@ -105,7 +105,7 @@ impl Ops for TrustedNews {
                 spawn_trusted_request(
                     self.client.clone(),
                     self.page_size,
-                    request_num as usize + 1,
+                    request_num + 1,
                     sources.clone(),
                     self.max_headline_age_days,
                 )


### PR DESCRIPTION
**References**

- [TY-2979]
- requires #519

**Summary**

- add `FeedConfig` and `SearchConfig` & add corresponding ffi in `InitConfig`
- align field access and function calls for `InitConfig` with its field declaration order for better readability
- add `Engine::configure()` & corresponding ffi
- remove `EventConfig` and use new logic in `SystemManager.changeConfiguration()` in dart
- update [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)


[TY-2979]: https://xainag.atlassian.net/browse/TY-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ