### PR TITLE
[Merged by Bors] - TO-3098 e2e test engine loop

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -35,6 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "anymap2"
@@ -189,7 +198,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 3.2.16",
+ "clap 3.2.17",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -321,7 +330,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "heck 0.4.0",
  "indexmap",
  "log",
@@ -357,14 +366,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -402,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -419,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -467,8 +478,25 @@ dependencies = [
  "libc",
  "once_cell",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -1315,6 +1343,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9512e544c25736b82aebbd2bf739a47c8a1c935dfcc3a6adcde10e35cd3cd468"
+dependencies = [
+ "android_system_properties",
+ "core-foundation",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,14 +1378,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2490,9 +2530,9 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -2509,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2520,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -2551,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,12 +3814,13 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b12f508bdca434a55d43614d26f02e6b3e98ebeecfbc5a1614e0a0c8bf3e315"
+checksum = "cc3c7b7557dbfdad6431b5a51196c9110cef9d83f6a9b26699f35cdc0ae113ec"
 dependencies = [
  "assert-json-diff",
  "async-trait",
+ "base64",
  "deadpool",
  "futures",
  "futures-timer",
@@ -3805,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#c5c99f45e3911f240c55ff4d56ba27e67bf1f3bd"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#63f02b0e5b54684f20d1910a0588ce727da2f1c5"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -3817,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#c5c99f45e3911f240c55ff4d56ba27e67bf1f3bd"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#63f02b0e5b54684f20d1910a0588ce727da2f1c5"
 dependencies = [
  "bindgen",
  "cc",
@@ -4014,8 +4055,10 @@ name = "xayn-discovery-engine-tooling"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.16",
+ "clap 3.2.17",
  "csv",
+ "indicatif",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",

--- a/discovery_engine_core/ai/ai/Cargo.toml
+++ b/discovery_engine_core/ai/ai/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-chrono = { version = "0.4.19", default-features = false }
+chrono = { version = "0.4.21", default-features = false }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 ndarray = "0.15.6"
 rayon = "1.5.3"
-serde = { version = "1.0.143", features = ["derive", "rc"] }
+serde = { version = "1.0.144", features = ["derive", "rc"] }
 thiserror = "1.0.32"
 tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
@@ -21,5 +21,5 @@ xayn-discovery-engine-bert = { path = "../bert" }
 xayn-discovery-engine-providers = { path = "../../providers" }
 
 [dev-dependencies]
-serde_json = "1.0.83"
+serde_json = "1.0.85"
 xayn-discovery-engine-test-utils = { path = "../test-utils" }

--- a/discovery_engine_core/ai/ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/ai/src/coi/system.rs
@@ -37,6 +37,10 @@ pub struct CoiSystem {
 }
 
 impl CoiSystem {
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
     /// Updates the view time of the positive coi closest to the embedding.
     pub fn log_document_view_time(
         cois: &mut [PositiveCoi],

--- a/discovery_engine_core/ai/bert/Cargo.toml
+++ b/discovery_engine_core/ai/bert/Cargo.toml
@@ -9,7 +9,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["dere
 displaydoc = "0.2.3"
 float-cmp = "0.9.0"
 ndarray = { version = "0.15.6", features = ["serde"] }
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 thiserror = "1.0.32"
 tract-onnx = "0.17.3"
 xayn-discovery-engine-tokenizer = { path = "../tokenizer" }
@@ -19,8 +19,8 @@ onnxruntime = { version = "0.0.13", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3.6", features = ["html_reports"] }
-csv = { version = "1.1.6" }
-indicatif = { version = "0.16.2" }
+csv = "1.1.6"
+indicatif = "0.17.0"
 xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[example]]

--- a/discovery_engine_core/ai/layer/Cargo.toml
+++ b/discovery_engine_core/ai/layer/Cargo.toml
@@ -10,7 +10,7 @@ displaydoc = "0.2.3"
 ndarray = "0.15.6"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 thiserror = "1.0.32"
 
 [dev-dependencies]

--- a/discovery_engine_core/ai/test-utils/Cargo.toml
+++ b/discovery_engine_core/ai/test-utils/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 float-cmp = "0.9.0"
 ndarray = "0.15.6"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 uuid = "1.1.2"

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.59"
+anyhow = "1.0.62"
 handlebars = "4.3.3"
 heck = "0.4.0"
 once_cell = "1.12.0"
 regex = "1.6.0"
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.144", features = ["derive"] }
 structopt = "0.3.26"
 
 [dev-dependencies]

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 async-bindgen = { path = "../async-bindgen/async-bindgen" }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.19", default-features = false }
+chrono = { version = "0.4.21", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
 itertools = "0.10.3"
 ndarray = "0.15.6"

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 async-trait = "0.1.57"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
-chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.21", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
@@ -22,8 +22,8 @@ num-traits = "0.2.15"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = "1.5.3"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_repr = "0.1.8"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_repr = "0.1.9"
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["macros", "sync"] }
 tracing = "0.1.36"
@@ -43,9 +43,9 @@ async-once-cell = "0.4.2"
 maplit = "1.0.2"
 mockall = "0.11.2"
 rand_chacha = "0.3.1"
-serde_json = "1.0.83"
+serde_json = "1.0.85"
 tokio = { version = "1.20.1", features = ["macros", "rt", "sync"] }
-wiremock = "0.5.13"
+wiremock = "0.5.14"
 xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 
 [features]

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -351,7 +351,7 @@ impl AiDocument for TrendingTopic {
 
     fn date_published(&self) -> NaiveDateTime {
         // return a default value as there is no `date_published` for trending topics
-        chrono::naive::MIN_DATETIME
+        NaiveDateTime::MIN
     }
 }
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -155,21 +155,21 @@ pub enum Error {
 /// Discovery Engine.
 pub struct Engine {
     // configs
-    endpoint_config: EndpointConfig,
-    core_config: CoreConfig,
-    feed_config: FeedConfig,
-    search_config: SearchConfig,
+    pub(crate) endpoint_config: EndpointConfig,
+    pub(crate) core_config: CoreConfig,
+    pub(crate) feed_config: FeedConfig,
+    pub(crate) search_config: SearchConfig,
     request_after: usize,
 
     // systems
     smbert: SMBert,
-    coi: CoiSystem,
+    pub(crate) coi: CoiSystem,
     kpe: KPE,
     providers: Providers,
 
     // states
     stacks: RwLock<HashMap<StackId, Stack>>,
-    exploration_stack: Exploration,
+    pub(crate) exploration_stack: Exploration,
     state: CoiSystemState,
     #[cfg(feature = "storage")]
     storage: BoxedStorage,
@@ -1445,7 +1445,8 @@ impl Engine {
                 .map_err(Error::InvalidStack)?;
         self.state.reset();
 
-        self.update_stacks_for_all_markets(&[], &[], self.core_config.request_new)
+        self.request_after = 0;
+        self.update_stacks_for_all_markets(&[], &[], usize::MAX)
             .await
             .ok();
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1798,7 +1798,7 @@ pub(crate) mod tests {
 
             // The config mostly tells the engine were to find the model assets.
             // Here we use the mocked ones, for speed.
-            let asset_base = "../../discovery_engine_flutter/example/assets/";
+            let asset_base = "../../discovery_engine_flutter/example/assets";
             let config = InitConfig {
                 api_key: "test-token".into(),
                 api_base_url: server.uri(),

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -39,6 +39,6 @@ pub mod stack;
 pub mod storage;
 
 pub use crate::{
-    config::InitConfig,
+    config::{CoreConfig, EndpointConfig, ExplorationConfig, FeedConfig, InitConfig, SearchConfig},
     engine::{Engine, Error, SearchBy},
 };

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -32,7 +32,7 @@ pub(crate) use self::selection::Error;
 #[derive(Debug)]
 pub struct Stack {
     pub(crate) data: Data,
-    config: Config,
+    pub(crate) config: Config,
 }
 
 impl Stack {

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.57"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4.21", default-features = false, features = ["clock", "serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "deref"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
@@ -14,8 +14,8 @@ maplit = "1.0.2"
 once_cell = "1.13.0"
 regex = { version = "1.6.0", features = ["unicode-gencat"] }
 reqwest = { version = "0.11.11", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 serde_path_to_error = "0.1.8"
 thiserror = "1.0.32"
 tracing = "0.1.36"
@@ -23,4 +23,4 @@ url = "2.2.2"
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["macros", "rt"] }
-wiremock = "0.5.13"
+wiremock = "0.5.14"

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -268,8 +268,8 @@ pub struct Article {
     pub published_date: NaiveDateTime,
 }
 
-fn default_published_date() -> NaiveDateTime {
-    chrono::naive::MIN_DATETIME
+const fn default_published_date() -> NaiveDateTime {
+    NaiveDateTime::MIN
 }
 
 // Taken from https://github.com/serde-rs/serde/issues/1098#issuecomment-760711617

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -5,20 +5,22 @@ license = "AGPL-3.0-only"
 edition = "2021"
 
 [[bin]]
-name = "newscatcher"
-
-[[bin]]
 name = "clean_sources"
 
 [[bin]]
 name = "discovery_engine"
 
+[[bin]]
+name = "newscatcher"
+
 [dependencies]
-anyhow = "1.0.59"
-clap = { version = "3.2.16", features = ["derive"] }
+anyhow = "1.0.62"
+clap = { version = "3.2.17", features = ["derive"] }
 csv = "1.1.6"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
+indicatif = "0.17.0"
+rand = "0.8.5"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 tokio = { version = "1.20.1", features = ["fs"] }
 url = "2.2.2"
 xayn-discovery-engine-ai = { path = "../ai/ai" }

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
@@ -12,11 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use anyhow::Result;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rand::{thread_rng, Rng};
 use xayn_discovery_engine_core::{
     document::{Document, TimeSpent, UserReacted, UserReaction, ViewMode},
@@ -29,25 +28,29 @@ use crate::io::{Dislike, Dislikes, Like, Likes, Output, Persona, Personas};
 
 pub(crate) struct TestEngine {
     engine: Engine,
+    progress: bool,
 }
 
 impl TestEngine {
-    pub(crate) async fn new(api_key: String) -> Result<Self> {
-        let asset_base = "../discovery_engine_flutter/example/assets";
+    pub(crate) async fn new(api_key: String, progress: bool) -> Result<Self> {
+        let spinner = progress_spinner(progress, "initializing engine");
+
+        let manifest = std::env::var("CARGO_MANIFEST_DIR")?;
+        let assets = "/../../discovery_engine_flutter/example/assets";
         let config = InitConfig {
             api_key,
             api_base_url: "https://api-gw.xaynet.dev".into(),
             news_provider_path: "/newscatcher/v1/search-news".into(),
             headlines_provider_path: "/newscatcher/v1/latest-headlines".into(),
-            markets: vec![Market::new("de", "DE"), Market::new("en", "US")],
+            markets: vec![Market::new("de", "DE")], //Market::new("en", "US")],
             trusted_sources: vec![],
             excluded_sources: vec![],
-            smbert_vocab: format!("{asset_base}/smbert_v0001/vocab.txt"),
-            smbert_model: format!("{asset_base}/smbert_v0001/smbert-quantized.onnx"),
-            kpe_vocab: format!("{asset_base}/kpe_v0001/vocab.txt"),
-            kpe_model: format!("{asset_base}/kpe_v0001/bert-quantized.onnx"),
-            kpe_cnn: format!("{asset_base}/kpe_v0001/cnn.binparams"),
-            kpe_classifier: format!("{asset_base}/kpe_v0001/classifier.binparams"),
+            smbert_vocab: format!("{manifest}{assets}/smbert_v0001/vocab.txt"),
+            smbert_model: format!("{manifest}{assets}/smbert_v0001/smbert-quantized.onnx"),
+            kpe_vocab: format!("{manifest}{assets}/kpe_v0001/vocab.txt"),
+            kpe_model: format!("{manifest}{assets}/kpe_v0001/bert-quantized.onnx"),
+            kpe_cnn: format!("{manifest}{assets}/kpe_v0001/cnn.binparams"),
+            kpe_classifier: format!("{manifest}{assets}/kpe_v0001/classifier.binparams"),
             max_docs_per_feed_batch: 1,
             max_docs_per_search_batch: 1,
             de_config: None,
@@ -57,7 +60,9 @@ impl TestEngine {
         };
         let engine = Engine::from_config(config, None, &[], &[]).await?;
 
-        Ok(Self { engine })
+        spinner.finish_with_message("initialized engine");
+
+        Ok(Self { engine, progress })
     }
 
     async fn like(
@@ -152,6 +157,9 @@ impl TestEngine {
         personas: Personas,
     ) -> Result<Output> {
         let mut output = HashMap::with_capacity(personas.len());
+        let multi_bar = MultiProgress::new();
+        let personas_bar =
+            multi_progress_bar(&multi_bar, self.progress, personas.len(), "personas");
         for (
             name,
             Persona {
@@ -160,7 +168,7 @@ impl TestEngine {
                 trusted_sources,
                 excluded_sources,
             },
-        ) in personas
+        ) in personas_bar.wrap_iter(personas.into_iter())
         {
             self.engine
                 .set_trusted_sources(
@@ -178,9 +186,16 @@ impl TestEngine {
                 .await?;
 
             let mut documents = Vec::with_capacity(runs * iterations);
-            for _ in 0..runs {
+            let runs_bar = multi_progress_bar(&multi_bar, self.progress, runs, "runs");
+            for _ in runs_bar.wrap_iter(0..runs) {
+                let spinner = multi_progress_spinner(&multi_bar, self.progress, "resetting engine");
                 self.reset(&like_topics, &dislike_topics).await?;
-                for _ in 0..iterations {
+                spinner.finish();
+                multi_bar.remove(&spinner);
+
+                let iterations_bar =
+                    multi_progress_bar(&multi_bar, self.progress, iterations, "iterations");
+                for _ in iterations_bar.wrap_iter(0..iterations) {
                     if let Some(document) = self
                         .engine
                         .get_feed_documents(
@@ -195,11 +210,54 @@ impl TestEngine {
                         documents.push(document.into());
                     }
                 }
+                multi_bar.remove(&iterations_bar);
             }
+            multi_bar.remove(&runs_bar);
             output.insert(name, documents);
         }
+        personas_bar.finish();
 
         Ok(Output(output))
+    }
+}
+
+fn progress_bar(progress: bool, len: usize, msg: &'static str) -> ProgressBar {
+    progress
+        .then(|| ProgressBar::new(len as u64))
+        .unwrap_or_else(ProgressBar::hidden)
+        .with_message(msg)
+        .with_style(ProgressStyle::with_template("{bar:50} {pos}/{len} {msg}").unwrap())
+}
+
+fn multi_progress_bar(
+    multi: &MultiProgress,
+    progress: bool,
+    len: usize,
+    msg: &'static str,
+) -> ProgressBar {
+    let bar = progress_bar(progress, len, msg);
+    if progress {
+        multi.add(bar)
+    } else {
+        bar
+    }
+}
+
+fn progress_spinner(progress: bool, msg: &'static str) -> ProgressBar {
+    let spinner = progress
+        .then(ProgressBar::new_spinner)
+        .unwrap_or_else(ProgressBar::hidden)
+        .with_message(msg);
+    spinner.enable_steady_tick(Duration::from_millis(100));
+    spinner
+}
+
+fn multi_progress_spinner(multi: &MultiProgress, progress: bool, msg: &'static str) -> ProgressBar {
+    let spinner = progress_spinner(progress, msg);
+    if progress {
+        multi.add(spinner)
+    } else {
+        spinner
     }
 }
 

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
@@ -1,0 +1,216 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use rand::{thread_rng, Rng};
+use xayn_discovery_engine_core::{
+    document::{Document, TimeSpent, UserReacted, UserReaction, ViewMode},
+    Engine,
+    InitConfig,
+};
+use xayn_discovery_engine_providers::Market;
+
+use crate::io::{Dislike, Dislikes, Like, Likes, Output, Persona, Personas};
+
+pub(crate) struct TestEngine {
+    engine: Engine,
+}
+
+impl TestEngine {
+    pub(crate) async fn new(api_key: String) -> Result<Self> {
+        let asset_base = "../discovery_engine_flutter/example/assets";
+        let config = InitConfig {
+            api_key,
+            api_base_url: "https://api-gw.xaynet.dev".into(),
+            news_provider_path: "/newscatcher/v1/search-news".into(),
+            headlines_provider_path: "/newscatcher/v1/latest-headlines".into(),
+            markets: vec![Market::new("de", "DE"), Market::new("en", "US")],
+            trusted_sources: vec![],
+            excluded_sources: vec![],
+            smbert_vocab: format!("{asset_base}/smbert_v0001/vocab.txt"),
+            smbert_model: format!("{asset_base}/smbert_v0001/smbert-quantized.onnx"),
+            kpe_vocab: format!("{asset_base}/kpe_v0001/vocab.txt"),
+            kpe_model: format!("{asset_base}/kpe_v0001/bert-quantized.onnx"),
+            kpe_cnn: format!("{asset_base}/kpe_v0001/cnn.binparams"),
+            kpe_classifier: format!("{asset_base}/kpe_v0001/classifier.binparams"),
+            max_docs_per_feed_batch: 1,
+            max_docs_per_search_batch: 1,
+            de_config: None,
+            log_file: None,
+            data_dir: String::new(),
+            use_in_memory_db: true,
+        };
+        let engine = Engine::from_config(config, None, &[], &[]).await?;
+
+        Ok(Self { engine })
+    }
+
+    async fn like(
+        &mut self,
+        mut document: Document,
+        topics: &Likes,
+        certainly: bool,
+    ) -> Result<Document> {
+        if let Some(Like {
+            probability,
+            time_spent,
+        }) = topics.get(&document.resource.topic)
+        {
+            if certainly || thread_rng().gen_bool(*probability) {
+                let reacted = user_reacted(document, UserReaction::Positive);
+                document = self
+                    .engine
+                    .user_reacted(
+                        Some(&[/* TODO: db migration */]),
+                        &[/* TODO: db migration */],
+                        reacted,
+                    )
+                    .await?;
+                let time_spent = TimeSpent {
+                    id: document.id,
+                    smbert_embedding: document.smbert_embedding.clone(),
+                    view_time: *time_spent,
+                    view_mode: ViewMode::Story,
+                    reaction: UserReaction::Positive,
+                };
+                self.engine.time_spent(time_spent).await?;
+            }
+        }
+
+        Ok(document)
+    }
+
+    async fn dislike(
+        &mut self,
+        mut document: Document,
+        topics: &Dislikes,
+        certainly: bool,
+    ) -> Result<Document> {
+        if let Some(Dislike { probability }) = topics.get(&document.resource.topic) {
+            if certainly || thread_rng().gen_bool(*probability) {
+                let reacted = user_reacted(document, UserReaction::Negative);
+                document = self
+                    .engine
+                    .user_reacted(None, &[/* TODO: db migration */], reacted)
+                    .await?;
+            }
+        }
+
+        Ok(document)
+    }
+
+    async fn reset(&mut self, like_topics: &Likes, dislike_topics: &Dislikes) -> Result<()> {
+        self.engine.reset_ai().await?;
+
+        let mut cois = 0;
+        while cois < self.engine.coi_system_config().min_positive_cois() {
+            if let Some(document) = self
+                .engine
+                .get_feed_documents(&[/* TODO: db migration */], &[/* TODO: db migration */])
+                .await?
+                .pop()
+            {
+                self.like(document, like_topics, true).await?;
+                cois += 1;
+            }
+        }
+        cois = 0;
+        while cois < self.engine.coi_system_config().min_negative_cois() {
+            if let Some(document) = self
+                .engine
+                .get_feed_documents(&[/* TODO: db migration */], &[/* TODO: db migration */])
+                .await?
+                .pop()
+            {
+                self.dislike(document, dislike_topics, true).await?;
+                cois += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn run(
+        &mut self,
+        runs: usize,
+        iterations: usize,
+        personas: Personas,
+    ) -> Result<Output> {
+        let mut output = HashMap::with_capacity(personas.len());
+        for (
+            name,
+            Persona {
+                like_topics,
+                dislike_topics,
+                trusted_sources,
+                excluded_sources,
+            },
+        ) in personas
+        {
+            self.engine
+                .set_trusted_sources(
+                    &[/* TODO: db migration */],
+                    &[/* TODO: db migration */],
+                    trusted_sources,
+                )
+                .await?;
+            self.engine
+                .set_excluded_sources(
+                    &[/* TODO: db migration */],
+                    &[/* TODO: db migration */],
+                    excluded_sources,
+                )
+                .await?;
+
+            let mut documents = Vec::with_capacity(runs * iterations);
+            for _ in 0..runs {
+                self.reset(&like_topics, &dislike_topics).await?;
+                for _ in 0..iterations {
+                    if let Some(document) = self
+                        .engine
+                        .get_feed_documents(
+                            &[/* TODO: db migration */],
+                            &[/* TODO: db migration */],
+                        )
+                        .await?
+                        .pop()
+                    {
+                        let document = self.like(document, &like_topics, false).await?;
+                        let document = self.dislike(document, &dislike_topics, false).await?;
+                        documents.push(document.into());
+                    }
+                }
+            }
+            output.insert(name, documents);
+        }
+
+        Ok(Output(output))
+    }
+}
+
+fn user_reacted(document: Document, reaction: UserReaction) -> UserReacted {
+    UserReacted {
+        id: document.id,
+        stack_id: document.stack_id,
+        title: document.resource.title,
+        snippet: document.resource.snippet,
+        smbert_embedding: document.smbert_embedding,
+        reaction,
+        market: Market::new(document.resource.language, document.resource.country),
+    }
+}

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/main.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/main.rs
@@ -53,8 +53,11 @@ struct Args {
     #[clap(long, short)]
     output: String,
     /// Pretty prints the JSON output.
-    #[clap(action, long, short)]
+    #[clap(action, long)]
     pretty: bool,
+    /// Displays engine progress to stderr.
+    #[clap(action, long)]
+    progress: bool,
 }
 
 #[tokio::main]
@@ -76,7 +79,7 @@ async fn main() -> Result<()> {
             .into(),
         )
     } else {
-        TestEngine::new(input.provider)
+        TestEngine::new(input.provider, args.progress)
             .await?
             .run(input.num_runs, input.num_iterations, input.personas)
             .await?

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -5,12 +5,12 @@ license = "AGPL-3.0-only"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.21", default-features = false, features = ["serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
 dotenvy = "0.15.1"
-serde = { version = "1.0.143", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }


### PR DESCRIPTION
**References**

- [TO-3098]
- [original python source](https://github.com/xaynetwork/xayn_ai_research/blob/main/xayn_ai/tunning/e2e_discovery/cases.py)
- [newscatcher `topic`s](https://github.com/kotartemiy/newscatcher/blob/master/README.md)

**Summary**

- expose getters to the engine configs
- add deps & fix deprecation warning
- fix `Engine::reset_ai()`
- adjust e2e io types & update [confluence docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2509373441/E2E+-+Input+Output+Specification+Rust+Binary)
- add e2e test engine
- add `--pretty` and `--progress` cli flags

with newscatcher as a provider, the input to the e2e test engine can look like
```json
{
    "num_runs": 2,
    "num_iterations": 5,
    "personas": {
        "a": {
            "like_topics": {
                "tech": {
                    "probability": 0.5,
                    "time_spent": 30
                },
                "news": {
                    "probability": 0.5,
                    "time_spent": 30
                }
            },
            "dislike_topics": {
                "entertainment": {
                    "probability": 0.25
                }
            },
            "trusted_sources": [
                "example.com"
            ],
            "excluded_sources": []
        }
    },
    "provider": "ADD_NC_DEV_API_KEY_HERE"
}

```
and the corresponding output will look like
```json
{
  "a": [
    {
      "topic": "invalid",
      "embedding": [1.9494998, ...],
      "stack": "Exploration",
      "user_reaction": 0
    },
    {
      "topic": "invalid",
      "embedding": [3.4870868, ...],
      "stack": "PersonalizedNews",
      "user_reaction": 0
    },
    {
      "topic": "invalid",
      "embedding": [2.5475225, ...],
      "stack": "Exploration",
      "user_reaction": 0
    },
    {
      "topic": "news",
      "embedding": [1.8915764, ...],
      "stack": "Exploration",
      "user_reaction": 0
    },
    {
      "topic": "invalid",
      "embedding": [3.4870868, ...],
      "stack": "PersonalizedNews",
      "user_reaction": 0
    },
    {
      "topic": "invalid",
      "embedding": [3.627833, ...],
      "stack": "BreakingNews",
      "user_reaction": 0
    },
    {
      "topic": "news",
      "embedding": [0.77389663, ...],
      "stack": "Exploration",
      "user_reaction": 0
    },
    {
      "topic": "news",
      "embedding": [3.6513264, ...],
      "stack": "BreakingNews",
      "user_reaction": 0
    },
    {
      "topic": "news",
      "embedding": [1.8107437, ...],
      "stack": "BreakingNews",
      "user_reaction": 0
    },
    {
      "topic": "invalid",
      "embedding": [4.074598, ...],
      "stack": "BreakingNews",
      "user_reaction": 0
    }
  ]
}
```


[TO-3098]: https://xainag.atlassian.net/browse/TO-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ