### PR TITLE
[Merged by Bors] - TO-3053 MLT snippet instead of kpe

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -177,12 +177,21 @@ pub struct NewsResource {
 }
 
 impl NewsResource {
-    /// Returns the title, if the title is empty it return the snippet instead.
+    /// Returns the title, or if empty the snippet instead.
     pub fn title_or_snippet(&self) -> &str {
         if self.title.is_empty() {
             &self.snippet
         } else {
             &self.title
+        }
+    }
+
+    /// Returns the snippet, or if empty the title instead.
+    pub fn snippet_or_title(&self) -> &str {
+        if self.snippet.is_empty() {
+            &self.title
+        } else {
+            &self.snippet
         }
     }
 }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -741,26 +741,12 @@ impl Engine {
         match reaction {
             UserReaction::Positive => {
                 let smbert = &self.smbert;
-                let key_phrases = self
-                    .kpe
-                    .run(&document.resource.snippet)
-                    .or_else(|_| {
-                        self.kpe.run(format!(
-                            "{} {}",
-                            document.resource.title, document.resource.snippet
-                        ))
-                    })
-                    .map_or_else(
-                        #[allow(clippy::if_not_else)]
-                        |_| vec![document.resource.title_or_snippet().to_owned()],
-                        Into::into,
-                    );
                 self.coi.log_positive_user_reaction(
                     &mut self.state.user_interests.positive,
                     &market,
                     &mut self.state.key_phrases,
                     &document.smbert_embedding,
-                    &key_phrases,
+                    &[document.resource.snippet.clone()],
                     |words| smbert.run(words).map_err(Into::into),
                 );
             }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -746,7 +746,7 @@ impl Engine {
                     &market,
                     &mut self.state.key_phrases,
                     &document.smbert_embedding,
-                    &[document.resource.snippet.clone()],
+                    &[document.resource.snippet_or_title().to_string()],
                     |words| smbert.run(words).map_err(Into::into),
                 );
             }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -343,7 +343,7 @@ impl Engine {
             )) as BoxedOps,
             Box::new(PersonalizedNews::new(
                 &endpoint_config,
-                providers.news.clone(),
+                providers.similar_news.clone(),
             )) as BoxedOps,
         ];
         let stack_config = stack_ops
@@ -2086,7 +2086,10 @@ pub(crate) mod tests {
                     )) as _
                 },
                 |config: &EndpointConfig, providers: &Providers| {
-                    Box::new(PersonalizedNews::new(config, providers.news.clone())) as _
+                    Box::new(PersonalizedNews::new(
+                        config,
+                        providers.similar_news.clone(),
+                    )) as _
                 },
             ],
             true,

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -20,12 +20,11 @@ use tokio::{sync::RwLock, task::JoinHandle};
 use uuid::uuid;
 use xayn_discovery_engine_ai::{GenericError, KeyPhrase};
 use xayn_discovery_engine_providers::{
-    Filter,
     GenericArticle,
     Market,
-    NewsProvider,
-    NewsQuery,
     RankLimit,
+    SimilarNewsProvider,
+    SimilarNewsQuery,
 };
 
 use crate::{
@@ -41,7 +40,7 @@ use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for personalized news items.
 pub struct PersonalizedNews {
-    client: Arc<dyn NewsProvider>,
+    client: Arc<dyn SimilarNewsProvider>,
     excluded_sources: Arc<RwLock<Vec<String>>>,
     page_size: usize,
     max_requests: usize,
@@ -59,7 +58,7 @@ impl PersonalizedNews {
     }
 
     /// Creates a personalized news stack.
-    pub(crate) fn new(config: &EndpointConfig, client: Arc<dyn NewsProvider>) -> Self {
+    pub(crate) fn new(config: &EndpointConfig, client: Arc<dyn SimilarNewsProvider>) -> Self {
         Self {
             client,
             page_size: config.page_size,
@@ -103,9 +102,7 @@ impl Ops for PersonalizedNews {
             return Err(NewItemsError::NotReady);
         }
 
-        let filter = Arc::new(key_phrases.iter().fold(Filter::default(), |filter, kp| {
-            filter.add_keyword(kp.words())
-        }));
+        let phrase = key_phrases[0].words(); // TODO maybe refactor key_phrases type later
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
 
         request_min_new_items(
@@ -116,7 +113,7 @@ impl Ops for PersonalizedNews {
                 spawn_news_request(
                     self.client.clone(),
                     market.clone(),
-                    filter.clone(),
+                    phrase.to_string(),
                     self.page_size,
                     request_num + 1,
                     excluded_sources.clone(),
@@ -135,9 +132,9 @@ impl Ops for PersonalizedNews {
 }
 
 fn spawn_news_request(
-    client: Arc<dyn NewsProvider>,
+    client: Arc<dyn SimilarNewsProvider>,
     market: Market,
-    filter: Arc<Filter>,
+    like: String,
     page_size: usize,
     page: usize,
     excluded_sources: Arc<Vec<String>>,
@@ -145,15 +142,15 @@ fn spawn_news_request(
 ) -> JoinHandle<Result<Vec<GenericArticle>, GenericError>> {
     tokio::spawn(async move {
         let market = market;
-        let query = NewsQuery {
+        let query = SimilarNewsQuery {
             market: &market,
             page_size,
             page,
             rank_limit: RankLimit::LimitedByMarket,
             excluded_sources: &excluded_sources,
-            filter: filter.as_ref(),
+            like: &like,
             max_age_days: Some(max_article_age_days),
         };
-        client.query_news(&query).await.map_err(Into::into)
+        client.query_similar_news(&query).await.map_err(Into::into)
     })
 }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -102,7 +102,12 @@ impl Ops for PersonalizedNews {
             return Err(NewItemsError::NotReady);
         }
 
-        let phrase = key_phrases[0].words(); // TODO maybe refactor key_phrases type later
+        let phrase = key_phrases
+            .iter()
+            .map(|kp| kp.words().to_string())
+            .reduce(|combined, kp| format!("{} {}", combined, kp))
+            .unwrap(/* nonempty key_phrases */);
+
         let excluded_sources = Arc::new(self.excluded_sources.read().await.clone());
 
         request_min_new_items(


### PR DESCRIPTION
**Summary**

- previously #527 

adjusts the engine's `user_reacted` method to bypass kpe on the document snippet.
adjusts `PersonalizedNews` to use `SimilarNewsProvider`.