### PR TITLE
[Merged by Bors] - TY-3072 use db serialized state

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -97,7 +97,6 @@ class DocumentManager {
           ),
         ),
       );
-      await _engineStateRepo.save(await _engine.serialize());
       _changedDocsReporter.notifyChanged([document]);
       return;
     }
@@ -172,7 +171,6 @@ class DocumentManager {
           reaction: UserReaction.neutral, // unused
         ),
       );
-      await _engineStateRepo.save(await _engine.serialize());
       return;
     }
 

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -141,7 +141,7 @@ abstract class Engine {
   );
 
   /// Returns the currently trending topics.
-  Future<List<TrendingTopic>> getTrendingTopics();
+  Future<List<TrendingTopic>> trendingTopics();
 
   /// Disposes the engine.
   Future<void> dispose();

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -233,8 +233,8 @@ class MockEngine implements Engine {
   }
 
   @override
-  Future<List<TrendingTopic>> getTrendingTopics() async {
-    _incrementCount('getTrendingTopics');
+  Future<List<TrendingTopic>> trendingTopics() async {
+    _incrementCount('trendingTopics');
     return [mockTrendingTopic];
   }
 

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -136,8 +136,6 @@ class FeedManager {
         );
       }
 
-      await _engineStateRepo.save(await _engine.serialize());
-
       if (docs.isEmpty) {
         return const EngineEvent.nextFeedBatchRequestFailed(
           FeedFailureReason.noNewsForMarket,

--- a/discovery_engine/lib/src/domain/search_manager.dart
+++ b/discovery_engine/lib/src/domain/search_manager.dart
@@ -135,7 +135,6 @@ class SearchManager {
         }
         rethrow;
       }
-      await _engineStateRepo.save(await _engine.serialize());
 
       return EngineEvent.activeSearchRequestSucceeded(
         search,
@@ -175,7 +174,6 @@ class SearchManager {
         }
         rethrow;
       }
-      await _engineStateRepo.save(await _engine.serialize());
 
       return EngineEvent.nextActiveSearchBatchRequestSucceeded(
         search.toApiRepr(),
@@ -370,10 +368,7 @@ class SearchManager {
 
   /// Return the current trending topics.
   Future<EngineEvent> trendingTopicsRequested() async {
-    final topics = await _engine.getTrendingTopics();
-
-    // TODO: do we need to persist the engine state??
-    await _engineStateRepo.save(await _engine.serialize());
+    final topics = await _engine.trendingTopics();
 
     if (topics.isEmpty) {
       const reason = SearchFailureReason.noResultsAvailable;

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -344,7 +344,7 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
-  Future<List<TrendingTopic>> getTrendingTopics() async {
+  Future<List<TrendingTopic>> trendingTopics() async {
     final result = await asyncFfi.trendingTopics(_engine.ref);
 
     return resultVecTrendingTopicStringFfiAdapter

--- a/discovery_engine/test/search_manager_test.dart
+++ b/discovery_engine/test/search_manager_test.dart
@@ -421,5 +421,5 @@ Future<void> main() async {
 
 class _NoTrendingTopicsMockEngine extends MockEngine {
   @override
-  Future<List<TrendingTopic>> getTrendingTopics() async => [];
+  Future<List<TrendingTopic>> trendingTopics() async => [];
 }


### PR DESCRIPTION
**References**

- [TY-3070], [TY-3071], [TY-3072]
- requires #525, #515, #533

**Summary**

- conditionally fetch state from db in `Engine::from_config()`
- store state in db in `Engine::serialize()`
- move serialization calls to rust & disable them in dart
- checked that all stack guards are dropped soon enough to avoid deadlocks with following code (eg serialization)
- fix some ffi naming issues


[TY-3070]: https://xainag.atlassian.net/browse/TY-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-3071]: https://xainag.atlassian.net/browse/TY-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-3072]: https://xainag.atlassian.net/browse/TY-3072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ