### PR TITLE
[Merged by Bors] - TO-2999 add path for db to config

### DIFF
--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -36,6 +36,7 @@ class Configuration with _$Configuration {
     required String applicationDirectoryPath,
     required FeedMarkets feedMarkets,
     required Manifest manifest,
+    @Default(false) bool useInMemoryDb,
     String? logFile,
   }) = _Configuration;
 

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -53,6 +53,7 @@ class InitConfigFfi with EquatableMixin {
   final int maxDocsPerSearchBatch;
   final String? deConfig;
   final String? logFile;
+  final String dataDir;
 
   @override
   List<Object?> get props => [
@@ -73,6 +74,7 @@ class InitConfigFfi with EquatableMixin {
         maxDocsPerSearchBatch,
         deConfig,
         logFile,
+        dataDir,
       ];
 
   factory InitConfigFfi(
@@ -100,6 +102,7 @@ class InitConfigFfi with EquatableMixin {
         maxDocsPerSearchBatch: configuration.maxItemsPerSearchBatch,
         deConfig: deConfig,
         logFile: configuration.logFile,
+        dataDir: configuration.applicationDirectoryPath,
       );
 
   InitConfigFfi.fromParts({
@@ -118,6 +121,7 @@ class InitConfigFfi with EquatableMixin {
     required this.kpeClassifier,
     required this.maxDocsPerFeedBatch,
     required this.maxDocsPerSearchBatch,
+    required this.dataDir,
     this.deConfig,
     this.logFile,
   });
@@ -152,6 +156,9 @@ class InitConfigFfi with EquatableMixin {
         .writeNative(ffi.init_config_place_of_max_docs_per_search_batch(place));
     deConfig.writeNative(ffi.init_config_place_of_de_config(place));
     logFile.writeNative(ffi.init_config_place_of_log_file(place));
+    dataDir.writeNative(
+      ffi.init_config_place_of_data_dir(place),
+    );
   }
 
   @visibleForTesting
@@ -196,6 +203,9 @@ class InitConfigFfi with EquatableMixin {
       ),
       logFile: OptionStringFfi.readNative(
         ffi.init_config_place_of_log_file(config),
+      ),
+      dataDir: StringFfi.readNative(
+        ffi.init_config_place_of_data_dir(config),
       ),
     );
   }

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -29,7 +29,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
 import 'package:xayn_discovery_engine/src/ffi/types/feed_market_vec.dart'
     show FeedMarketSliceFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart'
-    show FfiUsizeFfi;
+    show BoolFfi, FfiUsizeFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart'
     show OptionStringFfi, StringFfi, StringListFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
@@ -54,6 +54,7 @@ class InitConfigFfi with EquatableMixin {
   final String? deConfig;
   final String? logFile;
   final String dataDir;
+  final bool useInMemoryDb;
 
   @override
   List<Object?> get props => [
@@ -75,6 +76,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig,
         logFile,
         dataDir,
+        useInMemoryDb,
       ];
 
   factory InitConfigFfi(
@@ -103,6 +105,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig: deConfig,
         logFile: configuration.logFile,
         dataDir: configuration.applicationDirectoryPath,
+        useInMemoryDb: configuration.useInMemoryDb,
       );
 
   InitConfigFfi.fromParts({
@@ -122,6 +125,7 @@ class InitConfigFfi with EquatableMixin {
     required this.maxDocsPerFeedBatch,
     required this.maxDocsPerSearchBatch,
     required this.dataDir,
+    required this.useInMemoryDb,
     this.deConfig,
     this.logFile,
   });
@@ -159,6 +163,7 @@ class InitConfigFfi with EquatableMixin {
     dataDir.writeNative(
       ffi.init_config_place_of_data_dir(place),
     );
+    useInMemoryDb.writeNative(ffi.init_config_place_of_use_in_memory_db(place));
   }
 
   @visibleForTesting
@@ -206,6 +211,9 @@ class InitConfigFfi with EquatableMixin {
       ),
       dataDir: StringFfi.readNative(
         ffi.init_config_place_of_data_dir(config),
+      ),
+      useInMemoryDb: BoolFfi.readNative(
+        ffi.init_config_place_of_use_in_memory_db(config),
       ),
     );
   }

--- a/discovery_engine/lib/src/ffi/types/primitives.dart
+++ b/discovery_engine/lib/src/ffi/types/primitives.dart
@@ -12,7 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'dart:ffi' show FloatPointer, Pointer, Uint32Pointer, Uint8Pointer;
+import 'dart:ffi'
+    show FloatPointer, Pointer, Uint32Pointer, Uint8, Uint8Pointer;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
@@ -72,4 +73,12 @@ extension FfiUsizeFfi on int {
   }
 
   static int readNative(Pointer<RustFfiUsize> place) => place.value;
+}
+
+extension BoolFfi on bool {
+  void writeNative(Pointer<Uint8> place) {
+    place.value = this ? 1 : 0;
+  }
+
+  static bool readNative(Pointer<Uint8> ptr) => ptr.value == 1;
 }

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -40,6 +40,7 @@ void main() {
       maxDocsPerFeedBatch: 2,
       maxDocsPerSearchBatch: 20,
       dataDir: 'foo/bar',
+      useInMemoryDb: false,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);
@@ -69,6 +70,7 @@ void main() {
       maxDocsPerSearchBatch: 20,
       deConfig: '{ "key": "value" }',
       dataDir: 'bar/foo',
+      useInMemoryDb: true,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -39,6 +39,7 @@ void main() {
       kpeClassifier: 'magic',
       maxDocsPerFeedBatch: 2,
       maxDocsPerSearchBatch: 20,
+      dataDir: 'foo/bar',
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);
@@ -67,6 +68,7 @@ void main() {
       maxDocsPerFeedBatch: 2,
       maxDocsPerSearchBatch: 20,
       deConfig: '{ "key": "value" }',
+      dataDir: 'bar/foo',
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -36,6 +36,3 @@ storage = ["xayn-discovery-engine-core/storage"]
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
-
-[features]
-storage = ["xayn-discovery-engine-core/storage"]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -31,6 +31,9 @@ uuid = { version = "1.1.2", features = ["v4"] }
 cbindgen = "=0.24.3"
 heck = "0.4.0"
 
+[features]
+storage = ["xayn-discovery-engine-core/storage"]
+
 [lib]
 crate-type = ["cdylib", "staticlib"]
 

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -75,8 +75,6 @@ impl XaynDiscoveryEngineAsyncFfi {
                 state.as_deref().map(Vec::as_slice),
                 &history,
                 &sources,
-                #[cfg(feature = "storage")]
-                false,
             )
             .await
             .map(|engine| tokio::sync::Mutex::new(engine).into())

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -75,6 +75,8 @@ impl XaynDiscoveryEngineAsyncFfi {
                 state.as_deref().map(Vec::as_slice),
                 &history,
                 &sources,
+                #[cfg(feature = "storage")]
+                false,
             )
             .await
             .map(|engine| tokio::sync::Mutex::new(engine).into())

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -224,6 +224,17 @@ pub unsafe extern "C" fn init_config_place_of_data_dir(place: *mut InitConfig) -
     unsafe { addr_of_mut!((*place).data_dir) }
 }
 
+/// Returns a pointer to the `use_in_memory_db` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_use_in_memory_db(place: *mut InitConfig) -> *mut u8 {
+    unsafe { addr_of_mut!((*place).use_in_memory_db).cast() }
+}
+
 /// Returns a pointer to the `log_file` field of a configuration.
 ///
 /// # Safety

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -213,6 +213,17 @@ pub unsafe extern "C" fn init_config_place_of_de_config(
     unsafe { addr_of_mut!((*place).de_config) }
 }
 
+/// Returns a pointer to the `data_dir` field of a configuration.
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`InitConfig`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn init_config_place_of_data_dir(place: *mut InitConfig) -> *mut String {
+    unsafe { addr_of_mut!((*place).data_dir) }
+}
+
 /// Returns a pointer to the `log_file` field of a configuration.
 ///
 /// # Safety

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -65,6 +65,8 @@ pub struct InitConfig {
     pub de_config: Option<String>,
     /// Log file path.
     pub log_file: Option<String>,
+    /// Directory in which user data should be stored.
+    pub data_dir: String,
 }
 
 impl From<InitConfig> for ProviderConfig {

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -67,6 +67,8 @@ pub struct InitConfig {
     pub log_file: Option<String>,
     /// Directory in which user data should be stored.
     pub data_dir: String,
+    /// Use a in-memory db instead of a db in the `data_dir`
+    pub use_in_memory_db: bool,
 }
 
 impl From<InitConfig> for ProviderConfig {


### PR DESCRIPTION
This does following:

- expose the application data we already have in the configuration in dart to rust
- use that dir for the db (file name `db.sqlite`)
- add another `use_in_memory_db` option to `InitConfig`
  - this option is for integration tests
  - to reduce complexity this option is always there no matter the compiler feature
  

**References:**

- [TO-2999]



[TO-2999]: https://xainag.atlassian.net/browse/TO-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ