### PR TITLE
[Merged by Bors] - Fix: Allow release builds 24h a day.

### DIFF
--- a/justfile
+++ b/justfile
@@ -315,7 +315,7 @@ _dart-publish $WORKSPACE:
     fi
 
     # Dependency overrides are not allowed in published dart packages
-    $SED_CMD -i s/dependency_overrides/HACK_hide_dependency_overrides/ ./pubspec.yaml
+    $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
 
     # Use the branch name as metadata, replace invalid characters with "-".
     VERSION_METADATA="$(git rev-parse --abbrev-ref HEAD | sed s/[^0-9a-zA-Z-]/-/g )"
@@ -326,11 +326,11 @@ _dart-publish $WORKSPACE:
 
     # We use a timestamp as major version,
     # for now for our use case this is good enough and simple to do.
-    TIMESTAMP="$(date +%y%m%d%k%M%S)"
+    TIMESTAMP="$(date +%y%m%d%H%M%S)"
     VERSION="0.${TIMESTAMP}.0+${VERSION_METADATA}"
     echo "Version: $VERSION"
 
-    $SED_CMD -i s/0.1.0+replace.with.version/${VERSION}/ ./pubspec.yaml
+    $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
     dart pub publish --force
 
 # This should only be run by the CI

--- a/justfile
+++ b/justfile
@@ -298,8 +298,8 @@ _override-flutter-self-deps $VERSION:
     fi
 
     # This will add changes to your repo which should never be committed.
-    $SED_CMD -i s/dependency_overrides/HACK_hide_dependency_overrides/ ./pubspec.yaml
-    $SED_CMD -i s/0.1.0+replace.with.version/${VERSION}/ ./pubspec.yaml
+    $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
+    $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
 
 
 _dart-publish $WORKSPACE:


### PR DESCRIPTION
Due to a bug in the date formatting string release builds could only be done from 10:00:00 to 23:59:59 :shrug: 

If fixed that and also added some more quoting (which isn't needed but better) and used `/g` in `sed` which 
also shouldn't be needed but is a bit more robust.