### PR TITLE
[Merged by Bors] - TY-3087 install rust targets via just

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ FLUTTER_EXAMPLE_WORKSPACE=discovery_engine_flutter/example
 DART_VERSION=2.17.3
 FLUTTER_VERSION=3.0.2
 
-ANDROID_TARGETS="arm64-v8a x86_64 x86"
+ANDROID_TARGETS="aarch64-linux-android x86_64-linux-android i686-linux-android"
 ANDROID_PLATFORM_VERSION="21"
 
 IOS_TARGETS="aarch64-apple-ios x86_64-apple-ios"

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#04f9ee674e662ba9831faee152ff873268d86d22"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#c5c99f45e3911f240c55ff4d56ba27e67bf1f3bd"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#04f9ee674e662ba9831faee152ff873268d86d22"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#c5c99f45e3911f240c55ff4d56ba27e67bf1f3bd"
 dependencies = [
  "bindgen",
  "cc",

--- a/justfile
+++ b/justfile
@@ -46,7 +46,15 @@ flutter-deps:
 
 # Fetches rust dependencies
 rust-deps:
-    cd "$RUST_WORKSPACE"; \
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+    cd "$RUST_WORKSPACE"
+    for TARGET in $ANDROID_TARGETS; do
+        rustup target add $TARGET
+    done
+    for TARGET in $IOS_TARGETS; do
+        rustup target add $TARGET
+    done
     cargo fetch {{ if env_var_or_default("CI", "false") == "true" { "--locked" } else { "" } }}
 
 # Get/Update/Fetch/Install all dependencies
@@ -233,14 +241,13 @@ pre-push $CI="true":
 _compile-android target:
     # See also: https://developer.android.com/studio/projects/gradle-external-native-builds#jniLibs
     cd "$RUST_WORKSPACE"; \
-        cargo ndk --bindgen -t $(echo "{{target}}" | sed 's/[^ ]* */&/g') -p $ANDROID_PLATFORM_VERSION \
+    cargo ndk --bindgen -t {{target}} -p $ANDROID_PLATFORM_VERSION \
         -o "{{justfile_directory()}}/$FLUTTER_WORKSPACE/android/src/main/jniLibs" build \
         --release -p xayn-discovery-engine-bindings --locked
 
 compile-android-local: _codegen-order-workaround
     #!/usr/bin/env bash
     set -eux -o pipefail
-    cd "$RUST_WORKSPACE";
     for TARGET in $ANDROID_TARGETS; do
         {{just_executable()}} _compile-android $TARGET
     done

--- a/justfile
+++ b/justfile
@@ -52,9 +52,11 @@ rust-deps:
     for TARGET in $ANDROID_TARGETS; do
         rustup target add $TARGET
     done
-    for TARGET in $IOS_TARGETS; do
-        rustup target add $TARGET
-    done
+    if [[ "{{os()}}" == "macos" ]]; then
+        for TARGET in $IOS_TARGETS; do
+            rustup target add $TARGET
+        done
+    fi
     cargo fetch {{ if env_var_or_default("CI", "false") == "true" { "--locked" } else { "" } }}
 
 # Get/Update/Fetch/Install all dependencies


### PR DESCRIPTION
**References**

- [TY-3087]

**Summary**

- use full target triples for `cargo ndk`
- add rust targets to `just rust-deps`


[TY-3087]: https://xainag.atlassian.net/browse/TY-3087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ