### PR TITLE
[Merged by Bors] - TO-3249 fix update stacks error counting

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -963,9 +963,9 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -988,15 +988,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1048,15 +1048,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -1066,9 +1066,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -13,7 +13,7 @@ derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
 figment = { version = "0.10.6", default-features = false, features = ["json"] }
-futures = { version = "0.3.21", default-features = false, features = ["alloc"] }
+futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
 itertools = "0.10.3"
 kodama = "0.2.3"
 ndarray = "0.15.6"

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1539,8 +1539,11 @@ async fn update_stacks(
         };
     }
 
-    // return early if all needy stacks failed for all markets
-    if all_documents.is_empty() && errors.len() >= needy_stacks.len() {
+    // return early if all needy-ready stacks failed for all markets
+    if all_documents.is_empty()
+        && !errors.is_empty()
+        && errors.len() >= needy_stacks.len() - not_ready_stacks.len()
+    {
         return Err(Error::Errors(errors.into_values().flatten().collect()));
     }
     errors.clear();

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1624,7 +1624,8 @@ async fn update_stacks(
     }
 
     // only return an error if all stacks (including exploration) failed
-    if errors.len() > stacks.len() {
+    #[allow(clippy::int_plus_one)]
+    if errors.len() >= stacks.len() + 1 {
         Err(Error::Errors(errors.into_values().flatten().collect()))
     } else {
         Ok(())

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -36,7 +36,7 @@ pub(crate) mod trusted;
 #[derive(Error, Debug, Display)]
 pub enum NewItemsError {
     /// The stack is not ready to retrieve new items.
-    NotReady(Id),
+    NotReady,
     /// Retrieving new items error: {0}
     Error(#[from] GenericError),
 }

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -99,7 +99,7 @@ impl Ops for PersonalizedNews {
         market: &Market,
     ) -> Result<Vec<GenericArticle>, NewItemsError> {
         if key_phrases.is_empty() {
-            return Err(NewItemsError::NotReady(self.id()));
+            return Err(NewItemsError::NotReady);
         }
 
         let phrase = key_phrases

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -98,7 +98,7 @@ impl Ops for TrustedNews {
     ) -> Result<Vec<GenericArticle>, NewItemsError> {
         let sources = Arc::new(self.sources.read().await.clone());
         if sources.is_empty() {
-            return Err(NewItemsError::NotReady(self.id()));
+            return Err(NewItemsError::NotReady);
         }
 
         request_min_new_items(


### PR DESCRIPTION
**References**

- [TO-3249]

**Summary**

- fix error counting for needy stacks in case of multiple markets
- fix error counting for updated stacks including the exploration stack


[TO-3249]: https://xainag.atlassian.net/browse/TO-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ