### PR TITLE
[Merged by Bors] - TO-3247 filter documents near negative coi

### DIFF
--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -26,6 +26,7 @@ use xayn_discovery_engine_ai::{CoiSystem, GenericError, KeyPhrase, UserInterests
 use xayn_discovery_engine_providers::{GenericArticle, Market};
 
 use crate::{
+    config::StackConfig as Config,
     document::{Document, HistoricDocument, Id as DocumentId, UserReaction},
     mab::Bucket,
 };
@@ -125,14 +126,15 @@ pub(crate) struct Stack {
     pub(crate) data: Data,
     #[derivative(Debug = "ignore")]
     pub(crate) ops: BoxedOps,
+    config: Config,
 }
 
 impl Stack {
     /// Create a new `Stack` with the given [`Data`] and customized [`Ops`].
-    pub(crate) fn new(data: Data, ops: BoxedOps) -> Result<Self, Error> {
+    pub(crate) fn new(data: Data, ops: BoxedOps, config: Config) -> Result<Self, Error> {
         Self::validate_documents_stack_id(&data.documents, ops.id())?;
 
-        Ok(Self { data, ops })
+        Ok(Self { data, ops, config })
     }
 
     /// [`Id`] of this `Stack`.
@@ -370,7 +372,7 @@ mod tests {
     fn test_stack_new_from_default() {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
-        assert!(Stack::new(Data::default(), Box::new(ops)).is_ok());
+        assert!(Stack::new(Data::default(), Box::new(ops), Config::default()).is_ok());
     }
 
     #[test]
@@ -383,7 +385,7 @@ mod tests {
                 ops.expect_id().returning(move || stack_id);
 
                 let data = Data::new(0.01, 0.99, docs.to_vec()).unwrap();
-                Stack::new(data, Box::new(ops))
+                Stack::new(data, Box::new(ops), Config::default())
             },
             stack_id,
         );
@@ -399,7 +401,7 @@ mod tests {
                 ops.expect_id().returning(move || stack_id);
 
                 let data = Data::new(0.01, 0.99, docs.to_vec()).unwrap();
-                Stack::new(data, Box::new(ops))
+                Stack::new(data, Box::new(ops), Config::default())
             },
             stack_id,
         );
@@ -415,7 +417,7 @@ mod tests {
         ops.expect_id().returning(Id::default);
 
         let data = Data::new(alpha, beta, vec![]).unwrap();
-        let stack = Stack::new(data, Box::new(ops)).unwrap();
+        let stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
 
         assert_eq!(stack.alpha(), alpha);
         assert_eq!(stack.beta(), beta);
@@ -426,7 +428,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
 
-        let mut stack = Stack::new(Data::default(), Box::new(ops)).unwrap();
+        let mut stack = Stack::new(Data::default(), Box::new(ops), Config::default()).unwrap();
 
         assert!(stack.pop().is_none());
     }
@@ -438,7 +440,7 @@ mod tests {
         let data = Data::new(0.01, 0.99, vec![doc.clone(), doc]).unwrap();
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
-        let mut stack = Stack::new(data, Box::new(ops)).unwrap();
+        let mut stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
 
         assert!(stack.pop().is_some());
         assert!(stack.pop().is_some());
@@ -450,7 +452,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
         let data = Data::default();
-        let stack = Stack::new(data, Box::new(ops)).unwrap();
+        let stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
 
         assert!(stack.is_empty());
 
@@ -459,7 +461,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
         let data = Data::new(1., 1., vec![doc]).unwrap();
-        let mut stack = Stack::new(data, Box::new(ops)).unwrap();
+        let mut stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
 
         assert!(!stack.is_empty());
         stack.pop();
@@ -471,7 +473,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
         let data = Data::default();
-        let mut stack = Stack::new(data, Box::new(ops)).unwrap();
+        let mut stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
         let alpha = stack.alpha();
         let beta = stack.beta();
 
@@ -486,7 +488,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
         let data = Data::default();
-        let mut stack = Stack::new(data, Box::new(ops)).unwrap();
+        let mut stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
         let alpha = stack.alpha();
         let beta = stack.beta();
 
@@ -501,7 +503,7 @@ mod tests {
         let mut ops = MockOps::new();
         ops.expect_id().returning(Id::default);
         let data = Data::default();
-        let mut stack = Stack::new(data, Box::new(ops)).unwrap();
+        let mut stack = Stack::new(data, Box::new(ops), Config::default()).unwrap();
         let alpha = stack.alpha();
         let beta = stack.beta();
 

--- a/discovery_engine_core/core/src/stack/exploration/selection.rs
+++ b/discovery_engine_core/core/src/stack/exploration/selection.rs
@@ -16,11 +16,10 @@ use std::collections::{BTreeSet, HashSet};
 
 use displaydoc::Display;
 use itertools::{chain, Itertools};
-use ndarray::{Array2, ArrayView1};
+use ndarray::Array2;
 use rand::{prelude::IteratorRandom, Rng};
 use thiserror::Error;
 use xayn_discovery_engine_ai::{
-    cosine_similarity,
     nan_safe_f32_cmp,
     pairwise_cosine_similarity,
     CoiPoint,
@@ -28,7 +27,11 @@ use xayn_discovery_engine_ai::{
     PositiveCoi,
 };
 
-use crate::{config::ExplorationConfig as Config, document::Document};
+use crate::{
+    config::ExplorationConfig as Config,
+    document::Document,
+    stack::filters::{filter_too_similar, max_cosine_similarity},
+};
 
 #[derive(Error, Debug, Display)]
 pub enum Error {
@@ -137,57 +140,6 @@ fn argsort(arr: &[f32]) -> Vec<usize> {
     indices
 }
 
-/// Filters all documents which are too similar to their closest coi.
-///
-/// # Panics
-/// Panics if `cois` is empty.
-fn filter_too_similar(
-    mut documents: Vec<Document>,
-    cois: &[ArrayView1<'_, f32>],
-    threshold: f32,
-) -> Vec<Document> {
-    let mut retain = max_cosine_similarity(
-        documents
-            .iter()
-            .map(|document| document.smbert_embedding.view()),
-        cois,
-    )
-    .into_iter()
-    .map(|similarity| similarity <= threshold);
-    // the iterator is only empty if:
-    // - the documents are empty => retaining is a no-op and unwrapping doesn't happen
-    // - the cois are empty => the panic is already propagated above
-    documents.retain(|_| retain.next().unwrap());
-
-    documents
-}
-
-/// Computes the cosine similarity between the cois and documents and returns the
-/// cosine similarity of the nearest coi for each document.
-///
-/// # Panics
-/// Panics if `cois` is empty.
-fn max_cosine_similarity<'a, I>(docs: I, cois: &[ArrayView1<'_, f32>]) -> Vec<f32>
-where
-    I: IntoIterator<Item = ArrayView1<'a, f32>>,
-{
-    // creates a cosine similarity matrix (docs x cois)
-    // |      | coi1                  | coi2                  |
-    // | doc1 | `cos_sim(doc1, coi1)` | `cos_sim(doc1, coi2)` |
-    // | doc2 | `cos_sim(doc2, coi1)` | `cos_sim(doc2, coi2)` |
-    //
-    // finds the nearest coi for each document
-    // [doc1(max(cos_sim1, cos_sim2, ...)), doc2(max(cos_sim1, cos_sim2, ...)), ...]
-    docs.into_iter()
-        .map(|doc| {
-            cois.iter()
-                .map(|&coi| cosine_similarity(doc, coi))
-                .max_by(nan_safe_f32_cmp)
-                .unwrap()
-        })
-        .collect()
-}
-
 /// Determines the threshold and returns it together with the indices of the documents
 /// that are below that threshold.
 ///
@@ -291,22 +243,6 @@ mod tests {
         );
 
         assert_approx_eq!(f32, max, [0.894_427_2, 0.514_495_8]);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_max_cosine_similarity_no_cois() {
-        max_cosine_similarity(
-            [arr1(&[1., 1., 0.]).view()],
-            &[] as &[ArrayView1<'_, f32>; 0],
-        );
-    }
-
-    #[test]
-    fn test_max_cosine_similarity_no_docs() {
-        let max = max_cosine_similarity([], &[arr1(&[1., 1., 0.]).view()]);
-
-        assert!(max.is_empty());
     }
 
     #[test]

--- a/discovery_engine_core/core/src/stack/filters.rs
+++ b/discovery_engine_core/core/src/stack/filters.rs
@@ -20,6 +20,12 @@ mod source;
 pub(crate) use self::{
     article::{ArticleFilter, CommonFilter, MalformedFilter, SourcesFilter},
     deduplication::DuplicateFilter,
-    semantic::{filter_semantically, Criterion, SemanticFilterConfig},
+    semantic::{
+        filter_semantically,
+        filter_too_similar,
+        max_cosine_similarity,
+        Criterion,
+        SemanticFilterConfig,
+    },
     source::source_weight,
 };


### PR DESCRIPTION
**References**

- [TO-3247]

**Summary**

- move `max_cosine_similarity()` and `filter_too_similar()` from `stack::exploration::selection` to `stack::filters::semantic`, generalize both to work with iterators and remove the panic
- add `StackConfig` to stacks and engine constructor, update [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)
- filter documents which are too similar to the negative cois in `Stack::update()`, similarly to the exploration stack


[TO-3247]: https://xainag.atlassian.net/browse/TO-3247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ