### PR TITLE
[Merged by Bors] - TO-3248 Subtract one time for each stack when not ready

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1960,9 +1960,10 @@ pub(crate) mod tests {
         let engine = &mut *init_engine(
             [|_: &'_ _, _: &'_ _| {
                 let mut mock_ops = new_mock_stack_ops();
+                let id = mock_ops.id();
                 mock_ops
                     .expect_new_items()
-                    .returning(|_, _, _, _| Err(NewItemsError::NotReady));
+                    .returning(move |_, _, _, _| Err(NewItemsError::NotReady(id)));
                 Box::new(mock_ops) as _
             }],
             false,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1532,7 +1532,7 @@ async fn update_stacks<'a>(
             Ok(documents) => all_documents.extend(documents),
         };
     }
-    ready_stacks-=stacks_not_ready.len();
+    ready_stacks -= stacks_not_ready.len();
 
     // Since we need to de-duplicate not only the newly retrieved documents among themselves,
     // but also consider the existing documents in all stacks (not just the needy ones), we extract

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1989,7 +1989,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_update_stack_multiple_market_stack_not_ready() {
-        // When handling the errors in update_stacks we where counting
+        // When handling the errors in update_stacks we were counting
         // a not ready stack for each market in the configuration.
 
         let engine = &mut *init_engine(

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -36,7 +36,7 @@ pub(crate) mod trusted;
 #[derive(Error, Debug, Display)]
 pub enum NewItemsError {
     /// The stack is not ready to retrieve new items.
-    NotReady,
+    NotReady(Id),
     /// Retrieving new items error: {0}
     Error(#[from] GenericError),
 }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -99,7 +99,7 @@ impl Ops for PersonalizedNews {
         market: &Market,
     ) -> Result<Vec<GenericArticle>, NewItemsError> {
         if key_phrases.is_empty() {
-            return Err(NewItemsError::NotReady);
+            return Err(NewItemsError::NotReady(self.id()));
         }
 
         let phrase = key_phrases

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -98,7 +98,7 @@ impl Ops for TrustedNews {
     ) -> Result<Vec<GenericArticle>, NewItemsError> {
         let sources = Arc::new(self.sources.read().await.clone());
         if sources.is_empty() {
-            return Err(NewItemsError::NotReady);
+            return Err(NewItemsError::NotReady(self.id()));
         }
 
         request_min_new_items(


### PR DESCRIPTION
[TO-3248]

At the moment we are subtracting `1` from `ready_stacks` each time a stack is not ready multiplied for the number of market.
This is not correct and we should subtract `1` only once. At the moment if a stack is not ready for a market it will not be ready for other markets and no other property that can change the readiness can be updated during `update_stacks`.

[TO-3248]: https://xainag.atlassian.net/browse/TO-3248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ