### PR TITLE
[Merged by Bors] - To xxxx fix dart sdk version

### DIFF
--- a/async_bindgen_dart_utils/pubspec.yaml
+++ b/async_bindgen_dart_utils/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+replace.with.version
 publish_to: https://xayn.jfrog.io/artifactory/api/pub/dart.xayn.private
 
 environment:
-  sdk: '>=2.17.1 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Make sure to depend on sdk >= 2.17.0 instead of 2.17.1.