### PR TITLE
[Merged by Bors] - TO-3110 [1] rework storage init

### DIFF
--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -36,7 +36,7 @@ class Configuration with _$Configuration {
     required String applicationDirectoryPath,
     required FeedMarkets feedMarkets,
     required Manifest manifest,
-    @Default(false) bool useInMemoryDb,
+    @Default(false) bool useInEphemeralDb,
     String? logFile,
   }) = _Configuration;
 

--- a/discovery_engine/lib/src/domain/models/configuration.dart
+++ b/discovery_engine/lib/src/domain/models/configuration.dart
@@ -36,7 +36,7 @@ class Configuration with _$Configuration {
     required String applicationDirectoryPath,
     required FeedMarkets feedMarkets,
     required Manifest manifest,
-    @Default(false) bool useInEphemeralDb,
+    @Default(false) bool useEphemeralDb,
     String? logFile,
   }) = _Configuration;
 

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -88,7 +88,7 @@ import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_prov
 class DiscoveryEngineFfi implements Engine {
   final Boxed<RustSharedEngine> _engine;
 
-  const DiscoveryEngineFfi._(final this._engine);
+  const DiscoveryEngineFfi._(this._engine);
 
   /// Initializes the engine.
   static Future<DiscoveryEngineFfi> initialize(

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -54,7 +54,7 @@ class InitConfigFfi with EquatableMixin {
   final String? deConfig;
   final String? logFile;
   final String dataDir;
-  final bool useInEphemeralDb;
+  final bool useEphemeralDb;
 
   @override
   List<Object?> get props => [
@@ -76,7 +76,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig,
         logFile,
         dataDir,
-        useInEphemeralDb,
+        useEphemeralDb,
       ];
 
   factory InitConfigFfi(
@@ -105,7 +105,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig: deConfig,
         logFile: configuration.logFile,
         dataDir: configuration.applicationDirectoryPath,
-        useInEphemeralDb: configuration.useInEphemeralDb,
+        useEphemeralDb: configuration.useEphemeralDb,
       );
 
   InitConfigFfi.fromParts({
@@ -125,7 +125,7 @@ class InitConfigFfi with EquatableMixin {
     required this.maxDocsPerFeedBatch,
     required this.maxDocsPerSearchBatch,
     required this.dataDir,
-    required this.useInEphemeralDb,
+    required this.useEphemeralDb,
     this.deConfig,
     this.logFile,
   });
@@ -163,7 +163,7 @@ class InitConfigFfi with EquatableMixin {
     dataDir.writeNative(
       ffi.init_config_place_of_data_dir(place),
     );
-    useInEphemeralDb
+    useEphemeralDb
         .writeNative(ffi.init_config_place_of_use_ephemeral_db(place));
   }
 
@@ -213,7 +213,7 @@ class InitConfigFfi with EquatableMixin {
       dataDir: StringFfi.readNative(
         ffi.init_config_place_of_data_dir(config),
       ),
-      useInEphemeralDb: BoolFfi.readNative(
+      useEphemeralDb: BoolFfi.readNative(
         ffi.init_config_place_of_use_ephemeral_db(config),
       ),
     );

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -54,7 +54,7 @@ class InitConfigFfi with EquatableMixin {
   final String? deConfig;
   final String? logFile;
   final String dataDir;
-  final bool useInMemoryDb;
+  final bool useInEphemeralDb;
 
   @override
   List<Object?> get props => [
@@ -76,7 +76,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig,
         logFile,
         dataDir,
-        useInMemoryDb,
+        useInEphemeralDb,
       ];
 
   factory InitConfigFfi(
@@ -105,7 +105,7 @@ class InitConfigFfi with EquatableMixin {
         deConfig: deConfig,
         logFile: configuration.logFile,
         dataDir: configuration.applicationDirectoryPath,
-        useInMemoryDb: configuration.useInMemoryDb,
+        useInEphemeralDb: configuration.useInEphemeralDb,
       );
 
   InitConfigFfi.fromParts({
@@ -125,7 +125,7 @@ class InitConfigFfi with EquatableMixin {
     required this.maxDocsPerFeedBatch,
     required this.maxDocsPerSearchBatch,
     required this.dataDir,
-    required this.useInMemoryDb,
+    required this.useInEphemeralDb,
     this.deConfig,
     this.logFile,
   });
@@ -163,7 +163,8 @@ class InitConfigFfi with EquatableMixin {
     dataDir.writeNative(
       ffi.init_config_place_of_data_dir(place),
     );
-    useInMemoryDb.writeNative(ffi.init_config_place_of_use_ephemeral_db(place));
+    useInEphemeralDb
+        .writeNative(ffi.init_config_place_of_use_ephemeral_db(place));
   }
 
   @visibleForTesting
@@ -212,7 +213,7 @@ class InitConfigFfi with EquatableMixin {
       dataDir: StringFfi.readNative(
         ffi.init_config_place_of_data_dir(config),
       ),
-      useInMemoryDb: BoolFfi.readNative(
+      useInEphemeralDb: BoolFfi.readNative(
         ffi.init_config_place_of_use_ephemeral_db(config),
       ),
     );

--- a/discovery_engine/lib/src/ffi/types/init_config.dart
+++ b/discovery_engine/lib/src/ffi/types/init_config.dart
@@ -163,7 +163,7 @@ class InitConfigFfi with EquatableMixin {
     dataDir.writeNative(
       ffi.init_config_place_of_data_dir(place),
     );
-    useInMemoryDb.writeNative(ffi.init_config_place_of_use_in_memory_db(place));
+    useInMemoryDb.writeNative(ffi.init_config_place_of_use_ephemeral_db(place));
   }
 
   @visibleForTesting
@@ -213,7 +213,7 @@ class InitConfigFfi with EquatableMixin {
         ffi.init_config_place_of_data_dir(config),
       ),
       useInMemoryDb: BoolFfi.readNative(
-        ffi.init_config_place_of_use_in_memory_db(config),
+        ffi.init_config_place_of_use_ephemeral_db(config),
       ),
     );
   }

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -40,7 +40,7 @@ void main() {
       maxDocsPerFeedBatch: 2,
       maxDocsPerSearchBatch: 20,
       dataDir: 'foo/bar',
-      useInEphemeralDb: false,
+      useEphemeralDb: false,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);
@@ -70,7 +70,7 @@ void main() {
       maxDocsPerSearchBatch: 20,
       deConfig: '{ "key": "value" }',
       dataDir: 'bar/foo',
-      useInEphemeralDb: true,
+      useEphemeralDb: true,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine/test/ffi/types/init_config_test.dart
+++ b/discovery_engine/test/ffi/types/init_config_test.dart
@@ -40,7 +40,7 @@ void main() {
       maxDocsPerFeedBatch: 2,
       maxDocsPerSearchBatch: 20,
       dataDir: 'foo/bar',
-      useInMemoryDb: false,
+      useInEphemeralDb: false,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);
@@ -70,7 +70,7 @@ void main() {
       maxDocsPerSearchBatch: 20,
       deConfig: '{ "key": "value" }',
       dataDir: 'bar/foo',
-      useInMemoryDb: true,
+      useInEphemeralDb: true,
     );
     final boxed = config.allocNative();
     final res = InitConfigFfi.readNative(boxed.ref);

--- a/discovery_engine/test/integration/feed_test.dart
+++ b/discovery_engine/test/integration/feed_test.dart
@@ -80,7 +80,7 @@ void main() {
     late DiscoveryEngine engine;
 
     setUp(() async {
-      data = await setupTestEngineData(useInMemoryDb: false);
+      data = await setupTestEngineData(useInEphemeralDb: false);
       server = await LocalNewsApiServer.start();
       engine = await initEngine(data, server.port);
     });

--- a/discovery_engine/test/integration/feed_test.dart
+++ b/discovery_engine/test/integration/feed_test.dart
@@ -80,7 +80,7 @@ void main() {
     late DiscoveryEngine engine;
 
     setUp(() async {
-      data = await setupTestEngineData(useInEphemeralDb: false);
+      data = await setupTestEngineData(useEphemeralDb: false);
       server = await LocalNewsApiServer.start();
       engine = await initEngine(data, server.port);
     });

--- a/discovery_engine/test/integration/search_test.dart
+++ b/discovery_engine/test/integration/search_test.dart
@@ -173,7 +173,7 @@ void main() {
     late DiscoveryEngine engine;
 
     setUp(() async {
-      data = await setupTestEngineData(useInMemoryDb: false);
+      data = await setupTestEngineData(useInEphemeralDb: false);
       server = await LocalNewsApiServer.start();
       engine = await initEngine(data, server.port);
     });

--- a/discovery_engine/test/integration/search_test.dart
+++ b/discovery_engine/test/integration/search_test.dart
@@ -173,7 +173,7 @@ void main() {
     late DiscoveryEngine engine;
 
     setUp(() async {
-      data = await setupTestEngineData(useInEphemeralDb: false);
+      data = await setupTestEngineData(useEphemeralDb: false);
       server = await LocalNewsApiServer.start();
       engine = await initEngine(data, server.port);
     });

--- a/discovery_engine/test/integration/source_preferences_test.dart
+++ b/discovery_engine/test/integration/source_preferences_test.dart
@@ -308,7 +308,7 @@ void main() {
 
     setUp(() async {
       server = await LocalNewsApiServer.start();
-      data = await setupTestEngineData(useInMemoryDb: false);
+      data = await setupTestEngineData(useInEphemeralDb: false);
       engine = await initEngine(data, server.port);
     });
 

--- a/discovery_engine/test/integration/source_preferences_test.dart
+++ b/discovery_engine/test/integration/source_preferences_test.dart
@@ -308,7 +308,7 @@ void main() {
 
     setUp(() async {
       server = await LocalNewsApiServer.start();
-      data = await setupTestEngineData(useInEphemeralDb: false);
+      data = await setupTestEngineData(useEphemeralDb: false);
       engine = await initEngine(data, server.port);
     });
 

--- a/discovery_engine/test/integration/time_spent_test.dart
+++ b/discovery_engine/test/integration/time_spent_test.dart
@@ -52,7 +52,7 @@ void main() {
     });
 
     test('log the view time of a document', () async {
-      data.useInEphemeralDb = false;
+      data.useEphemeralDb = false;
       var engine = await initEngine(data, server.port);
 
       // fetch some documents

--- a/discovery_engine/test/integration/time_spent_test.dart
+++ b/discovery_engine/test/integration/time_spent_test.dart
@@ -52,7 +52,7 @@ void main() {
     });
 
     test('log the view time of a document', () async {
-      data.useInMemoryDb = false;
+      data.useInEphemeralDb = false;
       var engine = await initEngine(data, server.port);
 
       // fetch some documents

--- a/discovery_engine/test/integration/user_reacted_test.dart
+++ b/discovery_engine/test/integration/user_reacted_test.dart
@@ -53,7 +53,7 @@ void main() {
     });
 
     test('change the user reaction of a document', () async {
-      data.useInEphemeralDb = false;
+      data.useEphemeralDb = false;
       var engine = await initEngine(data, server.port);
 
       // fetch some documents

--- a/discovery_engine/test/integration/user_reacted_test.dart
+++ b/discovery_engine/test/integration/user_reacted_test.dart
@@ -53,7 +53,7 @@ void main() {
     });
 
     test('change the user reaction of a document', () async {
-      data.useInMemoryDb = false;
+      data.useInEphemeralDb = false;
       var engine = await initEngine(data, server.port);
 
       // fetch some documents

--- a/discovery_engine/test/integration/utils/helpers.dart
+++ b/discovery_engine/test/integration/utils/helpers.dart
@@ -28,15 +28,17 @@ import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
 class TestEngineData {
   final Manifest manifest;
   final String applicationDirectoryPath;
-  bool useInMemoryDb;
+  bool useInEphemeralDb;
   TestEngineData(
     this.manifest,
     this.applicationDirectoryPath, {
-    this.useInMemoryDb = true,
+    this.useInEphemeralDb = true,
   });
 }
 
-Future<TestEngineData> setupTestEngineData({bool useInMemoryDb = true}) async {
+Future<TestEngineData> setupTestEngineData({
+  bool useInEphemeralDb = true,
+}) async {
   final applicationDirectoryPath =
       (await Directory.systemTemp.createTemp()).path;
   await Link(
@@ -61,7 +63,7 @@ Future<TestEngineData> setupTestEngineData({bool useInMemoryDb = true}) async {
   return TestEngineData(
     mockedManifest,
     applicationDirectoryPath,
-    useInMemoryDb: useInMemoryDb,
+    useInEphemeralDb: useInEphemeralDb,
   );
 }
 
@@ -77,7 +79,7 @@ Configuration createConfig(TestEngineData data, int serverPort) {
     manifest: data.manifest,
     headlinesProviderPath: '/newscatcher/v1/latest-headlines',
     newsProviderPath: '/newscatcher/v1/search-news',
-    useInMemoryDb: data.useInMemoryDb,
+    useInEphemeralDb: data.useInEphemeralDb,
   );
 }
 

--- a/discovery_engine/test/integration/utils/helpers.dart
+++ b/discovery_engine/test/integration/utils/helpers.dart
@@ -28,16 +28,16 @@ import 'package:xayn_discovery_engine/src/domain/assets/assets.dart'
 class TestEngineData {
   final Manifest manifest;
   final String applicationDirectoryPath;
-  bool useInEphemeralDb;
+  bool useEphemeralDb;
   TestEngineData(
     this.manifest,
     this.applicationDirectoryPath, {
-    this.useInEphemeralDb = true,
+    this.useEphemeralDb = true,
   });
 }
 
 Future<TestEngineData> setupTestEngineData({
-  bool useInEphemeralDb = true,
+  bool useEphemeralDb = true,
 }) async {
   final applicationDirectoryPath =
       (await Directory.systemTemp.createTemp()).path;
@@ -63,7 +63,7 @@ Future<TestEngineData> setupTestEngineData({
   return TestEngineData(
     mockedManifest,
     applicationDirectoryPath,
-    useInEphemeralDb: useInEphemeralDb,
+    useEphemeralDb: useEphemeralDb,
   );
 }
 
@@ -79,7 +79,7 @@ Configuration createConfig(TestEngineData data, int serverPort) {
     manifest: data.manifest,
     headlinesProviderPath: '/newscatcher/v1/latest-headlines',
     newsProviderPath: '/newscatcher/v1/search-news',
-    useInEphemeralDb: data.useInEphemeralDb,
+    useEphemeralDb: data.useEphemeralDb,
   );
 }
 

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -4010,6 +4010,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sqlx",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/discovery_engine_core/bindings/src/types/init_config.rs
+++ b/discovery_engine_core/bindings/src/types/init_config.rs
@@ -224,15 +224,15 @@ pub unsafe extern "C" fn init_config_place_of_data_dir(place: *mut InitConfig) -
     unsafe { addr_of_mut!((*place).data_dir) }
 }
 
-/// Returns a pointer to the `use_in_memory_db` field of a configuration.
+/// Returns a pointer to the `use_ephemeral_db` field of a configuration.
 ///
 /// # Safety
 ///
 /// The pointer must point to a valid [`InitConfig`] memory object,
 /// it might be uninitialized.
 #[no_mangle]
-pub unsafe extern "C" fn init_config_place_of_use_in_memory_db(place: *mut InitConfig) -> *mut u8 {
-    unsafe { addr_of_mut!((*place).use_in_memory_db).cast() }
+pub unsafe extern "C" fn init_config_place_of_use_ephemeral_db(place: *mut InitConfig) -> *mut u8 {
+    unsafe { addr_of_mut!((*place).use_ephemeral_db).cast() }
 }
 
 /// Returns a pointer to the `log_file` field of a configuration.

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -44,6 +44,7 @@ maplit = "1.0.2"
 mockall = "0.11.2"
 rand_chacha = "0.3.1"
 serde_json = "1.0.85"
+tempfile = "3.3.0"
 tokio = { version = "1.20.1", features = ["macros", "rt", "sync"] }
 wiremock = "0.5.14"
 xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -104,7 +104,7 @@ pub struct InitConfig {
     /// Directory in which user data should be stored.
     pub data_dir: String,
     /// Use a in-memory db instead of a db in the `data_dir`
-    pub use_in_memory_db: bool,
+    pub use_ephemeral_db: bool,
 }
 
 impl InitConfig {

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -103,7 +103,7 @@ pub struct InitConfig {
     pub log_file: Option<String>,
     /// Directory in which user data should be stored.
     pub data_dir: String,
-    /// Use a in-memory db instead of a db in the `data_dir`
+    /// Use a ephemeral db instead of a db in the `data_dir`
     pub use_ephemeral_db: bool,
 }
 

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -103,7 +103,7 @@ pub struct InitConfig {
     pub log_file: Option<String>,
     /// Directory in which user data should be stored.
     pub data_dir: String,
-    /// Use a ephemeral db instead of a db in the `data_dir`
+    /// Use an ephemeral db instead of a db in the `data_dir`
     pub use_ephemeral_db: bool,
 }
 

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -258,7 +258,11 @@ impl Engine {
     }
 
     /// Creates a discovery [`Engine`] from a configuration and optional state.
-    #[allow(clippy::too_many_lines, clippy::similar_names, clippy::missing_panics_doc)]
+    #[allow(
+        clippy::too_many_lines,
+        clippy::similar_names,
+        clippy::missing_panics_doc
+    )]
     pub async fn from_config(
         config: InitConfig,
         // TODO: change this to a boolean flag after DB migration

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -258,7 +258,7 @@ impl Engine {
     }
 
     /// Creates a discovery [`Engine`] from a configuration and optional state.
-    #[allow(clippy::too_many_lines, clippy::similar_names)]
+    #[allow(clippy::too_many_lines, clippy::similar_names, clippy::missing_panics_doc)]
     pub async fn from_config(
         config: InitConfig,
         // TODO: change this to a boolean flag after DB migration
@@ -332,7 +332,7 @@ impl Engine {
         // initialize the states
         #[cfg(feature = "storage")]
         let storage = {
-            let db_file_path = (!config.use_in_memory_db).then(|| {
+            let db_file_path = (!config.use_ephemeral_db).then(|| {
                 PathBuf::from(&config.data_dir).join("db.sqlite")
                         .into_os_string()
                         .into_string()
@@ -1795,7 +1795,7 @@ pub(crate) mod tests {
                 de_config: None,
                 log_file: None,
                 data_dir: "tmp_test_data_dir".into(),
-                use_in_memory_db: true,
+                use_ephemeral_db: true,
             };
 
             // Now we can initialize the engine with no previous history or state. This should

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -38,6 +38,8 @@ pub mod stack;
 mod state;
 #[cfg(feature = "storage")]
 pub mod storage;
+//FIXME they are not storage specific but currently only used by storage
+#[cfg(feature = "storage")]
 mod utils;
 
 pub use crate::{

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod stack;
 mod state;
 #[cfg(feature = "storage")]
 pub mod storage;
+mod utils;
 
 pub use crate::{
     config::{CoreConfig, EndpointConfig, ExplorationConfig, FeedConfig, InitConfig, SearchConfig},

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -70,7 +70,9 @@ pub enum InitDbHint {
 
 #[async_trait]
 pub(crate) trait Storage {
-    async fn init_database(&mut self) -> Result<InitDbHint, Error>;
+    async fn init_storage_system(file_path: Option<String>) -> Result<(Self, InitDbHint), Error>
+    where
+        Self: Sized;
 
     async fn clear_database(&self) -> Result<bool, Error>;
 

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -70,7 +70,9 @@ pub enum InitDbHint {
 
 #[async_trait]
 pub(crate) trait Storage {
-    async fn init_storage_system(file_path: Option<String>) -> Result<(Self, InitDbHint), Error>
+    async fn init_storage_system(
+        file_path: Option<String>,
+    ) -> Result<(BoxedStorage, InitDbHint), Error>
     where
         Self: Sized;
 

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -70,8 +70,14 @@ pub enum InitDbHint {
 
 #[async_trait]
 pub(crate) trait Storage {
+    /// Initializes the storage system.
+    ///
+    /// The `db_identifier` is storage impl. specific, e.g. in case of sqlite
+    /// this would be the file path to the database file.
+    ///
+    /// Passing in `None` means a new temporary db should be created.
     async fn init_storage_system(
-        file_path: Option<String>,
+        db_identifier: Option<String>,
     ) -> Result<(BoxedStorage, InitDbHint), Error>
     where
         Self: Sized;

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -58,9 +58,19 @@ impl From<MalformedBytesEmbedding> for Error {
     }
 }
 
+/// Hint about what was done during db init.
+pub enum InitDbHint {
+    /// Hint to use if nothing special happened during init.
+    NormalInit,
+    /// A new db was created, there was no db beforehand.
+    NewDbCreated,
+    /// There was a db but we could not open it so we deleted it and created a new one.
+    DbOverwrittenDueToErrors(Error),
+}
+
 #[async_trait]
 pub(crate) trait Storage {
-    async fn init_database(&self) -> Result<(), Error>;
+    async fn init_database(&mut self) -> Result<InitDbHint, Error>;
 
     async fn clear_database(&self) -> Result<bool, Error>;
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -48,6 +48,7 @@ use crate::{
             TimeSpentDocumentView,
         },
         utils::SqlxPushTupleExt,
+        BoxedStorage,
         Error,
         FeedScope,
         FeedbackScope,
@@ -323,10 +324,15 @@ impl SqliteStorage {
 
 #[async_trait]
 impl Storage for SqliteStorage {
-    async fn init_storage_system(file_path: Option<String>) -> Result<(Self, InitDbHint), Error>
+    async fn init_storage_system(
+        file_path: Option<String>,
+    ) -> Result<(BoxedStorage, InitDbHint), Error>
     where
         Self: Sized,
     {
+        self::setup::init_storage_system(file_path)
+            .await
+            .map(|(storage, hint)| (Box::new(storage) as _, hint))
     }
 
     async fn clear_database(&self) -> Result<bool, Error> {

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -319,10 +319,7 @@ impl SqliteStorage {
 impl Storage for SqliteStorage {
     async fn init_storage_system(
         file_path: Option<String>,
-    ) -> Result<(BoxedStorage, InitDbHint), Error>
-    where
-        Self: Sized,
-    {
+    ) -> Result<(BoxedStorage, InitDbHint), Error> {
         self::setup::init_storage_system(file_path)
             .await
             .map(|(storage, hint)| (Box::new(storage) as _, hint))
@@ -1059,13 +1056,15 @@ mod tests {
         }};
     }
 
-    async fn create_memory_storage() -> BoxedStorage {
-        SqliteStorage::init_storage_system(None).await.unwrap().0
+    impl SqliteStorage {
+        async fn test_storage_system() -> BoxedStorage {
+            SqliteStorage::init_storage_system(None).await.unwrap().0
+        }
     }
 
     #[tokio::test]
     async fn test_fetch_history() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let history = storage.fetch_history().await.unwrap();
         assert!(history.is_empty());
 
@@ -1089,7 +1088,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_feed_methods() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let feed = storage.feed().fetch().await.unwrap();
         assert!(feed.is_empty());
 
@@ -1123,7 +1122,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_search_methods() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let search = storage.search().fetch().await;
         assert!(search.is_err());
         assert!(!storage.search().clear().await.unwrap());
@@ -1177,7 +1176,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_search() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
 
         let new_search = Search {
             search_by: SearchBy::Query,
@@ -1230,7 +1229,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rank_conversion() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let mut docs = create_documents(1);
         docs[0].newscatcher_data.domain_rank = u64::MAX;
         storage
@@ -1249,7 +1248,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::similar_names)]
     async fn test_storing_user_reaction() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let docs = create_documents(10);
         let stack_ids = stack_ids_for(&docs, stack::PersonalizedNews::id());
         storage
@@ -1305,7 +1304,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_storing_user_reaction_returns_the_right_document() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let docs = create_documents(1);
         let stack_ids = stack_ids_for(&docs, stack::PersonalizedNews::id());
         storage
@@ -1325,7 +1324,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_state() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
 
         assert!(!storage.state().clear().await.unwrap());
         assert!(storage.state().fetch().await.unwrap().is_none());
@@ -1343,7 +1342,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_source_preference() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
 
         // if no sources are set, return an empty set
         let trusted_db = storage.source_preference().fetch_trusted().await.unwrap();
@@ -1411,7 +1410,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_store_time_spent() {
-        let storage = create_memory_storage().await;
+        let storage = SqliteStorage::test_storage_system().await;
         let docs = create_documents(3);
         let stack_ids = stack_ids_for(&docs, stack::PersonalizedNews::id());
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -14,7 +14,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
     time::Duration,
 };
 
@@ -63,10 +62,6 @@ const BIND_LIMIT: usize = 32766;
 
 #[derive(Clone)]
 pub(crate) struct SqliteStorage {
-    /// Path to the database file.
-    ///
-    /// `None` in case of an ephemeral (i.e. in memory) db.
-    file_path: Option<PathBuf>,
     pool: Pool<Sqlite>,
 }
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -64,7 +64,7 @@ const BIND_LIMIT: usize = 32766;
 pub(crate) struct SqliteStorage {
     /// Path to the database file.
     ///
-    /// `None` in case of a in-memory db.
+    /// `None` in case of a ephemeral (i.e. in memory) db.
     ///
     /// We didn't use PathBuf as it must be valid string.
     //TODO[pmk] use file_path for app triggered db reset

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -1177,7 +1177,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_search() {
-        let mut storage = create_memory_storage().await;
+        let storage = create_memory_storage().await;
 
         let new_search = Search {
             search_by: SearchBy::Query,
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_document() {
-        let mut storage = super::setup::init_storage_system(None).await.unwrap().0;
+        let storage = super::setup::init_storage_system(None).await.unwrap().0;
 
         let id = document::Id::new();
         assert!(matches!(

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -64,7 +64,7 @@ const BIND_LIMIT: usize = 32766;
 pub(crate) struct SqliteStorage {
     /// Path to the database file.
     ///
-    /// `None` in case of a ephemeral (i.e. in memory) db.
+    /// `None` in case of an ephemeral (i.e. in memory) db.
     ///
     /// We didn't use PathBuf as it must be valid string.
     //TODO[pmk] use file_path for app triggered db reset

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -14,6 +14,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    path::PathBuf,
     time::Duration,
 };
 
@@ -65,11 +66,7 @@ pub(crate) struct SqliteStorage {
     /// Path to the database file.
     ///
     /// `None` in case of an ephemeral (i.e. in memory) db.
-    ///
-    /// We didn't use PathBuf as it must be valid string.
-    //TODO[pmk] use file_path for app triggered db reset
-    #[allow(unused)]
-    file_path: Option<String>,
+    file_path: Option<PathBuf>,
     pool: Pool<Sqlite>,
 }
 
@@ -320,7 +317,7 @@ impl Storage for SqliteStorage {
     async fn init_storage_system(
         file_path: Option<String>,
     ) -> Result<(BoxedStorage, InitDbHint), Error> {
-        self::setup::init_storage_system(file_path)
+        self::setup::init_storage_system(file_path.map(Into::into))
             .await
             .map(|(storage, hint)| (Box::new(storage) as _, hint))
     }

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -112,7 +112,7 @@ async fn init_storage_system_once(file_path: Option<PathBuf>) -> Result<SqliteSt
     let pool = create_connection_pool(file_path.as_deref()).await?;
     update_schema(&pool).await?;
     update_static_data(&pool).await?;
-    Ok(SqliteStorage { file_path, pool })
+    Ok(SqliteStorage { pool })
 }
 
 pub(super) async fn create_connection_pool(

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -127,7 +127,7 @@ async fn update_schema(pool: &Pool<Sqlite>) -> Result<(), Error> {
 }
 
 //FIXME at some point we probably should derive this from the configuration
-//      and also decide what to do we documents in the history which are
+//      and also decide what to do with documents in the history which are
 //      associated with a stack which is not included in the current config
 const EXISTING_STACKS: [stack::Id; 4] = [
     stack::ops::breaking::BreakingNews::id(),

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -88,7 +88,7 @@ async fn init_storage_system_once(file_path: Option<String>) -> Result<SqliteSto
     let pool = create_connection_pool(file_path.as_deref()).await?;
     update_schema(&pool).await?;
     update_static_data(&pool).await?;
-    Ok(SqliteStorage { pool, file_path })
+    Ok(SqliteStorage { file_path, pool })
 }
 
 pub(super) async fn create_connection_pool(file_path: Option<&str>) -> Result<Pool<Sqlite>, Error> {

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 use std::{path::Path, str::FromStr};
 
 use crate::{

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -1,0 +1,113 @@
+use std::str::FromStr;
+
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    Pool,
+    QueryBuilder,
+    Sqlite,
+    SqlitePool,
+    Transaction,
+};
+use tokio::fs;
+
+use crate::{
+    stack,
+    storage::{utils::SqlxPushTupleExt, Error, InitDbHint},
+};
+
+use super::SqliteStorage;
+
+async fn create_connection_pool(file_path: Option<&str>) -> Result<Pool<Sqlite>, Error> {
+    let opt = if let Some(file_path) = &file_path {
+        SqliteConnectOptions::from_str(&format!("sqlite:{}", file_path))
+    } else {
+        SqliteConnectOptions::from_str("sqlite::memory:")
+    }?
+    .create_if_missing(true);
+
+    SqlitePoolOptions::new()
+        .connect_with(opt)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn init_storage_system(
+    file_path: Option<String>,
+) -> Result<(SqliteStorage, InitDbHint), Error> {
+    let first_error = match init_storage_system_once(file_path.clone()).await {
+        (true, Ok(storage)) => return Ok((storage, InitDbHint::NewDbCreated)),
+        (false, Ok(storage)) => return Ok((storage, InitDbHint::NormalInit)),
+        (true, Err(err)) => return Err(err),
+        (false, Err(err)) => err,
+    };
+
+    if let Some(file_path) = &file_path {
+        fs::remove_file(file_path).await;
+        fs::remove_file(&format!("{}-wal", file_path)).await;
+        fs::remove_file(&format!("{}-shm", file_path)).await;
+    }
+
+    init_storage_system_once(file_path)
+        .await
+        .map(|storage| (storage, InitDbHint::DbOverwrittenDueToErrors(first_error)))
+}
+
+pub async fn init_storage_system_once(
+    file_path: Option<String>,
+) -> Result<(bool, SqliteStorage), Error> {
+    let pool = create_connection_pool(file_path.as_deref()).await?;
+    let fresh = query_if_db_is_empty(&pool).await?;
+    //todo[pmk]
+}
+
+pub(super) async fn init_database(pool: &Pool<Sqlite>) -> Result<(), Error> {
+    sqlx::migrate!("src/storage/migrations")
+        .run(pool)
+        .await
+        .map_err(|err| Error::Database(err.into()))?;
+
+    let mut tx = pool.begin().await?;
+    setup_stacks_sync(&mut tx).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Returns true if there are no tables in the db.
+async fn query_if_db_is_empty(pool: &Pool<Sqlite>) -> Result<bool, Error> {
+    let (count,) = sqlx::query_as::<_, (u32,)>("SELECT count(*) FROM sqlite_schema")
+        .fetch_one(pool)
+        .await?;
+
+    Ok(count == 0)
+}
+
+async fn setup_stacks_sync(tx: &mut Transaction<'_, Sqlite>) -> Result<(), Error> {
+    let expected_ids = &[
+        stack::ops::breaking::BreakingNews::id(),
+        stack::ops::personalized::PersonalizedNews::id(),
+        stack::ops::trusted::TrustedNews::id(),
+        stack::exploration::Stack::id(),
+    ];
+
+    let mut query_builder = QueryBuilder::new(String::new());
+    query_builder
+        .push("INSERT INTO Stack (stackId) ")
+        .push_values(expected_ids, |mut stm, id| {
+            stm.push_bind(id);
+        })
+        .push(" ON CONFLICT DO NOTHING;")
+        .build()
+        .persistent(false)
+        .execute(&mut *tx)
+        .await?;
+
+    query_builder
+        .reset()
+        .push("DELETE FROM Stack WHERE stackId NOT IN ")
+        .push_tuple(expected_ids)
+        .build()
+        .persistent(false)
+        .execute(tx)
+        .await?;
+    Ok(())
+}

--- a/discovery_engine_core/core/src/storage/sqlite/utils.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/utils.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fk_violation_is_invalid_document() {
-        let storage = SqliteStorage::connect("sqlite::memory:").await.unwrap();
+        let storage = SqliteStorage::connect(None).await.unwrap();
 
         sqlx::query("CREATE TABLE Foo(x INTEGER PRIMARY KEY);")
             .execute(&storage.pool)

--- a/discovery_engine_core/core/src/utils.rs
+++ b/discovery_engine_core/core/src/utils.rs
@@ -14,15 +14,14 @@
 
 //! Collection of utility functions.
 
-use std::{borrow::Cow, error::Error, fmt::Display, io, path::Path};
+use std::{borrow::Cow, error::Error, fmt::Display, path::Path};
 
 use tracing::error;
 
 /// Like [`tokio::fs::remove_file()`] but doesn't fail if the file doesn't exist.
-#[cfg(feature = "storage")]
-pub(crate) async fn remove_file_if_exists(path: impl AsRef<Path>) -> Result<(), io::Error> {
+pub(crate) async fn remove_file_if_exists(path: impl AsRef<Path>) -> Result<(), std::io::Error> {
     match tokio::fs::remove_file(path).await {
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         other => other,
     }
 }
@@ -56,7 +55,7 @@ impl<T, E> MiscErrorExt<T, E> for Result<T, E> {
             Ok(val) => Some(val),
             Err(err) => {
                 if slot.is_none() {
-                    *slot = Some(err)
+                    *slot = Some(err);
                 }
                 None
             }

--- a/discovery_engine_core/core/src/utils.rs
+++ b/discovery_engine_core/core/src/utils.rs
@@ -37,7 +37,7 @@ pub(crate) trait MiscErrorExt<T, E> {
     /// Like [`std::result::Result::ok()`] but if `slot` is `None` the error is moved into `slot`.
     fn extract_first_error(self, slot: &mut Option<E>) -> Option<T>;
 
-    /// Like [`std::result::Result::ok()`] the error is moved into the passed in vec (using `push`).
+    /// Like [`std::result::Result::ok()`] and the error is moved into the passed in vec (using `push`).
     fn extract_error(self, push_to: &mut Vec<E>) -> Option<T>;
 }
 

--- a/discovery_engine_core/core/src/utils.rs
+++ b/discovery_engine_core/core/src/utils.rs
@@ -20,7 +20,7 @@ use tracing::error;
 
 /// Like [`tokio::fs::remove_file()`] but doesn't fail if the file doesn't exist.
 #[cfg(feature = "storage")]
-pub(crate) async fn remove_file_if_exists(path: &Path) -> Result<(), io::Error> {
+pub(crate) async fn remove_file_if_exists(path: impl AsRef<Path>) -> Result<(), io::Error> {
     match tokio::fs::remove_file(path).await {
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         other => other,
@@ -82,7 +82,7 @@ pub(crate) struct CompoundError<E: Error + 'static> {
 }
 
 impl<E: Error + 'static> CompoundError<E> {
-    pub(crate) fn new(msg: impl Into<Cow<'static, str>>, errors: Vec<E>) {
+    pub(crate) fn new(msg: impl Into<Cow<'static, str>>, errors: Vec<E>) -> Self {
         Self {
             msg: msg.into(),
             errors,

--- a/discovery_engine_core/core/src/utils.rs
+++ b/discovery_engine_core/core/src/utils.rs
@@ -1,0 +1,75 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Collection of utility functions.
+
+use std::{fmt::Display, io, path::Path};
+
+use tracing::error;
+
+/// Like [`tokio::fs::remove_file()`] but doesn't fail if the file doesn't exist.
+#[cfg(feature = "storage")]
+pub(crate) async fn remove_file_if_exists(path: &Path) -> Result<(), io::Error> {
+    match tokio::fs::remove_file(path).await {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        other => other,
+    }
+}
+
+pub(crate) trait MiscErrorExt<T, E> {
+    // Logs the contained error if there is one.
+    fn log_error(self) -> Self
+    where
+        E: Display;
+
+    /// Like [`std::result::Result::ok()`] but if `slot` is `None` the error is moved into `slot`.
+    fn extract_first_error(self, slot: &mut Option<E>) -> Option<T>;
+
+    /// Like [`std::result::Result::ok()`] the error is moved into the passed in vec (using `push`).
+    fn extract_error(self, push_to: &mut Vec<E>) -> Option<T>;
+}
+
+impl<T, E> MiscErrorExt<T, E> for Result<T, E> {
+    fn log_error(self) -> Self
+    where
+        E: Display,
+    {
+        if let Err(err) = &self {
+            error!(error = %err);
+        }
+        self
+    }
+
+    fn extract_first_error(self, slot: &mut Option<E>) -> Option<T> {
+        match self {
+            Ok(val) => Some(val),
+            Err(err) => {
+                if slot.is_none() {
+                    *slot = Some(err)
+                }
+                None
+            }
+        }
+    }
+
+    fn extract_error(self, push_to: &mut Vec<E>) -> Option<T> {
+        match self {
+            Ok(val) => Some(val),
+            Err(err) => {
+                push_to.push(err);
+                None
+            }
+        }
+    }
+}

--- a/discovery_engine_core/core/src/utils.rs
+++ b/discovery_engine_core/core/src/utils.rs
@@ -19,7 +19,9 @@ use std::{borrow::Cow, error::Error, fmt::Display, path::Path};
 use tracing::error;
 
 /// Like [`tokio::fs::remove_file()`] but doesn't fail if the file doesn't exist.
-pub(crate) async fn remove_file_if_exists(path: impl AsRef<Path>) -> Result<(), std::io::Error> {
+pub(crate) async fn remove_file_if_exists(
+    path: impl AsRef<Path> + Send,
+) -> Result<(), std::io::Error> {
     match tokio::fs::remove_file(path).await {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         other => other,

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
@@ -56,7 +56,7 @@ impl TestEngine {
             de_config: None,
             log_file: None,
             data_dir: String::new(),
-            use_in_memory_db: true,
+            use_ephemeral_db: true,
         };
         let engine = Engine::from_config(config, None, &[], &[]).await?;
 


### PR DESCRIPTION
- move sqlite initialization code into `sqlite/setup.rs`

- Collapsed create storage and init db into one
(we can't use the storage without having called
init db).

- We now path an optional file path instead of an
  uri to the storage system, none is used to indicate
  a in memory (or otherwise temporary) db should
  be used.

- If we can't open the database file or can't apply
  migrations on an existing database file we overwrite
  it with a new db.

- When creating the storage instance we return an
  indicator weather or not it's on a new db, a
  existing db or an overwritten db.
  
- Rename `use_in_memory_db` to `use_ephemeral_db` as 
  ephemeral are not necessary in memory for all kinds of potential
  storage implementations.
  
**Based On:**

- #573 