### PR TITLE
[Merged by Bors] - TO-3024 configurable timeout

### DIFF
--- a/discovery_engine_core/providers/src/bing.rs
+++ b/discovery_engine_core/providers/src/bing.rs
@@ -14,6 +14,8 @@
 
 //! Client to retrieve trending topics.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Arc;
@@ -26,9 +28,9 @@ pub struct BingTrendingTopicsProvider {
 }
 
 impl BingTrendingTopicsProvider {
-    pub fn new(endpoint_url: Url, auth_token: String) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
         }
     }
 
@@ -132,7 +134,11 @@ mod tests {
     async fn test_trending() {
         let mock_server = MockServer::start().await;
         let endpoint_url = Url::parse(&mock_server.uri()).unwrap();
-        let provider = BingTrendingTopicsProvider::new(endpoint_url, "test-token".to_string());
+        let provider = BingTrendingTopicsProvider::new(
+            endpoint_url,
+            "test-token".to_string(),
+            Duration::from_secs(1),
+        );
 
         let tmpl = ResponseTemplate::new(200)
             .set_body_string(include_str!("../test-fixtures/trending-topics.json"));

--- a/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
+++ b/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
@@ -36,7 +36,7 @@ pub struct RestEndpoint {
 
 impl RestEndpoint {
     /// Create a `RestEndpoint` instance with a default timeout.
-    pub fn new(url: Url, auth_token: String) -> Self {
+    pub fn new(url: Url, auth_token: String, timeout: Duration) -> Self {
         let client = SHARED_CLIENT
             .get_or_init(|| {
                 // Note: If we need to use a ClientBuilder we should pass the `Arc<Client>` as
@@ -49,18 +49,9 @@ impl RestEndpoint {
             client,
             url,
             auth_token,
-            timeout: Duration::from_millis(3500),
+            timeout,
             get_as_post: false,
         }
-    }
-
-    /// Configures the timeout.
-    ///
-    /// The timeout defaults to 3.5s.
-    #[must_use = "dropped changed client"]
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
-        self
     }
 
     /// Configures if we should use POST for GET requests.

--- a/discovery_engine_core/providers/src/mlt.rs
+++ b/discovery_engine_core/providers/src/mlt.rs
@@ -14,6 +14,11 @@
 
 //! Client for "more like this" queries.
 
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use url::Url;
+
 use crate::{
     newscatcher::{append_market, max_age_to_date_string, to_generic_articles},
     Error,
@@ -23,10 +28,6 @@ use crate::{
     SimilarNewsProvider,
     SimilarNewsQuery,
 };
-
-use async_trait::async_trait;
-use std::sync::Arc;
-use url::Url;
 
 pub(crate) struct MltSimilarNewsProvider {
     endpoint: RestEndpoint,
@@ -66,9 +67,9 @@ impl SimilarNewsProvider for MltSimilarNewsProvider {
 
 impl MltSimilarNewsProvider {
     #[allow(dead_code)] // TEMP
-    pub(crate) fn new(endpoint_url: Url, auth_token: String) -> Self {
+    pub(crate) fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
         }
     }
 

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -12,6 +12,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::{NaiveDateTime, Utc};
+use derive_more::Deref;
+use serde::{de, Deserialize, Deserializer, Serialize};
+use url::Url;
+
 use crate::{
     helpers::rest_endpoint::RestEndpoint,
     models::NewsQuery,
@@ -25,13 +33,6 @@ use crate::{
     TrustedHeadlinesProvider,
     TrustedHeadlinesQuery,
 };
-use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
-use derive_more::Deref;
-use std::sync::Arc;
-
-use serde::{de, Deserialize, Deserializer, Serialize};
-use url::Url;
 
 #[derive(Deref)]
 pub struct NewscatcherNewsProvider {
@@ -39,9 +40,9 @@ pub struct NewscatcherNewsProvider {
 }
 
 impl NewscatcherNewsProvider {
-    pub fn new(endpoint_url: Url, auth_token: String) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
         }
     }
 
@@ -101,9 +102,9 @@ pub struct NewscatcherHeadlinesProvider {
 
 impl NewscatcherHeadlinesProvider {
     /// Create a new provider.
-    pub fn new(endpoint_url: Url, auth_token: String) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
         }
     }
 
@@ -149,9 +150,9 @@ pub struct NewscatcherTrustedHeadlinesProvider {
 }
 
 impl NewscatcherTrustedHeadlinesProvider {
-    pub fn new(endpoint_url: Url, auth_token: String) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
         }
     }
 
@@ -338,6 +339,7 @@ mod tests {
         let provider = NewscatcherNewsProvider::new(
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -384,6 +386,7 @@ mod tests {
         let provider = NewscatcherNewsProvider::new(
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -431,6 +434,7 @@ mod tests {
         let provider = NewscatcherNewsProvider::new(
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -480,6 +484,7 @@ mod tests {
         let provider = NewscatcherNewsProvider::new(
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -529,6 +534,7 @@ mod tests {
         let provider = NewscatcherHeadlinesProvider::new(
             Url::parse(&format!("{}/v1/latest-headlines", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -587,6 +593,7 @@ mod tests {
         let provider = NewscatcherTrustedHeadlinesProvider::new(
             Url::parse(&format!("{}/v2/trusted-sources", mock_server.uri())).unwrap(),
             "test-token".into(),
+            Duration::from_secs(1),
         );
 
         let tmpl = ResponseTemplate::new(200)

--- a/discovery_engine_core/tooling/src/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/src/bin/newscatcher.rs
@@ -30,6 +30,8 @@
     clippy::must_use_candidate
 )]
 
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use url::Url;
 use xayn_discovery_engine_providers::{
@@ -47,12 +49,13 @@ async fn main() -> Result<()> {
         "Please provide the NEWSCATCHER_DEV_BEARER_AUTH_TOKEN environment variable for the dev environment. \
                   The token can be found in 1Password",
     )?;
+    let timeout = Duration::from_millis(3500);
 
     tokio::fs::create_dir("./headlines_download")
         .await
         .context("Failed to create download directory. Does it already exist?")?;
 
-    let provider = NewscatcherHeadlinesProvider::new(url, token);
+    let provider = NewscatcherHeadlinesProvider::new(url, token, timeout);
     let market = Market::new("en", "US");
 
     // This is updated every iteration, based on the response from Newscatcher. So in reality,


### PR DESCRIPTION
**References**

- [TO-3024]
- followed by #562

**Summary**

- add `timeout` to `EndpointConfig` & use it in providers
- simplify usability of configs in engine constructor
- update [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)


[TO-3024]: https://xainag.atlassian.net/browse/TO-3024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ