### PR TITLE
[Merged by Bors] - TO-3086 better type for date_published

### DIFF
--- a/discovery_engine/lib/src/ffi/types/date_time.dart
+++ b/discovery_engine/lib/src/ffi/types/date_time.dart
@@ -15,26 +15,16 @@
 import 'dart:ffi' show Pointer;
 
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
-    show RustNaiveDateTime;
+    show RustDateTimeUtc;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 
-extension NaiveDateTimeFfi on DateTime {
-  void writeNative(Pointer<RustNaiveDateTime> place) {
-    // micro seconds since since since midnight on
-    // January 1, 1970 ignoring time zone.
-    ffi.init_naive_date_time_at(
-      place,
-      microsecondsSinceEpoch,
-    );
-  }
+extension DateTimeUtcFfi on DateTime {
+  void writeNative(Pointer<RustDateTimeUtc> place) =>
+      ffi.init_date_time_utc_at(place, microsecondsSinceEpoch);
 
-  static DateTime readNative(Pointer<RustNaiveDateTime> naiveDateTime) {
-    final microsecondsSinceEpochLocal =
-        ffi.get_naive_date_time_micros_since_epoch(naiveDateTime);
-    final dateTime = DateTime.fromMicrosecondsSinceEpoch(
-      microsecondsSinceEpochLocal,
-      isUtc: true,
-    );
-    return dateTime;
-  }
+  static DateTime readNative(Pointer<RustDateTimeUtc> dateTimeUtc) =>
+      DateTime.fromMicrosecondsSinceEpoch(
+        ffi.get_date_time_utc_micros_since_epoch(dateTimeUtc),
+        isUtc: true,
+      );
 }

--- a/discovery_engine/lib/src/ffi/types/document/news_resource.dart
+++ b/discovery_engine/lib/src/ffi/types/document/news_resource.dart
@@ -22,7 +22,7 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustNewsResource;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/date_time.dart'
-    show NaiveDateTimeFfi;
+    show DateTimeUtcFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/primitives.dart';
 import 'package:xayn_discovery_engine/src/ffi/types/string.dart' show StringFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/uri.dart' show UriFfi;
@@ -64,7 +64,7 @@ extension NewsResourceFfi on NewsResource {
       image: UriFfi.readNativeOption(
         ffi.news_resource_place_of_image(resource),
       ),
-      datePublished: NaiveDateTimeFfi.readNative(
+      datePublished: DateTimeUtcFfi.readNative(
         ffi.news_resource_place_of_date_published(resource),
       ),
       rank: ffi.news_resource_place_of_rank(resource).value,

--- a/discovery_engine/test/ffi/types/date_time_test.dart
+++ b/discovery_engine/test/ffi/types/date_time_test.dart
@@ -15,13 +15,13 @@
 import 'package:test/test.dart';
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/date_time.dart'
-    show NaiveDateTimeFfi;
+    show DateTimeUtcFfi;
 
 void readWriteTest(DateTime dateTime) {
-  final place = ffi.alloc_uninitialized_naive_date_time();
+  final place = ffi.alloc_uninitialized_date_time_utc();
   dateTime.writeNative(place);
-  final res = NaiveDateTimeFfi.readNative(place);
-  ffi.drop_naive_date_time(place);
+  final res = DateTimeUtcFfi.readNative(place);
+  ffi.drop_date_time_utc(place);
   expect(res, equals(dateTime));
 }
 

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -366,16 +366,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -480,16 +478,6 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "winapi",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1363,12 +1351,12 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.42"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9512e544c25736b82aebbd2bf739a47c8a1c935dfcc3a6adcde10e35cd3cd468"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
- "core-foundation",
+ "core-foundation-sys",
  "js-sys",
  "wasm-bindgen",
  "winapi",

--- a/discovery_engine_core/ai/ai/Cargo.toml
+++ b/discovery_engine_core/ai/ai/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-chrono = { version = "0.4.21", default-features = false }
+chrono = { version = "0.4.22", default-features = false }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"

--- a/discovery_engine_core/ai/ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/ai/src/coi/system.rs
@@ -204,6 +204,7 @@ fn rank(documents: &mut [impl Document], user_interests: &UserInterests, config:
 
 #[cfg(test)]
 mod tests {
+    use chrono::{TimeZone, Utc};
     use ndarray::arr1;
 
     use super::*;
@@ -300,10 +301,10 @@ mod tests {
     #[test]
     fn test_rank() {
         let mut documents = vec![
-            TestDocument::new(0, arr1(&[3., 7., 0.]), "2000-01-01 00:00:03"),
-            TestDocument::new(1, arr1(&[1., 0., 0.]), "2000-01-01 00:00:02"),
-            TestDocument::new(2, arr1(&[1., 2., 0.]), "2000-01-01 00:00:01"),
-            TestDocument::new(3, arr1(&[5., 3., 0.]), "2000-01-01 00:00:00"),
+            TestDocument::new(0, arr1(&[3., 7., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 3)),
+            TestDocument::new(1, arr1(&[1., 0., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 2)),
+            TestDocument::new(2, arr1(&[1., 2., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 1)),
+            TestDocument::new(3, arr1(&[5., 3., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 0)),
         ];
         let user_interests = UserInterests {
             positive: create_pos_cois(&[[1., 0., 0.], [4., 12., 2.]]),
@@ -325,9 +326,9 @@ mod tests {
     #[test]
     fn test_rank_no_user_interests() {
         let mut documents = vec![
-            TestDocument::new(0, arr1(&[0., 0., 0.]), "2000-01-01 00:00:03"),
-            TestDocument::new(1, arr1(&[0., 0., 0.]), "2000-01-01 00:00:01"),
-            TestDocument::new(2, arr1(&[0., 0., 0.]), "2000-01-01 00:00:02"),
+            TestDocument::new(0, arr1(&[0., 0., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 3)),
+            TestDocument::new(1, arr1(&[0., 0., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 1)),
+            TestDocument::new(2, arr1(&[0., 0., 0.]), Utc.ymd(2000, 1, 1).and_hms(0, 0, 2)),
         ];
         let user_interests = UserInterests::default();
         let config = CoiConfig::default().with_min_positive_cois(1).unwrap();

--- a/discovery_engine_core/ai/ai/src/document.rs
+++ b/discovery_engine_core/ai/ai/src/document.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use derive_more::Display;
 use uuid::Uuid;
 
@@ -37,7 +37,7 @@ pub trait Document {
     fn smbert_embedding(&self) -> &Embedding;
 
     /// Gets the publishing date.
-    fn date_published(&self) -> NaiveDateTime;
+    fn date_published(&self) -> DateTime<Utc>;
 }
 
 #[cfg(test)]
@@ -54,16 +54,19 @@ pub(crate) mod tests {
     pub(crate) struct TestDocument {
         pub(crate) id: DocumentId,
         pub(crate) smbert_embedding: Embedding,
-        pub(crate) date_published: NaiveDateTime,
+        pub(crate) date_published: DateTime<Utc>,
     }
 
     impl TestDocument {
-        pub(crate) fn new(id: u128, embedding: impl Into<Embedding>, date_published: &str) -> Self {
+        pub(crate) fn new(
+            id: u128,
+            embedding: impl Into<Embedding>,
+            date_published: DateTime<Utc>,
+        ) -> Self {
             Self {
                 id: DocumentId::from_u128(id),
                 smbert_embedding: embedding.into(),
-                date_published: NaiveDateTime::parse_from_str(date_published, "%Y-%m-%d %H:%M:%S")
-                    .unwrap(),
+                date_published,
             }
         }
     }
@@ -77,7 +80,7 @@ pub(crate) mod tests {
             &self.smbert_embedding
         }
 
-        fn date_published(&self) -> NaiveDateTime {
+        fn date_published(&self) -> DateTime<Utc> {
             self.date_published
         }
     }

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 async-bindgen = { path = "../async-bindgen/async-bindgen" }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.21", default-features = false }
+chrono = { version = "0.4.22", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
 itertools = "0.10.3"
 ndarray = "0.15.6"

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -7,7 +7,7 @@ sys_includes = ["stdint.h"]
 no_includes = true
 
 after_includes = """
-// Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
+// Typedefs to make sure these "unknown" types are treated as opaque by ffigen.
 typedef struct RustDateTimeUtc RustDateTimeUtc;
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -8,9 +8,9 @@ no_includes = true
 
 after_includes = """
 // Typedefs to make sure this "unknown" types are treated as opaque by ffigen.
+typedef struct RustDateTimeUtc RustDateTimeUtc;
 typedef struct RustDuration RustDuration;
 typedef struct RustEmbedding RustEmbedding;
-typedef struct RustNaiveDateTime RustNaiveDateTime;
 typedef struct RustUrl RustUrl;
 typedef struct RustUuid RustUuid;
 """
@@ -21,6 +21,7 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 
 [export.rename]
 # Renamings to avoid name conflicts/confusion in dart.
+"DateTimeUtc" = "RustDateTimeUtc"
 "Document" = "RustDocument"
 "Duration" = "RustDuration"
 "Embedding" = "RustEmbedding"
@@ -28,12 +29,12 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "HistoricDocument" = "RustHistoricDocument"
 "InitConfig" = "RustInitConfig"
 "Market" = "RustMarket"
-"NaiveDateTime" = "RustNaiveDateTime"
 "NewsResource" = "RustNewsResource"
 "Option_f32" = "RustOptionF32"
 "Option_String" = "RustOptionString"
 "Option_Url" = "RustOptionUrl"
 "Option_UserReaction" = "RustOptionUserReaction"
+"Result_Document__String" = "RustResultDocumentString"
 "Result_Search__String" = "RustResultSearchString"
 "Result_SharedEngine__String" = "RustResultSharedEngineString"
 "Result_String" = "RustResultVoidString"

--- a/discovery_engine_core/bindings/src/types/date_time.rs
+++ b/discovery_engine_core/bindings/src/types/date_time.rs
@@ -14,17 +14,20 @@
 
 //! FFI functions for handling date time fields.
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, TimeZone, Utc};
+
+/// cbindgen:ignore
+pub(super) type DateTimeUtc = DateTime<Utc>;
 
 const NANOS_PER_MICRO: i64 = 1_000;
 const MICROS_PER_SECOND: i64 = 1_000_000;
 
-/// [`chrono::naive::MAX_DATETIME`] in micros
+/// [`DateTimeUtc::MAX_UTC`] in micros
 const MAX_MICRO_SECONDS: i64 = 8_210_298_412_799_999_999;
-/// [`chrono::naive::MIN_DATETIME`] in micros
+/// [`DateTimeUtc::MIN_UTC`] in micros
 const MIN_MICRO_SECONDS: i64 = -8_334_632_851_200_000_000;
 
-/// Creates a rust `NaiveDateTime` at given memory address.
+/// Creates a rust `DateTimeUtc` at given memory address.
 ///
 /// Returns `1` if it succeeded `0` else wise.
 ///
@@ -33,100 +36,106 @@ const MIN_MICRO_SECONDS: i64 = -8_334_632_851_200_000_000;
 ///
 /// # Safety
 ///
-/// It must be valid to write a `NaiveDateTime` instance to given pointer,
+/// It must be valid to write a `DateTimeUtc` instance to given pointer,
 /// the pointer is expected to point to uninitialized memory.
 #[no_mangle]
-pub unsafe extern "C" fn init_naive_date_time_at(
-    place: *mut NaiveDateTime,
-    micros_since_naive_epoch: i64,
-) {
-    let micros_since_naive_epoch =
-        micros_since_naive_epoch.clamp(MIN_MICRO_SECONDS, MAX_MICRO_SECONDS);
-    let seconds = micros_since_naive_epoch / MICROS_PER_SECOND;
-    let nanos = (micros_since_naive_epoch.abs() % MICROS_PER_SECOND) * NANOS_PER_MICRO;
+pub unsafe extern "C" fn init_date_time_utc_at(place: *mut DateTimeUtc, micros_since_epoch: i64) {
+    let micros_since_epoch = micros_since_epoch.clamp(MIN_MICRO_SECONDS, MAX_MICRO_SECONDS);
+    let seconds = micros_since_epoch / MICROS_PER_SECOND;
+    let nanos = (micros_since_epoch.abs() % MICROS_PER_SECOND) * NANOS_PER_MICRO;
     // the unwraps failing is unreachable, but we do not want to have any panic path
     let nanos = u32::try_from(nanos).unwrap_or(u32::MAX);
-    let date_time = NaiveDateTime::from_timestamp_opt(seconds, nanos).unwrap_or(NaiveDateTime::MAX);
+    let date_time_utc = Utc
+        .timestamp_opt(seconds, nanos)
+        .single()
+        .unwrap_or(DateTimeUtc::MAX_UTC);
     unsafe {
-        place.write(date_time);
+        place.write(date_time_utc);
     }
 }
 
 /// Returns the number of micro seconds since midnight on January 1, 1970.
 ///
-/// More specifically it's the number of micro seconds since `1970-01-01T00:00:00Z` assuming
-/// the naive date time to be in UTC.
+/// More specifically it's the number of micro seconds since `1970-01-01T00:00:00Z`.
 ///
 /// # Safety
 ///
-/// The pointer must point to a sound initialized `NaiveDateTime` instance.
+/// The pointer must point to a soundly initialized `DateTimeUtc` instance.
 #[no_mangle]
-pub unsafe extern "C" fn get_naive_date_time_micros_since_epoch(
-    naive_date_time: *const NaiveDateTime,
+pub unsafe extern "C" fn get_date_time_utc_micros_since_epoch(
+    date_time_utc: *const DateTimeUtc,
 ) -> i64 {
-    let naive_date_time = unsafe { &*naive_date_time };
-    let sub_micros = naive_date_time.timestamp_subsec_micros();
-    let seconds = naive_date_time.timestamp();
+    let date_time_utc = unsafe { &*date_time_utc };
+    let sub_micros = date_time_utc.timestamp_subsec_micros();
+    let seconds = date_time_utc.timestamp();
     seconds * MICROS_PER_SECOND + i64::from(sub_micros)
 }
 
-/// Alloc an uninitialized `Box<NaiveDateTime>`, mainly used for testing.
+/// Alloc an uninitialized `Box<DateTimeUtc>`, mainly used for testing.
 #[no_mangle]
-pub extern "C" fn alloc_uninitialized_naive_date_time() -> *mut NaiveDateTime {
+pub extern "C" fn alloc_uninitialized_date_time_utc() -> *mut DateTimeUtc {
     super::boxed::alloc_uninitialized()
 }
 
-/// Drops a `Box<NaiveDateTime>`, mainly used for testing.
+/// Drops a `Box<DateTimeUtc>`, mainly used for testing.
 ///
 /// # Safety
 ///
-/// The pointer must represent an initialized `Box<NaiveDateTime>`.
+/// The pointer must represent an initialized `Box<DateTimeUtc>`.
 #[no_mangle]
-pub unsafe extern "C" fn drop_naive_date_time(naive_date_time: *mut NaiveDateTime) {
-    unsafe { super::boxed::drop(naive_date_time) }
+pub unsafe extern "C" fn drop_date_time_utc(date_time_utc: *mut DateTimeUtc) {
+    unsafe { super::boxed::drop(date_time_utc) }
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::{NaiveDate, Timelike};
+    use std::mem::MaybeUninit;
+
+    use chrono::Timelike;
 
     use super::*;
 
     #[test]
     fn test_max_date_is_supported() {
-        let place = &mut NaiveDate::from_ymd(1, 1, 1).and_hms(1, 1, 1);
-        unsafe { init_naive_date_time_at(place, MAX_MICRO_SECONDS) };
-        let truncated_max = NaiveDateTime::MAX.with_nanosecond(999_999_000).unwrap();
-        assert_eq!(*place, truncated_max);
+        let mut place = MaybeUninit::uninit();
+        unsafe { init_date_time_utc_at(place.as_mut_ptr(), MAX_MICRO_SECONDS) };
+        let place = unsafe { place.assume_init() };
+        let truncated_max = DateTimeUtc::MAX_UTC.with_nanosecond(999_999_000).unwrap();
+        assert_eq!(place, truncated_max);
 
-        let micros = unsafe { get_naive_date_time_micros_since_epoch(&NaiveDateTime::MAX) };
-        unsafe { init_naive_date_time_at(place, micros) };
-        assert_eq!(*place, truncated_max);
+        let mut place = MaybeUninit::uninit();
+        let micros = unsafe { get_date_time_utc_micros_since_epoch(&DateTimeUtc::MAX_UTC) };
+        unsafe { init_date_time_utc_at(place.as_mut_ptr(), micros) };
+        let place = unsafe { place.assume_init() };
+        assert_eq!(place, truncated_max);
     }
 
     #[test]
     fn test_min_date_is_supported() {
-        let place = &mut NaiveDate::from_ymd(1, 1, 1).and_hms(1, 1, 1);
-        unsafe { init_naive_date_time_at(place, MIN_MICRO_SECONDS) };
-        assert_eq!(*place, NaiveDateTime::MIN);
+        let mut place = MaybeUninit::uninit();
+        unsafe { init_date_time_utc_at(place.as_mut_ptr(), MIN_MICRO_SECONDS) };
+        let place = unsafe { place.assume_init() };
+        assert_eq!(place, DateTimeUtc::MIN_UTC);
 
-        let micros = unsafe { get_naive_date_time_micros_since_epoch(&NaiveDateTime::MIN) };
-        unsafe { init_naive_date_time_at(place, micros) };
-        assert_eq!(*place, NaiveDateTime::MIN);
+        let mut place = MaybeUninit::uninit();
+        let micros = unsafe { get_date_time_utc_micros_since_epoch(&DateTimeUtc::MIN_UTC) };
+        unsafe { init_date_time_utc_at(place.as_mut_ptr(), micros) };
+        let place = unsafe { place.assume_init() };
+        assert_eq!(place, DateTimeUtc::MIN_UTC);
     }
 
     #[test]
     fn test_consts_max_is_sync() {
-        let seconds = NaiveDateTime::MAX.timestamp();
-        let sub_micros = NaiveDateTime::MAX.timestamp_subsec_micros();
+        let seconds = DateTimeUtc::MAX_UTC.timestamp();
+        let sub_micros = DateTimeUtc::MAX_UTC.timestamp_subsec_micros();
         let micros = seconds.checked_mul(MICROS_PER_SECOND).unwrap() + i64::from(sub_micros);
         assert_eq!(micros, MAX_MICRO_SECONDS);
     }
 
     #[test]
     fn test_consts_min_is_sync() {
-        let seconds = NaiveDateTime::MIN.timestamp();
-        let sub_micros = NaiveDateTime::MIN.timestamp_subsec_micros();
+        let seconds = DateTimeUtc::MIN_UTC.timestamp();
+        let sub_micros = DateTimeUtc::MIN_UTC.timestamp_subsec_micros();
         let micros = seconds.checked_mul(MICROS_PER_SECOND).unwrap() + i64::from(sub_micros);
         assert_eq!(micros, MIN_MICRO_SECONDS);
     }

--- a/discovery_engine_core/bindings/src/types/document/news_resource.rs
+++ b/discovery_engine_core/bindings/src/types/document/news_resource.rs
@@ -14,10 +14,10 @@
 
 use std::ptr::addr_of_mut;
 
-use chrono::NaiveDateTime;
 use url::Url;
-
 use xayn_discovery_engine_core::document::NewsResource;
+
+use crate::types::date_time::DateTimeUtc;
 
 /// Returns a pointer to the `title` field of a news resource.
 ///
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn news_resource_place_of_source_domain(
 #[no_mangle]
 pub unsafe extern "C" fn news_resource_place_of_date_published(
     place: *mut NewsResource,
-) -> *mut NaiveDateTime {
+) -> *mut DateTimeUtc {
     unsafe { addr_of_mut!((*place).date_published) }
 }
 

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 async-trait = "0.1.57"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
-chrono = { version = "0.4.21", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use derive_more::Display;
 use displaydoc::Display as DisplayDoc;
@@ -134,7 +134,7 @@ impl AiDocument for Document {
         &self.smbert_embedding
     }
 
-    fn date_published(&self) -> NaiveDateTime {
+    fn date_published(&self) -> DateTime<Utc> {
         self.resource.date_published
     }
 }
@@ -155,7 +155,7 @@ pub struct NewsResource {
     pub source_domain: String,
 
     /// Publishing date.
-    pub date_published: NaiveDateTime,
+    pub date_published: DateTime<Utc>,
 
     /// Image attached to the news.
     pub image: Option<Url>,
@@ -358,15 +358,15 @@ impl AiDocument for TrendingTopic {
         &self.smbert_embedding
     }
 
-    fn date_published(&self) -> NaiveDateTime {
+    fn date_published(&self) -> DateTime<Utc> {
         // return a default value as there is no `date_published` for trending topics
-        NaiveDateTime::MIN
+        DateTime::<Utc>::MIN_UTC
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use chrono::NaiveDate;
+    use chrono::TimeZone;
 
     use xayn_discovery_engine_providers::{Rank, UrlWithDomain};
 
@@ -380,7 +380,7 @@ pub(crate) mod tests {
                 url: example_url(),
                 source_domain: "example.com".to_string(),
                 image: None,
-                date_published: NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+                date_published: Utc.ymd(2022, 1, 1).and_hms(9, 0, 0),
                 score: None,
                 rank: 0,
                 country: "GB".to_string(),
@@ -403,7 +403,7 @@ pub(crate) mod tests {
             topic: "news".to_string(),
             country: "GB".to_string(),
             language: "en".to_string(),
-            date_published: NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+            date_published: Utc.ymd(2022, 1, 1).and_hms(9, 0, 0),
             url: UrlWithDomain::new(Url::parse("https://example.com/news/").unwrap()).unwrap(),
             image: Some(Url::parse("https://example.com/news/image.jpg").unwrap()),
             embedding: None,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -706,7 +706,7 @@ impl Engine {
                         snippet: reacted.snippet,
                         url: Url::parse("https://foobar.invalid").unwrap(),
                         source_domain: "foobar.invalid".into(),
-                        date_published: Utc::now().naive_utc(),
+                        date_published: Utc::now(),
                         image: None,
                         rank: 0,
                         score: None,
@@ -1746,7 +1746,7 @@ pub(crate) mod tests {
     use std::mem::size_of;
 
     use async_once_cell::OnceCell;
-    use chrono::NaiveDate;
+    use chrono::{TimeZone, Utc};
     use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
     use url::Url;
     use wiremock::{
@@ -2177,7 +2177,7 @@ pub(crate) mod tests {
             snippet: String::default(),
             url: example_url(),
             image: None,
-            date_published: NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+            date_published: Utc.ymd(2022, 1, 1).and_hms(9, 0, 0),
             score: None,
             rank: Rank::default(),
             country: "US".to_string(),

--- a/discovery_engine_core/core/src/stack/filters/semantic.rs
+++ b/discovery_engine_core/core/src/stack/filters/semantic.rs
@@ -287,7 +287,7 @@ where
 mod tests {
     use std::iter::repeat_with;
 
-    use chrono::NaiveDateTime;
+    use chrono::{TimeZone, Utc};
     use ndarray::aview1;
     use xayn_discovery_engine_ai::Embedding;
     use xayn_discovery_engine_bert::{AveragePooler, SMBert, SMBertConfig};
@@ -482,7 +482,7 @@ mod tests {
             Document {
                 smbert_embedding,
                 resource: NewsResource {
-                    date_published: NaiveDateTime::from_timestamp(secs, 0),
+                    date_published: Utc.timestamp(secs, 0),
                     ..NewsResource::default()
                 },
                 ..Document::default()

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -154,7 +154,7 @@ pub(crate) trait SourcePreferenceScope {
 pub mod models {
     use std::time::Duration;
 
-    use chrono::NaiveDateTime;
+    use chrono::{DateTime, Utc};
     use url::Url;
     use xayn_discovery_engine_ai::Embedding;
     use xayn_discovery_engine_providers::Market;
@@ -272,10 +272,7 @@ pub mod models {
         pub(crate) image: Option<Url>,
 
         /// Publishing date.
-        // FIXME: it's NativeDateTime in the current codebase but we can't compare
-        //      NativeDateTimes across different markets, but we do! So this needs to be
-        //      at least a Utc DateTime.
-        pub(crate) date_published: NaiveDateTime,
+        pub(crate) date_published: DateTime<Utc>,
 
         /// The domain of the article's source, e.g. `example.com`. Not a valid URL.
         pub(crate) source: String,

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use num_traits::FromPrimitive;
 use sqlx::{
     sqlite::{Sqlite, SqliteConnectOptions, SqlitePoolOptions},
@@ -696,7 +696,7 @@ struct QueriedApiDocumentView {
     topic: String,
     url: String,
     image: Option<String>,
-    date_published: NaiveDateTime,
+    date_published: DateTime<Utc>,
     source: String,
     market: String,
     domain_rank: i64,

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.57"
-chrono = { version = "0.4.21", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "deref"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"

--- a/discovery_engine_core/providers/src/models/content.rs
+++ b/discovery_engine_core/providers/src/models/content.rs
@@ -12,11 +12,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Error, Error::InvalidUrl, NewscatcherArticle};
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use derive_more::Deref;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use crate::{Error, Error::InvalidUrl, NewscatcherArticle};
 
 /// A helper type used to ensure that, within the [`GenericArticle`] struct,
 /// we never use a URL which does not have a domain, such as `file:///foo/bar`.
@@ -70,7 +71,7 @@ pub struct GenericArticle {
     pub title: String,
     pub snippet: String,
     pub url: UrlWithDomain,
-    pub date_published: NaiveDateTime,
+    pub date_published: DateTime<Utc>,
     pub country: String,
     pub language: String,
     pub topic: String,
@@ -110,7 +111,7 @@ impl TryFrom<NewscatcherArticle> for GenericArticle {
         Ok(Self {
             title: article.title,
             snippet: article.excerpt,
-            date_published: article.published_date,
+            date_published: article.date_published,
             url,
             image,
             rank: Rank::new(article.rank),
@@ -125,7 +126,7 @@ impl TryFrom<NewscatcherArticle> for GenericArticle {
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveDate;
+    use chrono::TimeZone;
 
     use super::*;
 
@@ -136,7 +137,7 @@ mod tests {
                 snippet: String::default(),
                 url: example_url(),
                 image: None,
-                date_published: NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+                date_published: Utc.ymd(2022, 1, 1).and_hms(9, 0, 0),
                 score: None,
                 rank: Rank::default(),
                 country: "US".to_string(),
@@ -181,7 +182,7 @@ mod tests {
         assert_eq!(article.score, resource.score);
         assert_eq!(article.rank, resource.rank.0);
         assert_eq!(article.topic, resource.topic);
-        assert_eq!(article.published_date, resource.date_published);
+        assert_eq!(article.date_published, resource.date_published);
     }
 
     #[test]

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -15,9 +15,9 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use derive_more::Deref;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Deserializer};
 use url::Url;
 
 use crate::{
@@ -206,7 +206,7 @@ pub(crate) fn append_market(
 }
 
 /// A news article
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Article {
     /// The title of the article.
     #[serde(default, deserialize_with = "deserialize_null_default")]
@@ -261,54 +261,56 @@ pub struct Article {
     /// While Newscatcher claims to have some sort of timezone support in their
     /// [API][<https://docs.newscatcherapi.com/api-docs/endpoints/search-news>] (via the
     /// `published_date_precision` attribute), in practice they do not seem to be supplying any
-    /// sort of timezone information. As a result, we provide NaiveDateTime for now.
+    /// sort of timezone information. As a result, we provide DateTime<Utc> for now.
     #[serde(
         default = "default_published_date",
-        deserialize_with = "deserialize_naive_date_time_from_str"
+        rename(deserialize = "published_date"),
+        deserialize_with = "deserialize_date_time_utc_from_str"
     )]
-    pub published_date: NaiveDateTime,
+    pub date_published: DateTime<Utc>,
 
     /// Optional article embedding from the provider.
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub embedding: Option<Vec<f32>>,
 }
 
-const fn default_published_date() -> NaiveDateTime {
-    NaiveDateTime::MIN
+const fn default_published_date() -> DateTime<Utc> {
+    DateTime::<Utc>::MIN_UTC
 }
 
-// Taken from https://github.com/serde-rs/serde/issues/1098#issuecomment-760711617
+/// Null-value tolerant deserialization of `Option<T: Default>`.
+// see <https://github.com/serde-rs/serde/issues/1098#issuecomment-760711617>
 fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
+    Option::deserialize(deserializer).map(Option::unwrap_or_default)
 }
 
-/// Null-value tolerant deserialization of `NaiveDateTime`
-fn deserialize_naive_date_time_from_str<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
+/// Null-value tolerant deserialization of `DateTime<Utc>`.
+fn deserialize_date_time_utc_from_str<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let opt: Option<String> = Option::deserialize(deserializer)?;
-    opt.map_or_else(
-        || Ok(NaiveDateTime::from_timestamp(0, 0)),
-        |s| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").map_err(de::Error::custom),
+    Option::<String>::deserialize(deserializer)?.map_or_else(
+        || Ok(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0)),
+        |s| {
+            Utc.datetime_from_str(&s, "%Y-%m-%d %H:%M:%S")
+                .map_err(de::Error::custom)
+        },
     )
 }
 
-/// Null-value tolerant deserialization of rank
+/// Null-value tolerant deserialization of rank.
 fn deserialize_rank<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or(u64::MAX))
+    Option::deserialize(deserializer).map(|option| option.unwrap_or(u64::MAX))
 }
 
-/// Query response from the Newscatcher API
+/// Query response from the Newscatcher API.
 #[derive(Deserialize, Debug)]
 pub struct Response {
     /// Status message
@@ -322,20 +324,16 @@ pub struct Response {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use chrono::NaiveDate;
-
-    use crate::{Filter, HeadlinesQuery, Market, Rank, UrlWithDomain};
-
-    use chrono::NaiveDateTime;
-
-    use crate::models::RankLimit;
     use wiremock::{
         matchers::{header, method, path, query_param, query_param_is_missing},
         Mock,
         MockServer,
         ResponseTemplate,
     };
+
+    use crate::{models::RankLimit, Filter, HeadlinesQuery, Market, Rank, UrlWithDomain};
+
+    use super::*;
 
     #[tokio::test]
     async fn test_simple_news_query() {
@@ -588,7 +586,7 @@ mod tests {
             url: UrlWithDomain::parse("https://example.com/a/2").unwrap(),
             image: Some(Url::parse("https://uploads.example.com/image2.png").unwrap()),
             topic: "gaming".to_string(),
-            date_published: NaiveDateTime::parse_from_str("2022-01-27 13:24:33", "%Y-%m-%d %H:%M:%S").unwrap(),
+            date_published: Utc.ymd(2022, 1, 27).and_hms(13, 24, 33),
             country: "US".to_string(),
             language: "en".to_string(),
             embedding: None
@@ -646,7 +644,7 @@ mod tests {
             url: UrlWithDomain::parse("https://example.com/a/2").unwrap(),
             image: Some(Url::parse("https://uploads.example.com/image2.png").unwrap()),
             topic: "gaming".to_string(),
-            date_published: NaiveDateTime::parse_from_str("2022-01-27 13:24:33", "%Y-%m-%d %H:%M:%S").unwrap(),
+            date_published: Utc.ymd(2022, 1, 27).and_hms(13, 24, 33),
             country: "US".to_string(),
             language: "en".to_string(),
             embedding: None
@@ -668,7 +666,7 @@ mod tests {
                 topic: "news".to_string(),
                 country: "US".to_string(),
                 language: "en".to_string(),
-                published_date: NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+                date_published: Utc.ymd(2022, 1, 1).and_hms(9, 0, 0),
                 embedding: None,
             }
         }

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-chrono = { version = "0.4.21", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "as_ref"] }
 displaydoc = "0.2.3"
 dotenvy = "0.15.1"

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
@@ -69,8 +69,8 @@ impl AiDocument for Document {
         &self.smbert_embedding
     }
 
-    fn date_published(&self) -> NaiveDateTime {
-        Utc::now().naive_utc()
+    fn date_published(&self) -> DateTime<Utc> {
+        Utc::now()
     }
 }
 


### PR DESCRIPTION
**References**

- [TO-3086]

**Summary**

- replace `NaiveDateTime` with `DateTime<Utc>` for `date_published`
- adjust ffi & tests


[TO-3086]: https://xainag.atlassian.net/browse/TO-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ