### PR TITLE
[Merged by Bors] - TO-3025 configurable retry

### DIFF
--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -104,13 +104,14 @@ pub struct InitConfig {
 }
 
 impl InitConfig {
-    pub(crate) fn to_provider_config(&self, timeout: Duration) -> ProviderConfig {
+    pub(crate) fn to_provider_config(&self, timeout: Duration, retry: usize) -> ProviderConfig {
         ProviderConfig {
             api_base_url: self.api_base_url.clone(),
             api_key: self.api_key.clone(),
             news_provider_path: self.news_provider_path.clone(),
             headlines_provider_path: self.headlines_provider_path.clone(),
             timeout,
+            retry,
         }
     }
 }
@@ -146,6 +147,8 @@ pub struct EndpointConfig {
     /// The timeout after which a provider aborts a request.
     #[serde(with = "serde_duration_as_milliseconds")]
     pub timeout: Duration,
+    /// The number of retries in case of a timeout.
+    pub retry: usize,
 }
 
 impl Default for EndpointConfig {
@@ -160,6 +163,7 @@ impl Default for EndpointConfig {
             max_headline_age_days: 3,
             max_article_age_days: 30,
             timeout: Duration::from_millis(3500),
+            retry: 0,
         }
     }
 }

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -277,7 +277,8 @@ impl Engine {
         let exploration_config = de_config
             .extract_inner(&format!("stacks.{}", Exploration::id()))
             .map_err(|err| Error::Ranker(err.into()))?;
-        let provider_config = config.to_provider_config(endpoint_config.timeout);
+        let provider_config =
+            config.to_provider_config(endpoint_config.timeout, endpoint_config.retry);
 
         // build the systems
         let smbert = SMBertConfig::from_files(&config.smbert_vocab, &config.smbert_model)

--- a/discovery_engine_core/providers/src/bing.rs
+++ b/discovery_engine_core/providers/src/bing.rs
@@ -28,9 +28,9 @@ pub struct BingTrendingTopicsProvider {
 }
 
 impl BingTrendingTopicsProvider {
-    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration, retry: usize) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout, retry),
         }
     }
 
@@ -48,7 +48,7 @@ impl TrendingTopicsProvider for BingTrendingTopicsProvider {
     ) -> Result<Vec<TrendingTopic>, Error> {
         let response = self
             .endpoint
-            .get_request::<Response, _>(|query_append| {
+            .get_request::<_, Response>(|query_append| {
                 let lang = &request.market.lang_code;
                 let country = &request.market.country_code;
                 query_append("mkt", format!("{}-{}", lang, country));
@@ -138,6 +138,7 @@ mod tests {
             endpoint_url,
             "test-token".to_string(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)

--- a/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
+++ b/discovery_engine_core/providers/src/helpers/rest_endpoint.rs
@@ -31,12 +31,13 @@ pub struct RestEndpoint {
     url: Url,
     auth_token: String,
     timeout: Duration,
+    retry: usize,
     get_as_post: bool,
 }
 
 impl RestEndpoint {
     /// Create a `RestEndpoint` instance with a default timeout.
-    pub fn new(url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub fn new(url: Url, auth_token: String, timeout: Duration, retry: usize) -> Self {
         let client = SHARED_CLIENT
             .get_or_init(|| {
                 // Note: If we need to use a ClientBuilder we should pass the `Arc<Client>` as
@@ -50,6 +51,7 @@ impl RestEndpoint {
             url,
             auth_token,
             timeout,
+            retry,
             get_as_post: false,
         }
     }
@@ -71,38 +73,46 @@ impl RestEndpoint {
         &self.url
     }
 
-    pub async fn get_request<
+    pub async fn get_request<F, D>(&self, setup_query_params: F) -> Result<D, Error>
+    where
+        F: Fn(&mut dyn FnMut(&str, String)) + Send + Sync,
         D: DeserializeOwned + Send,
-        F: FnOnce(&mut dyn FnMut(&str, String)) + Send,
-    >(
-        &self,
-        setup_query_params: F,
-    ) -> Result<D, Error> {
-        let mut url = self.url.clone();
-
-        let query_builder = if self.get_as_post {
-            let mut query = Map::new();
-            setup_query_params(&mut |key, value| {
-                query.insert(key.into(), Value::String(value));
-            });
-            self.client.post(url).json(&Value::Object(query))
-        } else {
-            let mut query_mut = url.query_pairs_mut();
-            setup_query_params(&mut |key, value| {
-                query_mut.append_pair(key, &value);
-            });
-            drop(query_mut);
-            self.client.get(url)
-        };
-
-        let response = query_builder
+    {
+        let request_builder = || {
+            let mut url = self.url.clone();
+            if self.get_as_post {
+                let mut query = Map::new();
+                setup_query_params(&mut |key, value| {
+                    query.insert(key.into(), Value::String(value));
+                });
+                self.client.post(url).json(&Value::Object(query))
+            } else {
+                let mut query_mut = url.query_pairs_mut();
+                setup_query_params(&mut |key, value| {
+                    query_mut.append_pair(key, &value);
+                });
+                drop(query_mut);
+                self.client.get(url)
+            }
             .timeout(self.timeout)
             .bearer_auth(&self.auth_token)
-            .send()
-            .await
-            .map_err(Error::RequestExecution)?
-            .error_for_status()
-            .map_err(Error::StatusCode)?;
+        };
+
+        let mut retry = 0;
+        let response = loop {
+            match request_builder().send().await {
+                Err(error) if error.is_timeout() && retry < self.retry => {
+                    retry += 1;
+                    continue;
+                }
+                result => {
+                    break result
+                        .map_err(Error::RequestExecution)?
+                        .error_for_status()
+                        .map_err(Error::StatusCode)?;
+                }
+            }
+        };
 
         let raw_response = response.bytes().await.map_err(Error::Fetching)?;
         let deserializer = &mut serde_json::Deserializer::from_slice(&raw_response);

--- a/discovery_engine_core/providers/src/lib.rs
+++ b/discovery_engine_core/providers/src/lib.rs
@@ -125,6 +125,8 @@ pub struct ProviderConfig {
     pub headlines_provider_path: String,
     /// The timeout after which a provider aborts a request.
     pub timeout: Duration,
+    /// The number of retries in case of a timeout.
+    pub retry: usize,
 }
 
 pub struct Providers {
@@ -185,6 +187,7 @@ impl Providers {
             create_endpoint_url(&config.api_base_url, &config.headlines_provider_path)?,
             config.api_key.clone(),
             config.timeout,
+            config.retry,
         )
         .with_get_as_post(true);
         let headlines = select_provider(
@@ -196,6 +199,7 @@ impl Providers {
             create_endpoint_url(&config.api_base_url, &config.news_provider_path)?,
             config.api_key.clone(),
             config.timeout,
+            config.retry,
         )
         .with_get_as_post(true);
         let news = select_provider(news_endpoint, NewscatcherNewsProvider::from_endpoint)?;
@@ -205,6 +209,7 @@ impl Providers {
             create_endpoint_url(&config.api_base_url, "newscatcher/v2/trusted-sources")?,
             config.api_key.clone(),
             config.timeout,
+            config.retry,
         )
         .with_get_as_post(true);
         let trusted_headlines =
@@ -215,6 +220,7 @@ impl Providers {
             create_endpoint_url(&config.api_base_url, "bing/v1/trending-topics")?,
             config.api_key.clone(),
             config.timeout,
+            config.retry,
         );
         let trending_topics = BingTrendingTopicsProvider::from_endpoint(trending_topics_endpoint);
 
@@ -222,6 +228,7 @@ impl Providers {
             create_endpoint_url(&config.api_base_url, "_mlt")?,
             config.api_key,
             config.timeout,
+            config.retry,
         )
         .with_get_as_post(true);
         let similar_news = MltSimilarNewsProvider::from_endpoint(similar_news_endpoint);

--- a/discovery_engine_core/providers/src/mlt.rs
+++ b/discovery_engine_core/providers/src/mlt.rs
@@ -41,7 +41,7 @@ impl SimilarNewsProvider for MltSimilarNewsProvider {
     ) -> Result<Vec<GenericArticle>, Error> {
         let response = self
             .endpoint
-            .get_request::<NewscatcherResponse, _>(|query_append| {
+            .get_request::<_, NewscatcherResponse>(|query_append| {
                 query_append("like", query.like.to_string());
                 query_append("min_term_freq", "1".to_string());
 
@@ -67,9 +67,14 @@ impl SimilarNewsProvider for MltSimilarNewsProvider {
 
 impl MltSimilarNewsProvider {
     #[allow(dead_code)] // TEMP
-    pub(crate) fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub(crate) fn new(
+        endpoint_url: Url,
+        auth_token: String,
+        timeout: Duration,
+        retry: usize,
+    ) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout, retry),
         }
     }
 

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -40,9 +40,9 @@ pub struct NewscatcherNewsProvider {
 }
 
 impl NewscatcherNewsProvider {
-    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration, retry: usize) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout, retry),
         }
     }
 
@@ -74,7 +74,7 @@ impl NewsProvider for NewscatcherNewsProvider {
     async fn query_news(&self, request: &NewsQuery<'_>) -> Result<Vec<GenericArticle>, Error> {
         let response = self
             .endpoint
-            .get_request::<Response, _>(|query_append| {
+            .get_request::<_, Response>(|query_append| {
                 query_append("page_size", request.page_size.to_string());
                 query_append("page", request.page.to_string());
 
@@ -102,9 +102,9 @@ pub struct NewscatcherHeadlinesProvider {
 
 impl NewscatcherHeadlinesProvider {
     /// Create a new provider.
-    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration, retry: usize) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout, retry),
         }
     }
 
@@ -121,7 +121,7 @@ impl HeadlinesProvider for NewscatcherHeadlinesProvider {
     ) -> Result<Vec<GenericArticle>, Error> {
         let response = self
             .endpoint
-            .get_request::<Response, _>(|query_append| {
+            .get_request::<_, Response>(|query_append| {
                 query_append("page_size", request.page_size.to_string());
                 query_append("page", request.page.to_string());
 
@@ -150,9 +150,9 @@ pub struct NewscatcherTrustedHeadlinesProvider {
 }
 
 impl NewscatcherTrustedHeadlinesProvider {
-    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration) -> Self {
+    pub fn new(endpoint_url: Url, auth_token: String, timeout: Duration, retry: usize) -> Self {
         Self {
-            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout),
+            endpoint: RestEndpoint::new(endpoint_url, auth_token, timeout, retry),
         }
     }
 
@@ -169,7 +169,7 @@ impl TrustedHeadlinesProvider for NewscatcherTrustedHeadlinesProvider {
     ) -> Result<Vec<GenericArticle>, Error> {
         let response = self
             .endpoint
-            .get_request::<Response, _>(|query_append| {
+            .get_request::<_, Response>(|query_append| {
                 query_append("page_size", request.page_size.to_string());
                 query_append("page", request.page.to_string());
 
@@ -340,6 +340,7 @@ mod tests {
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -387,6 +388,7 @@ mod tests {
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -435,6 +437,7 @@ mod tests {
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -485,6 +488,7 @@ mod tests {
             Url::parse(&format!("{}/v1/search-news", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -535,6 +539,7 @@ mod tests {
             Url::parse(&format!("{}/v1/latest-headlines", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)
@@ -594,6 +599,7 @@ mod tests {
             Url::parse(&format!("{}/v2/trusted-sources", mock_server.uri())).unwrap(),
             "test-token".into(),
             Duration::from_secs(1),
+            0,
         );
 
         let tmpl = ResponseTemplate::new(200)

--- a/discovery_engine_core/tooling/src/bin/newscatcher.rs
+++ b/discovery_engine_core/tooling/src/bin/newscatcher.rs
@@ -50,12 +50,13 @@ async fn main() -> Result<()> {
                   The token can be found in 1Password",
     )?;
     let timeout = Duration::from_millis(3500);
+    let retry = 3;
 
     tokio::fs::create_dir("./headlines_download")
         .await
         .context("Failed to create download directory. Does it already exist?")?;
 
-    let provider = NewscatcherHeadlinesProvider::new(url, token, timeout);
+    let provider = NewscatcherHeadlinesProvider::new(url, token, timeout, retry);
     let market = Market::new("en", "US");
 
     // This is updated every iteration, based on the response from Newscatcher. So in reality,


### PR DESCRIPTION
**References**

- [TO-3025]
- requires #561

**Summary**

- add `retry` to `EndpointConfig` & use it in providers
- update [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)


[TO-3025]: https://xainag.atlassian.net/browse/TO-3025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ