### PR TITLE
[Merged by Bors] - TO-3259 fix dart/jfrog problems

### DIFF
--- a/.github/actions/setup-job-docker/action.yml
+++ b/.github/actions/setup-job-docker/action.yml
@@ -50,7 +50,7 @@ runs:
           echo "JFROG access token missing"
           exit 1
         fi
-        echo "${JFROG_TOKEN}" | dart pub token add "https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private"
+        echo "${JFROG_TOKEN}" | dart pub token add "https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private"
 
     - name: dart deps
       shell: bash

--- a/async_bindgen_dart_utils/pubspec.yaml
+++ b/async_bindgen_dart_utils/pubspec.yaml
@@ -1,7 +1,7 @@
 name: async_bindgen_dart_utils
 description: A starting point for Dart libraries or applications.
 version: 0.1.0+replace.with.version
-publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
 
 environment:
   sdk: '>=2.17.1 <3.0.0'

--- a/discovery_engine/pubspec.yaml
+++ b/discovery_engine/pubspec.yaml
@@ -2,7 +2,7 @@ name: xayn_discovery_engine
 description: Xayn Discovery Engine package for Dart VM and web.
 version: 0.1.0+replace.with.version
 homepage: https://github.com/xaynetwork/xayn_discovery_engine/
-publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
@@ -23,7 +23,7 @@ dependencies:
   universal_platform: ^1.0.0+1
   uuid: ^3.0.6
   async_bindgen_dart_utils:
-    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
     version: 0.1.0+replace.with.version
   source_gen: ^1.2.2
   build: ^2.3.0

--- a/discovery_engine_flutter/example/pubspec.yaml
+++ b/discovery_engine_flutter/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   path_provider: 2.0.11
   xayn_discovery_engine_flutter:
-    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
     version: 0.1.0+replace.with.version
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/discovery_engine_flutter/pubspec.yaml
+++ b/discovery_engine_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: xayn_discovery_engine_flutter
 description: Xayn Discovery Engine package for Flutter bundled with binaries.
 version: 0.1.0+replace.with.version
 homepage: https://github.com/xaynetwork/xayn_discovery_engine/
-publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   xayn_discovery_engine:
-    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.yellow.private
+    hosted: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
     version: 0.1.0+replace.with.version
 
 dev_dependencies:

--- a/justfile
+++ b/justfile
@@ -338,7 +338,14 @@ _ci-dart-publish:
     # We use a timestamp as major version,
     # for now for our use case this is good enough and simple to do.
     TIMESTAMP="$(date +%y%m%d%H%M%S)"
-    VERSION="0.${TIMESTAMP}.0+${VERSION_METADATA}"
+
+    # Due to bugs in JFrog we can only have small version numbers.
+    # VERSION="0.${TIMESTAMP}.0+${VERSION_METADATA}"
+
+    # This is very prone to problems as it relies on an undocumented implementation
+    # detail of dart pub/jfrog which is in conflict with the semver spec. But it's
+    # the best we can do for now.
+    VERSION="0.1.0+${VERSION_METADATA}.${TIMESTAMP}"
     echo "Version: $VERSION"
 
     {{just_executable()}} _ci-dart-publish-with-version "${VERSION}"

--- a/justfile
+++ b/justfile
@@ -303,20 +303,6 @@ download-assets:
 check-android-so:
     {{justfile_directory()}}/.github/scripts/check_android_so.sh "$FLUTTER_WORKSPACE"/android/src/main/jniLibs/
 
-_override-flutter-self-deps $VERSION:
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-    cd "$FLUTTER_EXAMPLE_WORKSPACE"
-
-    SED_CMD="sed"
-    if [[ "{{os()}}" == "macos" ]]; then
-        SED_CMD="gsed"
-    fi
-
-    # This will add changes to your repo which should never be committed.
-    $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
-    $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
-
 _override-dart-deps $WORKSPACE $VERSION:
     #!/usr/bin/env bash
     set -eux -o pipefail
@@ -333,7 +319,7 @@ _override-dart-deps $WORKSPACE $VERSION:
     $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
     $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
 
-_dart-publish $WORKSPACE $VERSION:
+_dart-publish $WORKSPACE:
     cd "$WORKSPACE"; \
     dart pub publish --force
 
@@ -362,9 +348,9 @@ _ci-dart-publish-with-version $VERSION:
     {{just_executable()}} _override-dart-deps "${DART_WORKSPACE}" "${VERSION}"
     {{just_executable()}} _override-dart-deps "${FLUTTER_WORKSPACE}" "${VERSION}"
 
-    {{just_executable()}} _dart-publish "${DART_UTILS_WORKSPACE}" "${VERSION}"
-    {{just_executable()}} _dart-publish "${FLUTTER_WORKSPACE}" "${VERSION}"
-    {{just_executable()}} _dart-publish "${DART_WORKSPACE}" "${VERSION}"
+    {{just_executable()}} _dart-publish "${DART_UTILS_WORKSPACE}"
+    {{just_executable()}} _dart-publish "${FLUTTER_WORKSPACE}"
+    {{just_executable()}} _dart-publish "${DART_WORKSPACE}"
 
 build-web-service:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -351,9 +351,9 @@ _dart-publish $WORKSPACE:
 
 # This should only be run by the CI
 _ci-dart-publish:
-    {{just_executable()}} _dart-publish "$FLUTTER_WORKSPACE"
     {{just_executable()}} _dart-publish "$DART_UTILS_WORKSPACE"
     {{just_executable()}} _dart-publish "$DART_WORKSPACE"
+    {{just_executable()}} _dart-publish "$FLUTTER_WORKSPACE"
 
 build-web-service:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -317,8 +317,7 @@ _override-flutter-self-deps $VERSION:
     $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
     $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
 
-
-_dart-publish $WORKSPACE:
+_override-dart-deps $WORKSPACE $VERSION:
     #!/usr/bin/env bash
     set -eux -o pipefail
     cd "$WORKSPACE"
@@ -332,6 +331,16 @@ _dart-publish $WORKSPACE:
 
     # Dependency overrides are not allowed in published dart packages
     $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
+    $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
+
+_dart-publish $WORKSPACE $VERSION:
+    cd "$WORKSPACE"; \
+    dart pub publish --force
+
+# This should only be run by the CI
+_ci-dart-publish:
+    #!/usr/bin/env bash
+    set -eux -o pipefail
 
     # Use the branch name as metadata, replace invalid characters with "-".
     VERSION_METADATA="$(git rev-parse --abbrev-ref HEAD | sed s/[^0-9a-zA-Z-]/-/g )"
@@ -346,14 +355,16 @@ _dart-publish $WORKSPACE:
     VERSION="0.${TIMESTAMP}.0+${VERSION_METADATA}"
     echo "Version: $VERSION"
 
-    $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
-    dart pub publish --force
+    {{just_executable()}} _ci-dart-publish-with-version "${VERSION}"
 
-# This should only be run by the CI
-_ci-dart-publish:
-    {{just_executable()}} _dart-publish "$DART_UTILS_WORKSPACE"
-    {{just_executable()}} _dart-publish "$DART_WORKSPACE"
-    {{just_executable()}} _dart-publish "$FLUTTER_WORKSPACE"
+_ci-dart-publish-with-version $VERSION:
+    {{just_executable()}} _override-dart-deps "${DART_UTILS_WORKSPACE}" "${VERSION}"
+    {{just_executable()}} _override-dart-deps "${DART_WORKSPACE}" "${VERSION}"
+    {{just_executable()}} _override-dart-deps "${FLUTTER_WORKSPACE}" "${VERSION}"
+
+    {{just_executable()}} _dart-publish "${DART_UTILS_WORKSPACE}" "${VERSION}"
+    {{just_executable()}} _dart-publish "${FLUTTER_WORKSPACE}" "${VERSION}"
+    {{just_executable()}} _dart-publish "${DART_WORKSPACE}" "${VERSION}"
 
 build-web-service:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -316,6 +316,7 @@ _override-dart-deps $WORKSPACE $VERSION:
     fi
 
     # Dependency overrides are not allowed in published dart packages
+    # This will add changes to your repo which should never be committed.
     $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
     $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
 

--- a/justfile
+++ b/justfile
@@ -320,7 +320,7 @@ _override-dart-deps $WORKSPACE $VERSION:
     $SED_CMD -i "s/dependency_overrides/HACK_hide_dependency_overrides/g" ./pubspec.yaml
     $SED_CMD -i "s/0.1.0+replace.with.version/${VERSION}/g" ./pubspec.yaml
 
-_dart-publish $WORKSPACE:
+_call-dart-publish $WORKSPACE:
     cd "$WORKSPACE"; \
     dart pub publish --force
 
@@ -356,9 +356,9 @@ _ci-dart-publish-with-version $VERSION:
     {{just_executable()}} _override-dart-deps "${DART_WORKSPACE}" "${VERSION}"
     {{just_executable()}} _override-dart-deps "${FLUTTER_WORKSPACE}" "${VERSION}"
 
-    {{just_executable()}} _dart-publish "${DART_UTILS_WORKSPACE}"
-    {{just_executable()}} _dart-publish "${FLUTTER_WORKSPACE}"
-    {{just_executable()}} _dart-publish "${DART_WORKSPACE}"
+    {{just_executable()}} _call-dart-publish "${DART_UTILS_WORKSPACE}"
+    {{just_executable()}} _call-dart-publish "${FLUTTER_WORKSPACE}"
+    {{just_executable()}} _call-dart-publish "${DART_WORKSPACE}"
 
 build-web-service:
     #!/usr/bin/env bash


### PR DESCRIPTION
This does a number of small changes:

- switch from `dart.yellow.private` to `dart.xayn.private`
- change versioning schema to `0.1.0+<branch-name>.<timestamp>`
  - we use the timestamp instead of the git hash as this creates a proper sorting of the packages by "branch,version"
  - note that this relies on non-documented standard conflicting implementation details of JFrog/dart pub, while it will probably not brake it could, especially if you depend on a version which had been deleted in the repo :sob: 
  - but it's for now the best we can do
 - slightly changes how the justfile does the CI publishing (to allow easier debugging locally and makes sure the same timestamp is used across all packages)

**References:**
 
 - TO-3259