### PR TITLE
[Merged by Bors] - TO-3253 UserId from string

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3637,6 +3637,7 @@ dependencies = [
  "dotenvy",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "uuid",
  "warp",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3634,6 +3634,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "derive_more",
+ "displaydoc",
  "dotenvy",
  "serde",
  "serde_json",

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
+displaydoc = "0.2.3"
 dotenvy = "0.15.1"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -10,6 +10,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["disp
 dotenvy = "0.15.1"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
+thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 warp = "0.3.2"

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -16,10 +16,18 @@ use chrono::{NaiveDateTime, Utc};
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
+use thiserror::Error;
 use uuid::Uuid;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, DocumentId, Embedding};
 use xayn_discovery_engine_core::document::Id;
+
+/// Web API errors.
+#[derive(Error, Debug)]
+pub(crate) enum Error {
+    #[error("`UserId` can't be empty")]
+    EmptyUserId,
+}
 
 /// Represents a result from a query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,12 +83,22 @@ pub(crate) struct InteractionRequestBody {
 
 /// Unique identifier for the user.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
-pub(crate) struct UserId(Uuid);
+pub(crate) struct UserId(String);
+
+impl UserId {
+    fn new(user_id_str: &str) -> Result<Self, Error> {
+        if user_id_str.is_empty() {
+            Err(Error::EmptyUserId)
+        } else {
+            Ok(Self(user_id_str.to_string()))
+        }
+    }
+}
 
 impl FromStr for UserId {
-    type Err = <Uuid as FromStr>::Err;
+    type Err = Error;
 
     fn from_str(user_id_str: &str) -> Result<Self, Self::Err> {
-        Uuid::from_str(user_id_str).map(Self)
+        UserId::new(user_id_str)
     }
 }

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -14,6 +14,7 @@
 
 use chrono::{NaiveDateTime, Utc};
 use derive_more::Display;
+use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
@@ -23,9 +24,9 @@ use xayn_discovery_engine_ai::{Document as AiDocument, DocumentId, Embedding};
 use xayn_discovery_engine_core::document::Id;
 
 /// Web API errors.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, DisplayDoc)]
 pub(crate) enum Error {
-    #[error("`UserId` can't be empty")]
+    /// [`UserId`] can't be empty.
     EmptyUserId,
 }
 
@@ -86,11 +87,11 @@ pub(crate) struct InteractionRequestBody {
 pub(crate) struct UserId(String);
 
 impl UserId {
-    fn new(user_id_str: &str) -> Result<Self, Error> {
-        if user_id_str.is_empty() {
+    fn new(user_id: &str) -> Result<Self, Error> {
+        if user_id.is_empty() {
             Err(Error::EmptyUserId)
         } else {
-            Ok(Self(user_id_str.to_string()))
+            Ok(Self(user_id.to_string()))
         }
     }
 }
@@ -98,7 +99,7 @@ impl UserId {
 impl FromStr for UserId {
     type Err = Error;
 
-    fn from_str(user_id_str: &str) -> Result<Self, Self::Err> {
-        UserId::new(user_id_str)
+    fn from_str(user_id: &str) -> Result<Self, Self::Err> {
+        UserId::new(user_id)
     }
 }


### PR DESCRIPTION
**Summary:**
- it changes `UserId` inner type from `Uuid` to `String`
- it checks that it can't be empty

**References:**
https://xainag.atlassian.net/browse/TO-3253