### PR TITLE
[Merged by Bors] - TO-3239 clear database during engine reset

### DIFF
--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1428,13 +1428,12 @@ impl Engine {
         unimplemented!("requires 'storage' feature")
     }
 
-    /// Resets the AI state
+    /// Resets the AI state.
     pub async fn reset_ai(&mut self) -> Result<(), Error> {
         self.clear_stack_data().await;
-        self.exploration_stack =
-            Exploration::new(StackData::default(), ExplorationConfig::default())
-                .map_err(Error::InvalidStack)?;
         self.state.reset();
+        #[cfg(feature = "storage")]
+        self.storage.clear_database().await?;
 
         self.request_after = 0;
         self.update_stacks_for_all_markets(&[], &[], usize::MAX)

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -62,6 +62,8 @@ impl From<MalformedBytesEmbedding> for Error {
 pub(crate) trait Storage {
     async fn init_database(&self) -> Result<(), Error>;
 
+    async fn clear_database(&self) -> Result<bool, Error>;
+
     async fn fetch_history(&self) -> Result<Vec<HistoricDocument>, Error>;
 
     fn feed(&self) -> &(dyn FeedScope + Send + Sync);

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -341,6 +341,32 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 
+    async fn clear_database(&self) -> Result<bool, Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let deletion = sqlx::query("DELETE FROM Document;")
+            .execute(&mut tx)
+            .await?
+            .rows_affected()
+            > 0;
+        let deletion = sqlx::query("DELETE FROM Search;")
+            .execute(&mut tx)
+            .await?
+            .rows_affected()
+            > 0
+            || deletion;
+        let deletion = sqlx::query("DELETE FROM SerializedState;")
+            .execute(&mut tx)
+            .await?
+            .rows_affected()
+            > 0
+            || deletion;
+
+        tx.commit().await?;
+
+        Ok(deletion)
+    }
+
     async fn fetch_history(&self) -> Result<Vec<HistoricDocument>, Error> {
         let mut tx = self.pool.begin().await?;
 


### PR DESCRIPTION
**References**

- [TO-3239]

**Summary**

- clear all tables of the database on engine state reset, except for the `Stack` & `SourcePreference` tables
- checked that `ON DELETE CASCADE` is set where appropriate


[TO-3239]: https://xainag.atlassian.net/browse/TO-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ