### PR TITLE
[Merged by Bors] - TO-3110 [2] pass dummy dart migration data to rust

### DIFF
--- a/discovery_engine/lib/src/domain/models/unique_id.dart
+++ b/discovery_engine/lib/src/domain/models/unique_id.dart
@@ -32,6 +32,10 @@ abstract class UniqueId with EquatableMixin {
   UniqueId.fromJson(Map<String, Object> json)
       : value = _validateId(_bytesFromJson(json));
 
+  UniqueId.fromString(String string)
+      : value =
+            UnmodifiableUint8ListView(Uint8List.fromList(Uuid.parse(string)));
+
   static UnmodifiableUint8ListView _generateId() {
     final id = const Uuid().v4();
     final bytes = Uuid.parseAsByteList(id);
@@ -61,6 +65,7 @@ abstract class UniqueId with EquatableMixin {
 /// Unique identifier of a [Document].
 class DocumentId extends UniqueId {
   DocumentId() : super();
+  DocumentId.fromString(String string) : super.fromString(string);
   DocumentId.fromBytes(Uint8List bytes) : super.fromBytes(bytes);
   DocumentId.fromJson(Map<String, Object> json) : super.fromJson(json);
 }

--- a/discovery_engine/lib/src/ffi/types/dart_migration_data.dart
+++ b/discovery_engine/lib/src/ffi/types/dart_migration_data.dart
@@ -13,38 +13,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:ffi';
-import 'dart:typed_data';
 
-import 'package:xayn_discovery_engine/src/domain/models/active_data.dart';
-import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
-import 'package:xayn_discovery_engine/src/domain/models/history.dart';
-import 'package:xayn_discovery_engine/src/domain/models/source.dart';
-import 'package:xayn_discovery_engine/src/domain/models/source_reacted.dart';
-import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
 import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustDartMigrationData;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/migration.dart';
 
-class DartMigrationData {
-  final Uint8List? engineState;
-  final List<HistoricDocument> history;
-  final Map<DocumentId, ActiveDocumentData> activeDocumentData;
-  final List<SourceReacted> reactedSources;
-  final Set<Source> trustedSources;
-  final Set<Source> excludedSources;
-  final ActiveSearch? activeSearch;
-
-  DartMigrationData({
-    required this.engineState,
-    required this.history,
-    required this.activeDocumentData,
-    required this.reactedSources,
-    required this.trustedSources,
-    required this.excludedSources,
-    required this.activeSearch,
-  });
-
+extension DartMigrationDataFfi on DartMigrationData {
   Boxed<RustDartMigrationData> allocNative() {
     final place = ffi.alloc_uninitialized_dart_migration_data();
     writeNative(place);

--- a/discovery_engine/lib/src/ffi/types/dart_migration_data.dart
+++ b/discovery_engine/lib/src/ffi/types/dart_migration_data.dart
@@ -1,0 +1,58 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:xayn_discovery_engine/src/domain/models/active_data.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
+import 'package:xayn_discovery_engine/src/domain/models/history.dart';
+import 'package:xayn_discovery_engine/src/domain/models/source.dart';
+import 'package:xayn_discovery_engine/src/domain/models/source_reacted.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
+import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
+    show RustDartMigrationData;
+import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show ffi;
+import 'package:xayn_discovery_engine/src/ffi/types/box.dart';
+
+class DartMigrationData {
+  final Uint8List? engineState;
+  final List<HistoricDocument> history;
+  final Map<DocumentId, ActiveDocumentData> activeDocumentData;
+  final List<SourceReacted> reactedSources;
+  final Set<Source> trustedSources;
+  final Set<Source> excludedSources;
+  final ActiveSearch? activeSearch;
+
+  DartMigrationData({
+    required this.engineState,
+    required this.history,
+    required this.activeDocumentData,
+    required this.reactedSources,
+    required this.trustedSources,
+    required this.excludedSources,
+    required this.activeSearch,
+  });
+
+  Boxed<RustDartMigrationData> allocNative() {
+    final place = ffi.alloc_uninitialized_dart_migration_data();
+    writeNative(place);
+    return Boxed(place, ffi.drop_dart_migration_data);
+  }
+
+  void writeNative(final Pointer<RustDartMigrationData> data) {
+    //TODO[pmk] pass the actual data to rust and use it there
+    ffi.dart_migration_data_place_of_dummy(data).value = 42;
+  }
+}

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -113,6 +113,8 @@ class DiscoveryEngineFfi implements Engine {
       initializer.engineState?.allocNative().move() ?? nullptr,
       initializer.history.allocNative().move(),
       initializer.reactedSources.allocVec().move(),
+      //TODO[pmk] pass in migration data if needed
+      nullptr,
     );
     final boxedEngine = resultSharedEngineStringFfiAdapter.moveNative(result);
 

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -43,6 +43,7 @@ import 'package:xayn_discovery_engine/src/ffi/genesis.ffigen.dart'
     show RustSharedEngine;
 import 'package:xayn_discovery_engine/src/ffi/load_lib.dart' show asyncFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/box.dart' show Boxed;
+import 'package:xayn_discovery_engine/src/ffi/types/dart_migration_data.dart';
 import 'package:xayn_discovery_engine/src/ffi/types/document/document_vec.dart'
     show DocumentSliceFfi;
 import 'package:xayn_discovery_engine/src/ffi/types/document/time_spent.dart'
@@ -93,6 +94,7 @@ class DiscoveryEngineFfi implements Engine {
   /// Initializes the engine.
   static Future<DiscoveryEngineFfi> initialize(
     EngineInitializer initializer,
+    DartMigrationData? dartMigrationData,
   ) async {
     final setupData = initializer.setupData;
     if (setupData is! NativeSetupData) {
@@ -113,8 +115,7 @@ class DiscoveryEngineFfi implements Engine {
       initializer.engineState?.allocNative().move() ?? nullptr,
       initializer.history.allocNative().move(),
       initializer.reactedSources.allocVec().move(),
-      //TODO[pmk] pass in migration data if needed
-      nullptr,
+      dartMigrationData?.allocNative().move() ?? nullptr,
     );
     final boxedEngine = resultSharedEngineStringFfiAdapter.moveNative(result);
 

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -84,6 +84,7 @@ import 'package:xayn_discovery_engine/src/ffi/types/weighted_source_vec.dart'
     show WeightedSourceListFfi;
 import 'package:xayn_discovery_engine/src/infrastructure/assets/native/data_provider.dart'
     show NativeSetupData;
+import 'package:xayn_discovery_engine/src/infrastructure/migration.dart';
 
 /// A handle to the discovery engine.
 class DiscoveryEngineFfi implements Engine {

--- a/discovery_engine/lib/src/infrastructure/migration.dart
+++ b/discovery_engine/lib/src/infrastructure/migration.dart
@@ -75,8 +75,7 @@ class DartMigrationData {
       engineState: await engineStateRepository.load(),
       documents: await documentRepository.fetchAll(),
       activeDocumentData: activeDocumentDataRepository.box.toMap().map(
-            // ignore: avoid_annotating_with_dynamic
-            (dynamic key, data) =>
+            (Object? key, data) =>
                 MapEntry(DocumentId.fromString(key as String), data),
           ),
       reactedSources: await sourceReactedRepository.fetchAll(),

--- a/discovery_engine/lib/src/infrastructure/migration.dart
+++ b/discovery_engine/lib/src/infrastructure/migration.dart
@@ -1,0 +1,98 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:typed_data';
+
+import 'package:xayn_discovery_engine/src/domain/models/active_data.dart';
+import 'package:xayn_discovery_engine/src/domain/models/active_search.dart';
+import 'package:xayn_discovery_engine/src/domain/models/document.dart';
+import 'package:xayn_discovery_engine/src/domain/models/source.dart';
+import 'package:xayn_discovery_engine/src/domain/models/source_reacted.dart';
+import 'package:xayn_discovery_engine/src/domain/models/unique_id.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_document_repo.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_active_search_repo.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_document_repo.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_engine_state_repo.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_source_preference_repo.dart';
+import 'package:xayn_discovery_engine/src/infrastructure/repository/hive_source_reacted_repo.dart';
+
+class DartMigrationData {
+  final Uint8List? engineState;
+  final List<Document> documents;
+  final Map<DocumentId, ActiveDocumentData> activeDocumentData;
+  final List<SourceReacted> reactedSources;
+  final Set<Source> trustedSources;
+  final Set<Source> excludedSources;
+  final ActiveSearch? activeSearch;
+
+  /// Cleanup callback (which should be) called after successfully initializing the engine.
+  final Future<void> Function() cleanup;
+
+  DartMigrationData({
+    required this.engineState,
+    required this.documents,
+    required this.activeDocumentData,
+    required this.reactedSources,
+    required this.trustedSources,
+    required this.excludedSources,
+    required this.activeSearch,
+    required this.cleanup,
+  });
+
+  /// If migrations is necessary extracts the data for it from the repos.
+  ///
+  /// The `cleanup` callback is set to clear the repositories.
+  static Future<DartMigrationData?> fromRepositories(
+    HiveEngineStateRepository engineStateRepository,
+    HiveDocumentRepository documentRepository,
+    HiveActiveSearchRepository activeSearchRepository,
+    HiveActiveDocumentDataRepository activeDocumentDataRepository,
+    HiveSourceReactedRepository sourceReactedRepository,
+    HiveSourcePreferenceRepository sourcePreferenceRepository,
+  ) async {
+    if (engineStateRepository.box.isEmpty &&
+        documentRepository.box.isEmpty &&
+        activeSearchRepository.box.isEmpty &&
+        activeDocumentDataRepository.box.isEmpty &&
+        //FIXME even with cfgFeatureStorage we still set this values to hive
+        // sourcePreferenceRepository.box.isEmpty &&
+        sourceReactedRepository.box.isEmpty) {
+      return null;
+    }
+
+    return DartMigrationData(
+      engineState: await engineStateRepository.load(),
+      documents: await documentRepository.fetchAll(),
+      activeDocumentData: activeDocumentDataRepository.box.toMap().map(
+            // ignore: avoid_annotating_with_dynamic
+            (dynamic key, data) =>
+                MapEntry(DocumentId.fromString(key as String), data),
+          ),
+      reactedSources: await sourceReactedRepository.fetchAll(),
+      trustedSources: await sourcePreferenceRepository.getTrusted(),
+      excludedSources: await sourcePreferenceRepository.getExcluded(),
+      activeSearch: await activeSearchRepository.getCurrent(),
+      cleanup: () {
+        //TODO[pmk] uncomment section once migration part was added
+        // await engineStateRepository.clear();
+        // await documentRepository.box.clear();
+        // await activeSearchRepository.clear();
+        // await activeDocumentDataRepository.box.clear();
+        // await sourceReactedRepository.box.clear();
+        // await sourcePreferenceRepository.clear();
+        return Future<void>.value(null);
+      },
+    );
+  }
+}

--- a/discovery_engine/test/ffi/ffi_test.dart
+++ b/discovery_engine/test/ffi/ffi_test.dart
@@ -66,6 +66,7 @@ void main() {
           trustedSources: {},
           excludedSources: {},
         ),
+        null,
       ),
       allOf(
         throwsException,

--- a/discovery_engine_core/bindings/cbindgen.toml
+++ b/discovery_engine_core/bindings/cbindgen.toml
@@ -24,6 +24,7 @@ include = ["xayn-discovery-engine-core", "xayn-discovery-engine-providers"]
 "DateTimeUtc" = "RustDateTimeUtc"
 "Document" = "RustDocument"
 "Duration" = "RustDuration"
+"DartMigrationData" = "RustDartMigrationData"
 "Embedding" = "RustEmbedding"
 "FfiUsize" = "RustFfiUsize"
 "HistoricDocument" = "RustHistoricDocument"

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -52,7 +52,7 @@ pub extern "C" fn cfg_feature_storage() -> u8 {
     use xayn_discovery_engine_ai::Embedding;
     use xayn_discovery_engine_core::{
         document::{Document, HistoricDocument, TimeSpent, TrendingTopic, UserReacted, WeightedSource},
-        InitConfig,
+        InitConfig, DartMigrationData
     };
     use xayn_discovery_engine_providers::Market;
 
@@ -66,6 +66,7 @@ impl XaynDiscoveryEngineAsyncFfi {
         state: Option<Box<Vec<u8>>>,
         history: Box<Vec<HistoricDocument>>,
         sources: Box<Vec<WeightedSource>>,
+        dart_migration_data: Option<Box<DartMigrationData>>,
     ) -> Box<Result<SharedEngine, String>> {
         tracing::init_tracing(config.log_file.as_deref().map(Path::new));
 
@@ -75,6 +76,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 state.as_deref().map(Vec::as_slice),
                 &history,
                 &sources,
+                dart_migration_data.map(|d| *d),
             )
             .await
             .map(|engine| tokio::sync::Mutex::new(engine).into())

--- a/discovery_engine_core/bindings/src/types.rs
+++ b/discovery_engine_core/bindings/src/types.rs
@@ -17,6 +17,7 @@
 #![allow(unsafe_code)]
 
 mod boxed;
+pub mod dart_migration_data;
 pub mod date_time;
 pub mod document;
 pub mod duration;

--- a/discovery_engine_core/bindings/src/types/dart_migration_data.rs
+++ b/discovery_engine_core/bindings/src/types/dart_migration_data.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::ptr::addr_of_mut;
+
+use xayn_discovery_engine_core::DartMigrationData;
+
+/// Returns a pointer to the `dummy` field of a [`DartMigrationData`].
+///
+/// # Safety
+///
+/// The pointer must point to a valid [`DartMigrationData`] memory object,
+/// it might be uninitialized.
+#[no_mangle]
+pub unsafe extern "C" fn dart_migration_data_place_of_dummy(
+    place: *mut DartMigrationData,
+) -> *mut u8 {
+    unsafe { addr_of_mut!((*place).dummy) }
+}
+
+/// Alloc an uninitialized `Box<DartMigrationData>`, mainly used for testing.
+#[no_mangle]
+pub extern "C" fn alloc_uninitialized_dart_migration_data() -> *mut DartMigrationData {
+    crate::types::boxed::alloc_uninitialized()
+}
+
+/// Drops a `Box<DartMigrationData>`, mainly used for testing.
+///
+/// # Safety
+///
+/// The pointer must represent a valid `Box<DartMigrationData>` instance.
+#[no_mangle]
+pub unsafe extern "C" fn drop_dart_migration_data(data: *mut DartMigrationData) {
+    unsafe { crate::types::boxed::drop(data) };
+}

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -107,6 +107,7 @@ use crate::{
         Stack,
         TrustedNews,
     },
+    DartMigrationData,
 };
 
 /// Discovery engine errors.
@@ -269,6 +270,7 @@ impl Engine {
         state: Option<&[u8]>,
         history: &[HistoricDocument],
         sources: &[WeightedSource],
+        _dart_migration_data: Option<DartMigrationData>,
     ) -> Result<Self, Error> {
         // read the configs
         let de_config =
@@ -342,7 +344,8 @@ impl Engine {
                         .into_string()
                         .unwrap(/*can't fail as we only join rust strings*/)
             });
-            let (storage, _init_hint) = SqliteStorage::init_storage_system(db_file_path).await?;
+            let (storage, _init_hint) =
+                SqliteStorage::init_storage_system(db_file_path, _dart_migration_data).await?;
             //FIXME pass the hint to dart for deciding if migrations are needed
             storage
         };
@@ -1804,7 +1807,9 @@ pub(crate) mod tests {
 
             // Now we can initialize the engine with no previous history or state. This should
             // be the same as when it's initialized for the first time after the app is downloaded.
-            let engine = Engine::from_config(config, None, &[], &[]).await.unwrap();
+            let engine = Engine::from_config(config, None, &[], &[], None)
+                .await
+                .unwrap();
 
             Mutex::new((server, engine))
         };

--- a/discovery_engine_core/core/src/lib.rs
+++ b/discovery_engine_core/core/src/lib.rs
@@ -46,3 +46,8 @@ pub use crate::{
     config::{CoreConfig, EndpointConfig, ExplorationConfig, FeedConfig, InitConfig, SearchConfig},
     engine::{Engine, Error, SearchBy},
 };
+
+//FIXME move into crate::storage once the feature "storage" flag is removed
+pub struct DartMigrationData {
+    pub dummy: u8,
+}

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -25,6 +25,7 @@ use xayn_discovery_engine_ai::{GenericError, MalformedBytesEmbedding};
 use crate::{
     document::{self, HistoricDocument, UserReaction, ViewMode},
     stack,
+    DartMigrationData,
 };
 
 use self::models::{ApiDocumentView, NewDocument, Search, TimeSpentDocumentView};
@@ -78,6 +79,7 @@ pub(crate) trait Storage {
     /// Passing in `None` means a new temporary db should be created.
     async fn init_storage_system(
         db_identifier: Option<String>,
+        dart_migration_data: Option<DartMigrationData>,
     ) -> Result<(BoxedStorage, InitDbHint), Error>
     where
         Self: Sized;

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -36,6 +36,7 @@ use crate::{
         BoxedStorage, Error, FeedScope, FeedbackScope, InitDbHint, SearchScope,
         SourcePreferenceScope, SourceReactionScope, StateScope, Storage,
     },
+    DartMigrationData,
 };
 
 use self::utils::SqlxSqliteResultExt;
@@ -1038,7 +1039,7 @@ mod tests {
 
     impl SqliteStorage {
         async fn test_storage_system() -> BoxedStorage {
-            SqliteStorage::init_storage_system(None).await.unwrap().0
+            SqliteStorage::init_storage_system(None, None).await.unwrap().0
         }
     }
 
@@ -1178,7 +1179,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_document() {
-        let storage = super::setup::init_storage_system(None).await.unwrap().0;
+        let storage = super::setup::init_storage_system(None, None)
+            .await
+            .unwrap()
+            .0;
 
         let id = document::Id::new();
         assert!(matches!(

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -29,31 +29,18 @@ use crate::{
     stack,
     storage::{
         models::{
-            ApiDocumentView,
-            NewDocument,
-            NewsResource,
-            NewscatcherData,
-            Paging,
-            Search,
-            SearchBy,
+            ApiDocumentView, NewDocument, NewsResource, NewscatcherData, Paging, Search, SearchBy,
             TimeSpentDocumentView,
         },
         utils::SqlxPushTupleExt,
-        BoxedStorage,
-        Error,
-        FeedScope,
-        FeedbackScope,
-        InitDbHint,
-        SearchScope,
-        SourcePreferenceScope,
-        SourceReactionScope,
-        StateScope,
-        Storage,
+        BoxedStorage, Error, FeedScope, FeedbackScope, InitDbHint, SearchScope,
+        SourcePreferenceScope, SourceReactionScope, StateScope, Storage,
     },
 };
 
 use self::utils::SqlxSqliteResultExt;
 
+mod dart_migrations;
 mod setup;
 mod utils;
 
@@ -311,8 +298,9 @@ impl SqliteStorage {
 impl Storage for SqliteStorage {
     async fn init_storage_system(
         file_path: Option<String>,
+        dart_migration_data: Option<DartMigrationData>,
     ) -> Result<(BoxedStorage, InitDbHint), Error> {
-        self::setup::init_storage_system(file_path.map(Into::into))
+        self::setup::init_storage_system(file_path.map(Into::into), dart_migration_data)
             .await
             .map(|(storage, hint)| (Box::new(storage) as _, hint))
     }

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -29,12 +29,26 @@ use crate::{
     stack,
     storage::{
         models::{
-            ApiDocumentView, NewDocument, NewsResource, NewscatcherData, Paging, Search, SearchBy,
+            ApiDocumentView,
+            NewDocument,
+            NewsResource,
+            NewscatcherData,
+            Paging,
+            Search,
+            SearchBy,
             TimeSpentDocumentView,
         },
         utils::SqlxPushTupleExt,
-        BoxedStorage, Error, FeedScope, FeedbackScope, InitDbHint, SearchScope,
-        SourcePreferenceScope, SourceReactionScope, StateScope, Storage,
+        BoxedStorage,
+        Error,
+        FeedScope,
+        FeedbackScope,
+        InitDbHint,
+        SearchScope,
+        SourcePreferenceScope,
+        SourceReactionScope,
+        StateScope,
+        Storage,
     },
     DartMigrationData,
 };
@@ -1039,7 +1053,10 @@ mod tests {
 
     impl SqliteStorage {
         async fn test_storage_system() -> BoxedStorage {
-            SqliteStorage::init_storage_system(None, None).await.unwrap().0
+            SqliteStorage::init_storage_system(None, None)
+                .await
+                .unwrap()
+                .0
         }
     }
 

--- a/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
@@ -20,9 +20,10 @@ use crate::{storage::Error, DartMigrationData};
 
 /// Add the data from the  dart->rust/sqltie migration to the prepared database.
 pub(super) async fn store_migration_data(
-    pool: &Pool<Sqlite>,
-    data: &DartMigrationData,
+    _pool: &Pool<Sqlite>,
+    _data: &DartMigrationData,
 ) -> Result<(), Error> {
+    #![allow(clippy::unused_async)]
     //TODO[pmk] implement
     Ok(())
 }

--- a/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
@@ -1,0 +1,28 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Module for handling dart->rust/sqltie migrations
+
+use sqlx::{Pool, Sqlite};
+
+use crate::{storage::Error, DartMigrationData};
+
+/// Add the data from the  dart->rust/sqltie migration to the prepared database.
+pub(super) async fn store_migration_data(
+    pool: &Pool<Sqlite>,
+    data: &DartMigrationData,
+) -> Result<(), Error> {
+    //TODO[pmk] implement
+    Ok(())
+}

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -308,7 +308,9 @@ mod tests {
         create_bad_file(&db_file);
         assert!(db_file.exists());
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None)
+            .await
+            .unwrap();
 
         assert!(db_file.exists());
 
@@ -323,7 +325,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_file = dir.path().join("db.sqlite");
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None)
+            .await
+            .unwrap();
 
         assert!(db_file.exists());
         assert!(matches!(hint, InitDbHint::NewDbCreated));
@@ -333,7 +337,9 @@ mod tests {
 
         assert!(db_file.exists());
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None)
+            .await
+            .unwrap();
 
         assert!(db_file.exists());
         assert!(matches!(hint, InitDbHint::NormalInit));

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -22,6 +22,7 @@ use crate::{
     stack,
     storage::{utils::SqlxPushTupleExt, Error, InitDbHint},
     utils::{remove_file_if_exists, CompoundError, MiscErrorExt},
+    DartMigrationData,
 };
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
@@ -38,14 +39,19 @@ use super::SqliteStorage;
 /// and a new db is opened instead.
 pub(super) async fn init_storage_system(
     file_path: Option<PathBuf>,
+    dart_migration_data: Option<DartMigrationData>,
 ) -> Result<(SqliteStorage, InitDbHint), Error> {
-    let file_exists = if let Some(path) = &file_path {
+    let file_exists = if dart_migration_data.is_some() {
+        delete_db_files(file_path.as_deref()).await?;
+        false
+    } else if let Some(path) = &file_path {
         //tokio version of `std::path::Path::exists()`
         tokio::fs::metadata(path).await.is_ok()
     } else {
         false
     };
-    let result = init_storage_system_once(file_path.clone()).await;
+
+    let result = init_storage_system_once(file_path.clone(), dart_migration_data.as_ref()).await;
     match (file_exists, result) {
         (false, Ok(storage)) => Ok((storage, InitDbHint::NewDbCreated)),
         (true, Ok(storage)) => Ok((storage, InitDbHint::NormalInit)),
@@ -58,7 +64,7 @@ pub(super) async fn init_storage_system(
             //      this is fully out of scope of what we have resources for.
             delete_db_files(file_path.as_deref()).await?;
 
-            init_storage_system_once(file_path)
+            init_storage_system_once(file_path, dart_migration_data.as_ref())
                 .await
                 .map(|storage| (storage, InitDbHint::DbOverwrittenDueToErrors(first_error)))
         }
@@ -108,10 +114,16 @@ fn with_file_name_suffix(path: &Path, suffix: &str) -> Result<PathBuf, Error> {
     Ok(path.with_file_name(file_name))
 }
 
-async fn init_storage_system_once(file_path: Option<PathBuf>) -> Result<SqliteStorage, Error> {
+async fn init_storage_system_once(
+    file_path: Option<PathBuf>,
+    dart_migration_data: Option<&DartMigrationData>,
+) -> Result<SqliteStorage, Error> {
     let pool = create_connection_pool(file_path.as_deref()).await?;
     update_schema(&pool).await?;
     update_static_data(&pool).await?;
+    if let Some(dart_migration_data) = dart_migration_data {
+        super::dart_migrations::store_migration_data(&pool, dart_migration_data).await?;
+    }
     Ok(SqliteStorage { pool })
 }
 
@@ -296,7 +308,7 @@ mod tests {
         create_bad_file(&db_file);
         assert!(db_file.exists());
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone())).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
 
         assert!(db_file.exists());
 
@@ -311,7 +323,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_file = dir.path().join("db.sqlite");
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone())).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
 
         assert!(db_file.exists());
         assert!(matches!(hint, InitDbHint::NewDbCreated));
@@ -321,7 +333,7 @@ mod tests {
 
         assert!(db_file.exists());
 
-        let (storage, hint) = init_storage_system(Some(db_file.clone())).await.unwrap();
+        let (storage, hint) = init_storage_system(Some(db_file.clone()), None).await.unwrap();
 
         assert!(db_file.exists());
         assert!(matches!(hint, InitDbHint::NormalInit));

--- a/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
+++ b/discovery_engine_core/tooling/src/bin/discovery_engine/engine.rs
@@ -58,7 +58,7 @@ impl TestEngine {
             data_dir: String::new(),
             use_ephemeral_db: true,
         };
-        let engine = Engine::from_config(config, None, &[], &[]).await?;
+        let engine = Engine::from_config(config, None, &[], &[], None).await?;
 
         spinner.finish_with_message("initialized engine");
 

--- a/discovery_engine_flutter/test/xayn_discovery_engine_flutter_test.dart
+++ b/discovery_engine_flutter/test/xayn_discovery_engine_flutter_test.dart
@@ -34,8 +34,15 @@ void main() {
 
     tearDown(() {
       final dir = Directory(outputPath);
-      if (dir.existsSync()) {
+      try {
         dir.deleteSync(recursive: true);
+      } on FileSystemException catch (exception) {
+        // don't fail if it is already deleted,
+        // checking dir exists creates a subtle
+        // race condition and can fail
+        if (exception.osError?.errorCode != 2) {
+          rethrow;
+        }
       }
     });
 

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ dart-check: dart-build
 flutter-check: dart-build flutter-deps
     @{{just_executable()}} _dart-analyze "$FLUTTER_WORKSPACE"
 
-flutter-test: dart-build flutter-deps
+flutter-test: rust-build dart-build flutter-deps
     cd "$FLUTTER_WORKSPACE"; \
     flutter test
 


### PR DESCRIPTION
Create a skeleton to passing dart migration data to rust, using them when initializing the db and cleaning up the dart db(s) afterward.

**Based On:**

- #577 