### PR TITLE
[Merged by Bors] - TO-3278 split coi & kps configs

### DIFF
--- a/discovery_engine_core/ai/ai/src/coi/config.rs
+++ b/discovery_engine_core/ai/ai/src/coi/config.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, time::Duration};
+use std::time::Duration;
 
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
@@ -21,60 +21,35 @@ use thiserror::Error;
 use crate::{
     coi::system::CoiSystem,
     embedding::COSINE_SIMILARITY_RANGE,
-    utils::{nan_safe_f32_cmp_desc, serde_duration_as_days, SECONDS_PER_DAY_U64},
+    kps::config::Config as KpsConfig,
+    utils::{serde_duration_as_days, SECONDS_PER_DAY_U64},
 };
 
-/// The configuration of the cois.
+/// Configurations of the coi system.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct CoiConfig {
+#[must_use]
+pub struct Config {
     shift_factor: f32,
     threshold: f32,
     min_positive_cois: usize,
     min_negative_cois: usize,
+    #[serde(with = "serde_duration_as_days")]
+    horizon: Duration,
 }
 
 // the f32 fields are never NaN by construction
-impl Eq for CoiConfig {}
+impl Eq for Config {}
 
-impl Default for CoiConfig {
+impl Default for Config {
     fn default() -> Self {
         Self {
             shift_factor: 0.1,
             threshold: 0.67,
             min_positive_cois: 2,
             min_negative_cois: 0,
-        }
-    }
-}
-
-/// The configuration of the kpe.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-struct KPEConfig {
-    #[serde(with = "serde_duration_as_days")]
-    horizon: Duration,
-    gamma: f32,
-    penalty: Vec<f32>,
-}
-
-// the f32 fields are never NaN by construction
-impl Eq for KPEConfig {}
-
-impl Default for KPEConfig {
-    fn default() -> Self {
-        Self {
             horizon: Duration::from_secs(SECONDS_PER_DAY_U64 * 30),
-            gamma: 0.9,
-            penalty: vec![1., 0.75, 0.66],
         }
     }
-}
-
-/// The configuration of the coi system.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[must_use]
-pub struct Config {
-    coi: CoiConfig,
-    kpe: KPEConfig,
 }
 
 /// Errors of the coi system configuration.
@@ -86,16 +61,12 @@ pub enum Error {
     Threshold,
     /// Invalid minimum number of positive cois, expected positive value
     MinPositiveCois,
-    /// Invalid coi gamma, expected value from the unit interval
-    Gamma,
-    /// Invalid coi penalty, expected non-empty, finite and sorted values
-    Penalty,
 }
 
 impl Config {
     /// The shift factor by how much a coi is shifted towards a new point.
     pub fn shift_factor(&self) -> f32 {
-        self.coi.shift_factor
+        self.shift_factor
     }
 
     /// Sets the shift factor.
@@ -104,7 +75,7 @@ impl Config {
     /// Fails if the shift factor is outside of the unit interval.
     pub fn with_shift_factor(mut self, shift_factor: f32) -> Result<Self, Error> {
         if (0. ..=1.).contains(&shift_factor) {
-            self.coi.shift_factor = shift_factor;
+            self.shift_factor = shift_factor;
             Ok(self)
         } else {
             Err(Error::ShiftFactor)
@@ -113,7 +84,7 @@ impl Config {
 
     /// The maximum similarity between distinct cois.
     pub fn threshold(&self) -> f32 {
-        self.coi.threshold
+        self.threshold
     }
 
     /// Sets the threshold.
@@ -124,7 +95,7 @@ impl Config {
     /// [`COSINE_SIMILARITY_RANGE`]: crate::embedding::COSINE_SIMILARITY_RANGE
     pub fn with_threshold(mut self, threshold: f32) -> Result<Self, Error> {
         if COSINE_SIMILARITY_RANGE.contains(&threshold) {
-            self.coi.threshold = threshold;
+            self.threshold = threshold;
             Ok(self)
         } else {
             Err(Error::Threshold)
@@ -133,7 +104,7 @@ impl Config {
 
     /// The minimum number of positive cois required for the context calculation.
     pub fn min_positive_cois(&self) -> usize {
-        self.coi.min_positive_cois
+        self.min_positive_cois
     }
 
     /// Sets the minimum number of positive cois.
@@ -142,7 +113,7 @@ impl Config {
     /// Fails if the minimum number is zero.
     pub fn with_min_positive_cois(mut self, min_positive_cois: usize) -> Result<Self, Error> {
         if min_positive_cois > 0 {
-            self.coi.min_positive_cois = min_positive_cois;
+            self.min_positive_cois = min_positive_cois;
             Ok(self)
         } else {
             Err(Error::MinPositiveCois)
@@ -151,81 +122,31 @@ impl Config {
 
     /// The minimum number of negative cois required for the context calculation.
     pub fn min_negative_cois(&self) -> usize {
-        self.coi.min_negative_cois
+        self.min_negative_cois
     }
 
     /// Sets the minimum number of negative cois.
     pub fn with_min_negative_cois(mut self, min_negative_cois: usize) -> Self {
-        self.coi.min_negative_cois = min_negative_cois;
+        self.min_negative_cois = min_negative_cois;
         self
     }
 
     /// The time since the last view after which a coi becomes irrelevant.
     pub fn horizon(&self) -> Duration {
-        self.kpe.horizon
+        self.horizon
     }
 
     /// Sets the horizon.
     pub fn with_horizon(mut self, horizon: Duration) -> Self {
-        self.kpe.horizon = horizon;
+        self.horizon = horizon;
         self
     }
 
-    /// The weighting between coi and pairwise candidate similarities in the key phrase selection.
-    pub fn gamma(&self) -> f32 {
-        self.kpe.gamma
-    }
-
-    /// Sets the gamma.
-    ///
-    /// # Errors
-    /// Fails if the gamma is outside of the unit interval.
-    pub fn with_gamma(mut self, gamma: f32) -> Result<Self, Error> {
-        if (0. ..=1.).contains(&gamma) {
-            self.kpe.gamma = gamma;
-            Ok(self)
-        } else {
-            Err(Error::Gamma)
+    /// Creates a coi system.
+    pub fn build(self, kps_config: KpsConfig) -> CoiSystem {
+        CoiSystem {
+            coi_config: self,
+            kps_config,
         }
-    }
-
-    /// The penalty for less relevant key phrases of a coi in increasing order (ie. lowest penalty
-    /// for the most relevant key phrase first and highest penalty for the least relevant key phrase
-    /// last). The length of the penalty also serves as the maximum number of key phrases.
-    pub fn penalty(&self) -> &[f32] {
-        &self.kpe.penalty
-    }
-
-    /// Sets the penalty.
-    ///
-    /// # Errors
-    /// Fails if the penalty is empty, has non-finite values or is unsorted.
-    pub fn with_penalty(mut self, penalty: &[f32]) -> Result<Self, Error> {
-        // TODO: refactor once slice::is_sorted_by() is stabilized
-        fn is_sorted_by(slice: &[f32], compare: impl FnMut(&f32, &f32) -> Ordering) -> bool {
-            let mut vector = slice.to_vec();
-            vector.sort_unstable_by(compare);
-            vector == slice
-        }
-
-        if !penalty.is_empty()
-            && penalty.iter().copied().all(f32::is_finite)
-            && is_sorted_by(penalty, nan_safe_f32_cmp_desc)
-        {
-            self.kpe.penalty = penalty.to_vec();
-            Ok(self)
-        } else {
-            Err(Error::Penalty)
-        }
-    }
-
-    /// The maximum number of key phrases picked during the coi key phrase selection.
-    pub fn max_key_phrases(&self) -> usize {
-        self.kpe.penalty.len()
-    }
-
-    /// Creates a centre of interest system.
-    pub fn build(self) -> CoiSystem {
-        CoiSystem { config: self }
     }
 }

--- a/discovery_engine_core/ai/ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/ai/src/coi/key_phrase.rs
@@ -464,7 +464,10 @@ mod tests {
     use ndarray::arr2;
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
-    use crate::{coi::point::tests::create_pos_cois, kps::config::Config};
+    use crate::{
+        coi::{config::Config as CoiConfig, point::tests::create_pos_cois},
+        kps::config::Config as KpsConfig,
+    };
 
     use super::*;
 
@@ -799,7 +802,7 @@ mod tests {
         let market = Market::new("aa", "AA");
         let candidates = [];
         let smbert = |_: &str| unreachable!();
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -823,7 +826,7 @@ mod tests {
         let market = Market::new("aa", "AA");
         let candidates = [];
         let smbert = |_: &str| unreachable!();
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -852,7 +855,7 @@ mod tests {
             "phrase" => Ok([1., 1., 1.].into()),
             _ => unreachable!(),
         };
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -877,7 +880,7 @@ mod tests {
         let market = Market::new("aa", "AA");
         let candidates = ["  a  !@#$%  b  ".into()];
         let smbert = |_: &str| Ok([1., 1., 0.].into());
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -906,7 +909,7 @@ mod tests {
             "words" => Ok([2., 1., 0.].into()),
             _ => unreachable!(),
         };
-        let config = Config::default();
+        let config = KpsConfig::default();
         assert_eq!(config.max_key_phrases(), 3);
 
         key_phrases.update(
@@ -935,7 +938,7 @@ mod tests {
             "phrase" => Ok([1., 1., 1.].into()),
             _ => unreachable!(),
         };
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -966,7 +969,7 @@ mod tests {
             "words" => Ok([3., 1., 0.].into()),
             _ => unreachable!(),
         };
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.update(
             &cois[0],
@@ -995,7 +998,7 @@ mod tests {
         let market = Market::new("aa", "AA");
         let mut key_phrases = KeyPhrases::new([(coi_id, ("aa", "AA"), "key", [1., 1., 1.])]);
         swap(&mut key_phrases.selected, &mut key_phrases.removed);
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.refresh(&cois, &market, config.max_key_phrases(), config.gamma());
         assert!(key_phrases.selected.is_empty());
@@ -1009,7 +1012,7 @@ mod tests {
         let market = Market::new("bb", "BB");
         let mut key_phrases = KeyPhrases::new([(cois[0].id, ("aa", "AA"), "key", [1., 1., 1.])]);
         swap(&mut key_phrases.selected, &mut key_phrases.removed);
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.refresh(&cois, &market, config.max_key_phrases(), config.gamma());
         assert!(key_phrases.selected.is_empty());
@@ -1025,7 +1028,7 @@ mod tests {
         let cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
         let market = Market::new("aa", "AA");
         let mut key_phrases = KeyPhrases::default();
-        let config = Config::default();
+        let config = KpsConfig::default();
 
         key_phrases.refresh(&cois, &market, config.max_key_phrases(), config.gamma());
         assert!(key_phrases.selected.is_empty());
@@ -1048,7 +1051,7 @@ mod tests {
             (cois[1].id, ("bb", "BB"), "enough", [1., 1., 1.]),
         ]);
         swap(&mut key_phrases.selected, &mut key_phrases.removed);
-        let config = Config::default();
+        let config = KpsConfig::default();
         assert_eq!(config.max_key_phrases(), 3);
 
         key_phrases.refresh(&cois, &market, config.max_key_phrases(), config.gamma());
@@ -1182,15 +1185,16 @@ mod tests {
         let coi_id = CoiId::mocked(1);
         let market = Market::new("aa", "AA");
         let mut key_phrases = KeyPhrases::new([(coi_id, ("aa", "AA"), "key", [1., 1., 1.])]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert!(top_key_phrases.is_empty());
         assert_eq!(key_phrases.selected.len(), 1);
@@ -1203,15 +1207,16 @@ mod tests {
         let cois = create_pos_cois(&[[1., 0., 0.]]);
         let market = Market::new("bb", "BB");
         let mut key_phrases = KeyPhrases::new([(cois[0].id, ("aa", "AA"), "key", [1., 1., 1.])]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert!(top_key_phrases.is_empty());
         assert_eq!(key_phrases.selected.len(), 1);
@@ -1227,15 +1232,16 @@ mod tests {
         let cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
         let market = Market::new("aa", "AA");
         let mut key_phrases = KeyPhrases::default();
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert!(top_key_phrases.is_empty());
         assert!(key_phrases.selected.is_empty());
@@ -1251,15 +1257,16 @@ mod tests {
             (cois[1].id, ("aa", "AA"), "phrase", [2., 1., 1.]),
             (cois[2].id, ("aa", "AA"), "words", [3., 1., 1.]),
         ]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             0,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert!(top_key_phrases.is_empty());
         assert_eq!(key_phrases.selected.len(), cois.len());
@@ -1293,15 +1300,16 @@ mod tests {
             (cois[2].id, ("aa", "AA"), "not", [1., 1., 8.]),
             (cois[2].id, ("aa", "AA"), "enough", [1., 1., 7.]),
         ]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert_eq!(top_key_phrases.len(), 9);
         assert_eq!(
@@ -1342,15 +1350,16 @@ mod tests {
             (cois[2].id, ("bb", "BB"), "not", [1., 1., 8.]),
             (cois[2].id, ("bb", "BB"), "enough", [1., 1., 7.]),
         ]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert_eq!(top_key_phrases.len(), 6);
         assert_eq!(
@@ -1399,23 +1408,24 @@ mod tests {
             (cois[2].id, ("bb", "BB"), "not", [1., 1., 8.]),
             (cois[2].id, ("bb", "BB"), "enough", [1., 1., 7.]),
         ]);
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         let top_key_phrases_first = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         let top_key_phrases_second = key_phrases.take(
             &cois,
             &market,
             usize::MAX,
-            config.horizon(),
-            config.penalty(),
-            config.gamma(),
+            coi_config.horizon(),
+            kps_config.penalty(),
+            kps_config.gamma(),
         );
         assert_eq!(top_key_phrases_first, top_key_phrases_second);
     }

--- a/discovery_engine_core/ai/ai/src/coi/key_phrase.rs
+++ b/discovery_engine_core/ai/ai/src/coi/key_phrase.rs
@@ -464,7 +464,7 @@ mod tests {
     use ndarray::arr2;
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
-    use crate::coi::{config::Config, point::tests::create_pos_cois};
+    use crate::{coi::point::tests::create_pos_cois, kps::config::Config};
 
     use super::*;
 

--- a/discovery_engine_core/ai/ai/src/coi/stats.rs
+++ b/discovery_engine_core/ai/ai/src/coi/stats.rs
@@ -125,7 +125,7 @@ pub(crate) fn compute_coi_decay_factor(
 
 #[cfg(test)]
 mod tests {
-    use crate::{coi::point::tests::create_pos_cois, kps::config::Config};
+    use crate::coi::{config::Config, point::tests::create_pos_cois};
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;

--- a/discovery_engine_core/ai/ai/src/coi/stats.rs
+++ b/discovery_engine_core/ai/ai/src/coi/stats.rs
@@ -125,7 +125,7 @@ pub(crate) fn compute_coi_decay_factor(
 
 #[cfg(test)]
 mod tests {
-    use crate::coi::{config::Config, point::tests::create_pos_cois};
+    use crate::{coi::point::tests::create_pos_cois, kps::config::Config};
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;

--- a/discovery_engine_core/ai/ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/ai/src/coi/system.rs
@@ -95,7 +95,7 @@ impl CoiSystem {
             cois,
             market,
             top,
-            self.kps_config.horizon(),
+            self.coi_config.horizon(),
             self.kps_config.penalty(),
             self.kps_config.gamma(),
         )

--- a/discovery_engine_core/ai/ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/ai/src/coi/system.rs
@@ -20,25 +20,31 @@ use xayn_discovery_engine_providers::Market;
 
 use crate::{
     coi::{
-        config::Config,
+        config::Config as CoiConfig,
         context::compute_scores_for_docs,
         key_phrase::{KeyPhrase, KeyPhrases},
         point::{find_closest_coi_mut, CoiPoint, NegativeCoi, PositiveCoi, UserInterests},
     },
     document::Document,
     embedding::Embedding,
+    kps::config::Config as KpsConfig,
     nan_safe_f32_cmp_desc,
     GenericError,
 };
 
 /// The main system of the AI.
 pub struct CoiSystem {
-    pub(crate) config: Config,
+    pub(crate) coi_config: CoiConfig,
+    pub(crate) kps_config: KpsConfig,
 }
 
 impl CoiSystem {
-    pub fn config(&self) -> &Config {
-        &self.config
+    pub fn coi_config(&self) -> &CoiConfig {
+        &self.coi_config
+    }
+
+    pub fn kps_config(&self) -> &KpsConfig {
+        &self.kps_config
     }
 
     /// Updates the view time of the positive coi closest to the embedding.
@@ -64,7 +70,8 @@ impl CoiSystem {
             cois,
             market,
             embedding,
-            &self.config,
+            &self.coi_config,
+            &self.kps_config,
             key_phrases,
             candidates,
             smbert,
@@ -73,7 +80,7 @@ impl CoiSystem {
 
     /// Updates the negative coi closest to the embedding or creates a new one if it's too far away.
     pub fn log_negative_user_reaction(&self, cois: &mut Vec<NegativeCoi>, embedding: &Embedding) {
-        log_negative_user_reaction(cois, embedding, &self.config);
+        log_negative_user_reaction(cois, embedding, &self.coi_config);
     }
 
     /// Takes the top key phrases from the positive cois and market, sorted in descending relevance.
@@ -88,9 +95,9 @@ impl CoiSystem {
             cois,
             market,
             top,
-            self.config.horizon(),
-            self.config.penalty(),
-            self.config.gamma(),
+            self.kps_config.horizon(),
+            self.kps_config.penalty(),
+            self.kps_config.gamma(),
         )
     }
 
@@ -102,16 +109,18 @@ impl CoiSystem {
     /// Ranks the given documents in descending order of relevancy based on the
     /// learned user interests.
     pub fn rank(&self, documents: &mut [impl Document], user_interests: &UserInterests) {
-        rank(documents, user_interests, &self.config);
+        rank(documents, user_interests, &self.coi_config);
     }
 }
 
 /// Updates the positive coi closest to the embedding or creates a new one if it's too far away.
+#[allow(clippy::too_many_arguments)]
 fn log_positive_user_reaction(
     cois: &mut Vec<PositiveCoi>,
     market: &Market,
     embedding: &Embedding,
-    config: &Config,
+    coi_config: &CoiConfig,
+    kps_config: &KpsConfig,
     key_phrases: &mut KeyPhrases,
     candidates: &[String],
     smbert: impl Fn(&str) -> Result<Embedding, GenericError> + Sync,
@@ -119,15 +128,15 @@ fn log_positive_user_reaction(
     match find_closest_coi_mut(cois, embedding) {
         // If the given embedding's similarity to the CoI is above the threshold,
         // we adjust the position of the nearest CoI
-        Some((coi, similarity)) if similarity >= config.threshold() => {
-            coi.shift_point(embedding, config.shift_factor());
+        Some((coi, similarity)) if similarity >= coi_config.threshold() => {
+            coi.shift_point(embedding, coi_config.shift_factor());
             coi.update_key_phrases(
                 market,
                 key_phrases,
                 candidates,
                 smbert,
-                config.max_key_phrases(),
-                config.gamma(),
+                kps_config.max_key_phrases(),
+                kps_config.gamma(),
             );
             coi.log_reaction();
         }
@@ -140,8 +149,8 @@ fn log_positive_user_reaction(
                 key_phrases,
                 candidates,
                 smbert,
-                config.max_key_phrases(),
-                config.gamma(),
+                kps_config.max_key_phrases(),
+                kps_config.gamma(),
             );
             cois.push(coi);
         }
@@ -149,10 +158,14 @@ fn log_positive_user_reaction(
 }
 
 /// Updates the negative coi closest to the embedding or creates a new one if it's too far away.
-fn log_negative_user_reaction(cois: &mut Vec<NegativeCoi>, embedding: &Embedding, config: &Config) {
+fn log_negative_user_reaction(
+    cois: &mut Vec<NegativeCoi>,
+    embedding: &Embedding,
+    coi_config: &CoiConfig,
+) {
     match find_closest_coi_mut(cois, embedding) {
-        Some((coi, similarity)) if similarity >= config.threshold() => {
-            coi.shift_point(embedding, config.shift_factor());
+        Some((coi, similarity)) if similarity >= coi_config.threshold() => {
+            coi.shift_point(embedding, coi_config.shift_factor());
             coi.log_reaction();
         }
         _ => cois.push(NegativeCoi::new(Uuid::new_v4(), embedding.clone())),
@@ -167,7 +180,7 @@ fn log_document_view_time(cois: &mut [PositiveCoi], embedding: &Embedding, viewe
 }
 
 #[instrument(skip_all)]
-fn rank(documents: &mut [impl Document], user_interests: &UserInterests, config: &Config) {
+fn rank(documents: &mut [impl Document], user_interests: &UserInterests, config: &CoiConfig) {
     if documents.len() < 2 {
         return;
     }
@@ -204,15 +217,16 @@ mod tests {
         let mut cois = create_pos_cois(&[[1., 1., 1.], [10., 10., 10.], [20., 20., 20.]]);
         let mut key_phrases = KeyPhrases::default();
         let embedding = arr1(&[2., 3., 4.]).into();
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
-        let last_view_before = cois[0].stats.last_view;
-
+        let last_view = cois[0].stats.last_view;
         log_positive_user_reaction(
             &mut cois,
             &Market::new("aa", "AA"),
             &embedding,
-            &config,
+            &coi_config,
+            &kps_config,
             &mut key_phrases,
             &[],
             |_| unreachable!(),
@@ -224,7 +238,7 @@ mod tests {
         assert_eq!(cois[2].point, arr1(&[20., 20., 20.]));
 
         assert_eq!(cois[0].stats.view_count, 2);
-        assert!(cois[0].stats.last_view > last_view_before);
+        assert!(cois[0].stats.last_view > last_view);
     }
 
     #[test]
@@ -232,13 +246,15 @@ mod tests {
         let mut cois = create_pos_cois(&[[0., 1.]]);
         let mut key_phrases = KeyPhrases::default();
         let embedding = arr1(&[1., 0.]).into();
-        let config = Config::default();
+        let coi_config = CoiConfig::default();
+        let kps_config = KpsConfig::default();
 
         log_positive_user_reaction(
             &mut cois,
             &Market::new("aa", "AA"),
             &embedding,
-            &config,
+            &coi_config,
+            &kps_config,
             &mut key_phrases,
             &[],
             |_| unreachable!(),
@@ -252,11 +268,14 @@ mod tests {
     #[test]
     fn test_log_negative_user_reaction_last_view() {
         let mut cois = create_neg_cois(&[[1., 2., 3.]]);
-        let config = Config::default();
-        let before = cois[0].last_view;
-        log_negative_user_reaction(&mut cois, &arr1(&[1., 2., 4.]).into(), &config);
-        assert!(cois[0].last_view > before);
+        let embedding = arr1(&[1., 2., 4.]).into();
+        let config = CoiConfig::default();
+
+        let last_view = cois[0].last_view;
+        log_negative_user_reaction(&mut cois, &embedding, &config);
+
         assert_eq!(cois.len(), 1);
+        assert!(cois[0].last_view > last_view);
     }
 
     #[test]
@@ -286,15 +305,14 @@ mod tests {
             TestDocument::new(2, arr1(&[1., 2., 0.]), "2000-01-01 00:00:01"),
             TestDocument::new(3, arr1(&[5., 3., 0.]), "2000-01-01 00:00:00"),
         ];
-
-        let config = Config::default()
+        let user_interests = UserInterests {
+            positive: create_pos_cois(&[[1., 0., 0.], [4., 12., 2.]]),
+            negative: create_neg_cois(&[[-100., -10., 0.]]),
+        };
+        let config = CoiConfig::default()
             .with_min_positive_cois(2)
             .unwrap()
             .with_min_negative_cois(1);
-        let positive = create_pos_cois(&[[1., 0., 0.], [4., 12., 2.]]);
-        let negative = create_neg_cois(&[[-100., -10., 0.]]);
-
-        let user_interests = UserInterests { positive, negative };
 
         rank(&mut documents, &user_interests, &config);
 
@@ -311,10 +329,10 @@ mod tests {
             TestDocument::new(1, arr1(&[0., 0., 0.]), "2000-01-01 00:00:01"),
             TestDocument::new(2, arr1(&[0., 0., 0.]), "2000-01-01 00:00:02"),
         ];
+        let user_interests = UserInterests::default();
+        let config = CoiConfig::default().with_min_positive_cois(1).unwrap();
 
-        let config = Config::default().with_min_positive_cois(1).unwrap();
-
-        rank(&mut documents, &UserInterests::default(), &config);
+        rank(&mut documents, &user_interests, &config);
 
         assert_eq!(documents[0].id(), DocumentId::from_u128(0));
         assert_eq!(documents[1].id(), DocumentId::from_u128(2));
@@ -324,11 +342,11 @@ mod tests {
     #[test]
     fn test_rank_no_documents() {
         let mut documents = Vec::<TestDocument>::new();
-        rank(
-            &mut documents,
-            &UserInterests::default(),
-            &Config::default(),
-        );
+        let user_interests = UserInterests::default();
+        let config = CoiConfig::default();
+
+        rank(&mut documents, &user_interests, &config);
+
         assert!(documents.is_empty());
     }
 }

--- a/discovery_engine_core/ai/ai/src/kps/config.rs
+++ b/discovery_engine_core/ai/ai/src/kps/config.rs
@@ -1,0 +1,119 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{cmp::Ordering, time::Duration};
+
+use displaydoc::Display;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::utils::{nan_safe_f32_cmp_desc, serde_duration_as_days, SECONDS_PER_DAY_U64};
+
+/// Configurations of the kps system.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[must_use]
+pub struct Config {
+    #[serde(with = "serde_duration_as_days")]
+    horizon: Duration,
+    gamma: f32,
+    penalty: Vec<f32>,
+}
+
+// the f32 fields are never NaN by construction
+impl Eq for Config {}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            horizon: Duration::from_secs(SECONDS_PER_DAY_U64 * 30),
+            gamma: 0.9,
+            penalty: vec![1., 0.75, 0.66],
+        }
+    }
+}
+
+/// Errors of the kps system configuration.
+#[derive(Copy, Clone, Debug, Display, Error)]
+pub enum Error {
+    /// Invalid coi gamma, expected value from the unit interval
+    Gamma,
+    /// Invalid coi penalty, expected non-empty, finite and sorted values
+    Penalty,
+}
+
+impl Config {
+    /// The time since the last view after which a coi becomes irrelevant.
+    pub fn horizon(&self) -> Duration {
+        self.horizon
+    }
+
+    /// Sets the horizon.
+    pub fn with_horizon(mut self, horizon: Duration) -> Self {
+        self.horizon = horizon;
+        self
+    }
+
+    /// The weighting between coi and pairwise candidate similarities in the key phrase selection.
+    pub fn gamma(&self) -> f32 {
+        self.gamma
+    }
+
+    /// Sets the gamma.
+    ///
+    /// # Errors
+    /// Fails if the gamma is outside of the unit interval.
+    pub fn with_gamma(mut self, gamma: f32) -> Result<Self, Error> {
+        if (0. ..=1.).contains(&gamma) {
+            self.gamma = gamma;
+            Ok(self)
+        } else {
+            Err(Error::Gamma)
+        }
+    }
+
+    /// The penalty for less relevant key phrases of a coi in increasing order (ie. lowest penalty
+    /// for the most relevant key phrase first and highest penalty for the least relevant key phrase
+    /// last). The length of the penalty also serves as the maximum number of key phrases.
+    pub fn penalty(&self) -> &[f32] {
+        &self.penalty
+    }
+
+    /// Sets the penalty.
+    ///
+    /// # Errors
+    /// Fails if the penalty is empty, has non-finite values or is unsorted.
+    pub fn with_penalty(mut self, penalty: &[f32]) -> Result<Self, Error> {
+        // TODO: refactor once slice::is_sorted_by() is stabilized
+        fn is_sorted_by(slice: &[f32], compare: impl FnMut(&f32, &f32) -> Ordering) -> bool {
+            let mut vector = slice.to_vec();
+            vector.sort_unstable_by(compare);
+            vector == slice
+        }
+
+        if !penalty.is_empty()
+            && penalty.iter().copied().all(f32::is_finite)
+            && is_sorted_by(penalty, nan_safe_f32_cmp_desc)
+        {
+            self.penalty = penalty.to_vec();
+            Ok(self)
+        } else {
+            Err(Error::Penalty)
+        }
+    }
+
+    /// The maximum number of key phrases picked during the coi key phrase selection.
+    pub fn max_key_phrases(&self) -> usize {
+        self.penalty.len()
+    }
+}

--- a/discovery_engine_core/ai/ai/src/kps/config.rs
+++ b/discovery_engine_core/ai/ai/src/kps/config.rs
@@ -12,20 +12,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, time::Duration};
+use std::cmp::Ordering;
 
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::utils::{nan_safe_f32_cmp_desc, serde_duration_as_days, SECONDS_PER_DAY_U64};
+use crate::utils::nan_safe_f32_cmp_desc;
 
 /// Configurations of the kps system.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[must_use]
 pub struct Config {
-    #[serde(with = "serde_duration_as_days")]
-    horizon: Duration,
     gamma: f32,
     penalty: Vec<f32>,
 }
@@ -36,7 +34,6 @@ impl Eq for Config {}
 impl Default for Config {
     fn default() -> Self {
         Self {
-            horizon: Duration::from_secs(SECONDS_PER_DAY_U64 * 30),
             gamma: 0.9,
             penalty: vec![1., 0.75, 0.66],
         }
@@ -53,17 +50,6 @@ pub enum Error {
 }
 
 impl Config {
-    /// The time since the last view after which a coi becomes irrelevant.
-    pub fn horizon(&self) -> Duration {
-        self.horizon
-    }
-
-    /// Sets the horizon.
-    pub fn with_horizon(mut self, horizon: Duration) -> Self {
-        self.horizon = horizon;
-        self
-    }
-
     /// The weighting between coi and pairwise candidate similarities in the key phrase selection.
     pub fn gamma(&self) -> f32 {
         self.gamma

--- a/discovery_engine_core/ai/ai/src/kps/mod.rs
+++ b/discovery_engine_core/ai/ai/src/kps/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub(crate) mod config;

--- a/discovery_engine_core/ai/ai/src/lib.rs
+++ b/discovery_engine_core/ai/ai/src/lib.rs
@@ -35,11 +35,12 @@ mod coi;
 mod document;
 mod embedding;
 mod error;
+mod kps;
 mod utils;
 
 pub use crate::{
     coi::{
-        config::{Config as CoiSystemConfig, Error as CoiSystemConfigError},
+        config::{Config as CoiConfig, Error as CoiConfigError},
         key_phrase::{KeyPhrase, KeyPhrases},
         point::{CoiPoint, NegativeCoi, PositiveCoi, UserInterests},
         state::State as CoiSystemState,
@@ -54,6 +55,7 @@ pub use crate::{
         MalformedBytesEmbedding,
     },
     error::GenericError,
+    kps::config::{Config as KpsConfig, Error as KpsConfigError},
     utils::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc},
 };
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -35,8 +35,8 @@ use tracing::{debug, error, info, instrument, Level};
 use xayn_discovery_engine_ai::{
     cosine_similarity,
     nan_safe_f32_cmp,
+    CoiConfig,
     CoiSystem,
-    CoiSystemConfig,
     CoiSystemState,
     Embedding,
     GenericError,
@@ -296,9 +296,13 @@ impl Engine {
             .build()
             .map_err(GenericError::from)?;
         let coi = de_config
-            .extract::<CoiSystemConfig>()
+            .extract_inner::<CoiConfig>("coi")
             .map_err(|err| Error::Ranker(err.into()))?
-            .build();
+            .build(
+                de_config
+                    .extract_inner("kps")
+                    .map_err(|err| Error::Ranker(err.into()))?,
+            );
         let kpe = KpeConfig::from_files(
             &config.kpe_vocab,
             &config.kpe_model,
@@ -308,7 +312,7 @@ impl Engine {
         .map_err(|err| Error::Ranker(err.into()))?
         .with_token_size(
             de_config
-                .extract_inner("kpe.token_size")
+                .extract_inner("kps.token_size")
                 .map_err(|err| Error::Ranker(err.into()))?,
         )
         .map_err(|err| Error::Ranker(err.into()))?

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
@@ -123,7 +123,7 @@ impl TestEngine {
         self.engine.reset_ai().await?;
 
         let mut cois = 0;
-        while cois < self.engine.coi_system_config().min_positive_cois() {
+        while cois < self.engine.coi_config().min_positive_cois() {
             if let Some(document) = self
                 .engine
                 .get_feed_documents(&[/* TODO: db migration */], &[/* TODO: db migration */])
@@ -135,7 +135,7 @@ impl TestEngine {
             }
         }
         cois = 0;
-        while cois < self.engine.coi_system_config().min_negative_cois() {
+        while cois < self.engine.coi_config().min_negative_cois() {
             if let Some(document) = self
                 .engine
                 .get_feed_documents(&[/* TODO: db migration */], &[/* TODO: db migration */])

--- a/discovery_engine_core/web-api/src/db.rs
+++ b/discovery_engine_core/web-api/src/db.rs
@@ -14,7 +14,7 @@
 
 use serde_json::from_reader;
 use std::{collections::HashMap, fs::File, path::PathBuf, sync::Arc};
-use xayn_discovery_engine_ai::{CoiSystem, CoiSystemConfig, GenericError};
+use xayn_discovery_engine_ai::{CoiConfig, CoiSystem, GenericError, KpsConfig};
 use xayn_discovery_engine_bert::{AveragePooler, SMBert, SMBertConfig};
 use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 
@@ -45,7 +45,7 @@ impl AppState {
             documents_by_id,
             documents,
             smbert,
-            coi: CoiSystemConfig::default().build(),
+            coi: CoiConfig::default().build(KpsConfig::default()),
             user_state,
         }
     }


### PR DESCRIPTION
**References**

- [TO-3278]
- followed by #571

**Summary**

- split the `coi::config::Config as CoiSystemConfig` into `coi::config::Config as CoiConfig` & `kps::config::Config as KpsConfig` (kps for key phrase selection instead of kpe for key phrase extraction, because the latter is actually a subsystem/presystem of the former)
- use the splitted configs in the `CoiSystem` & the `Engine`
- update the [confluence config docs](https://xainag.atlassian.net/wiki/spaces/M2D/pages/2476605445/Discovery+Engine+Configurations)


[TO-3278]: https://xainag.atlassian.net/browse/TO-3278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ