### PR TITLE
[Merged by Bors] - TY-3052 set dart cfgFeatureStorage based on how rust has been compiled

### DIFF
--- a/discovery_engine/lib/discovery_engine.dart
+++ b/discovery_engine/lib/discovery_engine.dart
@@ -18,6 +18,7 @@
 library discovery_engine;
 
 import 'package:logger/logger.dart' show Logger;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/logger.dart' show initLogger, logger;
 
 export 'package:xayn_discovery_engine/src/api/api.dart';
@@ -31,4 +32,4 @@ export 'package:xayn_discovery_engine/src/worker/common/exceptions.dart';
 void discoveryEngineInitLogger(Logger logger) => initLogger(logger);
 Logger get discoveryEngineLogger => logger;
 
-const cfgFeatureStorage = false;
+final cfgFeatureStorage = ffi.rust_cfg_storage() == 1;

--- a/discovery_engine/lib/discovery_engine.dart
+++ b/discovery_engine/lib/discovery_engine.dart
@@ -32,4 +32,4 @@ export 'package:xayn_discovery_engine/src/worker/common/exceptions.dart';
 void discoveryEngineInitLogger(Logger logger) => initLogger(logger);
 Logger get discoveryEngineLogger => logger;
 
-final cfgFeatureStorage = ffi.rust_cfg_storage() == 1;
+final cfgFeatureStorage = ffi.cfg_feature_storage() == 1;

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -32,3 +32,6 @@ heck = "0.4.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
+
+[features]
+storage = ["xayn-discovery-engine-core/storage"]

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -40,6 +40,12 @@ use std::path::Path;
 use itertools::Itertools;
 use xayn_discovery_engine_core::Engine;
 
+#[allow(unsafe_code)]
+#[no_mangle]
+pub extern "C" fn rust_cfg_storage() -> u8 {
+    u8::from(cfg!(feature = "storage"))
+}
+
 #[async_bindgen::api(
     use uuid::Uuid;
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -42,7 +42,7 @@ use xayn_discovery_engine_core::Engine;
 
 #[allow(unsafe_code)]
 #[no_mangle]
-pub extern "C" fn rust_cfg_storage() -> u8 {
+pub extern "C" fn cfg_feature_storage() -> u8 {
     u8::from(cfg!(feature = "storage"))
 }
 


### PR DESCRIPTION
This just does what the title says, it doesn't setup the justfile  to allow running tests
with the feature enabled and doesn't fix any of the tests failing with it enabled.

**References:**

- TY-3052