### PR TITLE
[Merged by Bors] - TO-3075 rustify source reaction logic

### DIFF
--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -77,7 +77,6 @@ abstract class Engine {
 
   /// Changes the excluded and trusted sources.
   Future<void> setSources(
-    List<SourceReacted> sources,
     Set<Source> excluded,
     Set<Source> trusted,
   );
@@ -90,32 +89,26 @@ abstract class Engine {
 
   /// Adds an excluded source.
   Future<void> addExcludedSource(
-    List<SourceReacted> sources,
     Source excluded,
   );
 
   /// Removes an excluded source.
   Future<void> removeExcludedSource(
-    List<SourceReacted> sources,
     Source excluded,
   );
 
   /// Adds a trusted source.
   Future<void> addTrustedSource(
-    List<SourceReacted> sources,
     Source trusted,
   );
 
   /// Removes a trusted source.
   Future<void> removeTrustedSource(
-    List<SourceReacted> sources,
     Source trusted,
   );
 
   /// Gets the next batch of feed documents.
-  Future<List<DocumentWithActiveData>> feedNextBatch(
-    List<SourceReacted> sources,
-  );
+  Future<List<DocumentWithActiveData>> feedNextBatch();
 
   /// Gets the next batch of feed documents.
   Future<List<DocumentWithActiveData>> getFeedDocuments(

--- a/discovery_engine/lib/src/domain/engine/mock_engine.dart
+++ b/discovery_engine/lib/src/domain/engine/mock_engine.dart
@@ -112,7 +112,6 @@ class MockEngine implements Engine {
 
   @override
   Future<void> setSources(
-    List<SourceReacted> sources,
     Set<Source> excluded,
     Set<Source> trusted,
   ) async {
@@ -135,7 +134,6 @@ class MockEngine implements Engine {
 
   @override
   Future<void> addExcludedSource(
-    List<SourceReacted> sources,
     Source excluded,
   ) async {
     _incrementCount('addExcludedSource');
@@ -143,7 +141,6 @@ class MockEngine implements Engine {
 
   @override
   Future<void> removeExcludedSource(
-    List<SourceReacted> sources,
     Source excluded,
   ) async {
     _incrementCount('removeExcludedSource');
@@ -151,7 +148,6 @@ class MockEngine implements Engine {
 
   @override
   Future<void> addTrustedSource(
-    List<SourceReacted> sources,
     Source trusted,
   ) async {
     _incrementCount('addTrustedSource');
@@ -159,16 +155,13 @@ class MockEngine implements Engine {
 
   @override
   Future<void> removeTrustedSource(
-    List<SourceReacted> sources,
     Source trusted,
   ) async {
     _incrementCount('removeTrustedSource');
   }
 
   @override
-  Future<List<DocumentWithActiveData>> feedNextBatch(
-    List<SourceReacted> sources,
-  ) async {
+  Future<List<DocumentWithActiveData>> feedNextBatch() async {
     _incrementCount('feedNextBatch');
     return feedDocuments.take(2).toList(growable: false);
   }

--- a/discovery_engine/lib/src/domain/feed_manager.dart
+++ b/discovery_engine/lib/src/domain/feed_manager.dart
@@ -125,10 +125,9 @@ class FeedManager {
   /// Obtain the next batch of feed documents and persist to repositories.
   Future<EngineEvent> nextFeedBatch() async {
     if (cfgFeatureStorage) {
-      final sources = await _sourceReactedRepo.fetchAll();
       final List<DocumentWithActiveData> docs;
       try {
-        docs = await _engine.feedNextBatch(sources);
+        docs = await _engine.feedNextBatch();
       } on Exception catch (e) {
         return EngineEvent.nextFeedBatchRequestFailed(
           FeedFailureReason.stacksOpsError,
@@ -231,11 +230,8 @@ class FeedManager {
       return EngineEvent.setSourcesRequestFailed(duplicates);
     }
 
-    final sources = await _sourceReactedRepo.fetchAll();
-
     if (cfgFeatureStorage) {
       await _engine.setSources(
-        sources,
         excludedSources,
         trustedSources,
       );
@@ -257,6 +253,7 @@ class FeedManager {
     final currentTrusted = await _sourcePreferenceRepository.getTrusted();
     final currentExcluded = await _sourcePreferenceRepository.getExcluded();
     final history = await _docRepo.fetchHistory();
+    final sources = await _sourceReactedRepo.fetchAll();
     await _sourcePreferenceRepository.clear();
     await _sourcePreferenceRepository.saveAll(dbEntries);
 
@@ -291,8 +288,7 @@ class FeedManager {
     await _sourcePreferenceRepository.save(pref);
 
     if (cfgFeatureStorage) {
-      final sources = await _sourceReactedRepo.fetchAll();
-      await _engine.addExcludedSource(sources, source);
+      await _engine.addExcludedSource(source);
       return EngineEvent.addExcludedSourceRequestSucceeded(source);
     }
 
@@ -303,14 +299,14 @@ class FeedManager {
   /// Removes an excluded source.
   Future<EngineEvent> removeExcludedSource(Source source) async {
     await _sourcePreferenceRepository.remove(source);
-    final sources = await _sourceReactedRepo.fetchAll();
 
     if (cfgFeatureStorage) {
-      await _engine.removeExcludedSource(sources, source);
+      await _engine.removeExcludedSource(source);
       return EngineEvent.removeExcludedSourceRequestSucceeded(source);
     }
 
     final history = await _docRepo.fetchHistory();
+    final sources = await _sourceReactedRepo.fetchAll();
     final excluded = await _sourcePreferenceRepository.getExcluded();
     await _engine.setExcludedSources(history, sources, excluded);
     return EngineEvent.removeExcludedSourceRequestSucceeded(source);
@@ -334,8 +330,7 @@ class FeedManager {
     await _sourcePreferenceRepository.save(pref);
 
     if (cfgFeatureStorage) {
-      final sources = await _sourceReactedRepo.fetchAll();
-      await _engine.addTrustedSource(sources, source);
+      await _engine.addTrustedSource(source);
       return EngineEvent.addTrustedSourceRequestSucceeded(source);
     }
 
@@ -346,14 +341,14 @@ class FeedManager {
   /// Removes a trusted source.
   Future<EngineEvent> removeTrustedSource(Source source) async {
     await _sourcePreferenceRepository.remove(source);
-    final sources = await _sourceReactedRepo.fetchAll();
 
     if (cfgFeatureStorage) {
-      await _engine.removeTrustedSource(sources, source);
+      await _engine.removeTrustedSource(source);
       return EngineEvent.removeTrustedSourceRequestSucceeded(source);
     }
 
     final history = await _docRepo.fetchHistory();
+    final sources = await _sourceReactedRepo.fetchAll();
     final trusted = await _sourcePreferenceRepository.getTrusted();
     await _engine.setTrustedSources(history, sources, trusted);
     return EngineEvent.removeTrustedSourceRequestSucceeded(source);

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -196,7 +196,6 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> setSources(
-    List<SourceReacted> sources, // TODO remove
     Set<Source> excluded,
     Set<Source> trusted,
   ) async {
@@ -231,7 +230,6 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> addExcludedSource(
-    List<SourceReacted> sources, // TODO remove
     Source excluded,
   ) async {
     final result = await asyncFfi.addExcludedSource(
@@ -244,7 +242,6 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> removeExcludedSource(
-    List<SourceReacted> sources, // TODO remove
     Source excluded,
   ) async {
     final result = await asyncFfi.removeExcludedSource(
@@ -257,7 +254,6 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> addTrustedSource(
-    List<SourceReacted> sources, // TODO remove
     Source trusted,
   ) async {
     final result = await asyncFfi.addTrustedSource(
@@ -270,7 +266,6 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> removeTrustedSource(
-    List<SourceReacted> sources, // TODO remove
     Source trusted,
   ) async {
     final result = await asyncFfi.removeTrustedSource(
@@ -282,11 +277,8 @@ class DiscoveryEngineFfi implements Engine {
   }
 
   @override
-  Future<List<DocumentWithActiveData>> feedNextBatch(
-    final List<SourceReacted> sources, // TODO remove
-  ) async {
-    final result =
-        await asyncFfi.feedNextBatch(_engine.ref);
+  Future<List<DocumentWithActiveData>> feedNextBatch() async {
+    final result = await asyncFfi.feedNextBatch(_engine.ref);
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)

--- a/discovery_engine/lib/src/ffi/types/engine.dart
+++ b/discovery_engine/lib/src/ffi/types/engine.dart
@@ -196,13 +196,12 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> setSources(
-    List<SourceReacted> sources,
+    List<SourceReacted> sources, // TODO remove
     Set<Source> excluded,
     Set<Source> trusted,
   ) async {
     final result = await asyncFfi.setSources(
       _engine.ref,
-      sources.allocVec().move(),
       excluded.toStringList().allocNative().move(),
       trusted.toStringList().allocNative().move(),
     );
@@ -232,12 +231,11 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> addExcludedSource(
-    List<SourceReacted> sources,
+    List<SourceReacted> sources, // TODO remove
     Source excluded,
   ) async {
     final result = await asyncFfi.addExcludedSource(
       _engine.ref,
-      sources.allocVec().move(),
       excluded.toString().allocNative().move(),
     );
 
@@ -246,12 +244,11 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> removeExcludedSource(
-    List<SourceReacted> sources,
+    List<SourceReacted> sources, // TODO remove
     Source excluded,
   ) async {
     final result = await asyncFfi.removeExcludedSource(
       _engine.ref,
-      sources.allocVec().move(),
       excluded.toString().allocNative().move(),
     );
 
@@ -260,12 +257,11 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> addTrustedSource(
-    List<SourceReacted> sources,
+    List<SourceReacted> sources, // TODO remove
     Source trusted,
   ) async {
     final result = await asyncFfi.addTrustedSource(
       _engine.ref,
-      sources.allocVec().move(),
       trusted.toString().allocNative().move(),
     );
 
@@ -274,12 +270,11 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<void> removeTrustedSource(
-    List<SourceReacted> sources,
+    List<SourceReacted> sources, // TODO remove
     Source trusted,
   ) async {
     final result = await asyncFfi.removeTrustedSource(
       _engine.ref,
-      sources.allocVec().move(),
       trusted.toString().allocNative().move(),
     );
 
@@ -288,10 +283,10 @@ class DiscoveryEngineFfi implements Engine {
 
   @override
   Future<List<DocumentWithActiveData>> feedNextBatch(
-    final List<SourceReacted> sources,
+    final List<SourceReacted> sources, // TODO remove
   ) async {
     final result =
-        await asyncFfi.feedNextBatch(_engine.ref, sources.allocVec().move());
+        await asyncFfi.feedNextBatch(_engine.ref);
 
     return resultVecDocumentStringFfiAdapter
         .consumeNative(result)

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -123,10 +123,7 @@ impl XaynDiscoveryEngineAsyncFfi {
 
     /// Gets the next batch of feed documents.
     #[allow(clippy::box_collection)]
-    pub async fn feed_next_batch(
-        engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
-    ) -> Box<Result<Vec<Document>, String>> {
+    pub async fn feed_next_batch(engine: &SharedEngine) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
@@ -401,7 +398,6 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Sets a new list of excluded and trusted sources.
     pub async fn set_sources(
         engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<Vec<String>>,
         trusted: Box<Vec<String>>,
     ) -> Box<Result<(), String>> {
@@ -445,7 +441,6 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Adds a trusted source.
     pub async fn add_trusted_source(
         engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
         trusted: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -462,7 +457,6 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Removes a trusted source.
     pub async fn remove_trusted_source(
         engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
         trusted: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -479,7 +473,6 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Adds an excluded source.
     pub async fn add_excluded_source(
         engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -496,7 +489,6 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Removes an excluded source.
     pub async fn remove_excluded_source(
         engine: &SharedEngine,
-        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -125,14 +125,14 @@ impl XaynDiscoveryEngineAsyncFfi {
     #[allow(clippy::box_collection)]
     pub async fn feed_next_batch(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
     ) -> Box<Result<Vec<Document>, String>> {
         Box::new(
             engine
                 .as_ref()
                 .lock()
                 .await
-                .feed_next_batch(&sources)
+                .feed_next_batch()
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -401,7 +401,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Sets a new list of excluded and trusted sources.
     pub async fn set_sources(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<Vec<String>>,
         trusted: Box<Vec<String>>,
     ) -> Box<Result<(), String>> {
@@ -410,7 +410,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .set_sources(&sources, *excluded, *trusted)
+                .set_sources(*excluded, *trusted)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -445,7 +445,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Adds a trusted source.
     pub async fn add_trusted_source(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
         trusted: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -453,7 +453,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .add_trusted_source(&sources, *trusted)
+                .add_trusted_source(*trusted)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -462,7 +462,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Removes a trusted source.
     pub async fn remove_trusted_source(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
         trusted: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -470,7 +470,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .remove_trusted_source(&sources, *trusted)
+                .remove_trusted_source(*trusted)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -479,7 +479,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Adds an excluded source.
     pub async fn add_excluded_source(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -487,7 +487,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .add_excluded_source(&sources, *excluded)
+                .add_excluded_source(*excluded)
                 .await
                 .map_err(|error| error.to_string()),
         )
@@ -496,7 +496,7 @@ impl XaynDiscoveryEngineAsyncFfi {
     /// Removes an excluded source.
     pub async fn remove_excluded_source(
         engine: &SharedEngine,
-        sources: Box<Vec<WeightedSource>>,
+        _sources: Box<Vec<WeightedSource>>,
         excluded: Box<String>,
     ) -> Box<Result<(), String>> {
         Box::new(
@@ -504,7 +504,7 @@ impl XaynDiscoveryEngineAsyncFfi {
                 .as_ref()
                 .lock()
                 .await
-                .remove_excluded_source(&sources, *excluded)
+                .remove_excluded_source(*excluded)
                 .await
                 .map_err(|error| error.to_string()),
         )

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1959,7 +1959,7 @@ pub(crate) mod tests {
         )
         .await;
 
-        let documents = engine.feed_next_batch(&[]).await.unwrap();
+        let documents = engine.feed_next_batch().await.unwrap();
         assert!(!documents.is_empty());
 
         let state1 = engine.storage.state().fetch().await.unwrap();

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -503,10 +503,7 @@ impl Engine {
     /// Gets the next batch of feed documents.
     #[instrument(skip(self))]
     #[cfg_attr(not(feature = "storage"), allow(clippy::unused_async))]
-    pub async fn feed_next_batch(
-        &mut self,
-        sources: &[WeightedSource], // TODO remove
-    ) -> Result<Vec<Document>, Error> {
+    pub async fn feed_next_batch(&mut self) -> Result<Vec<Document>, Error> {
         #[cfg(feature = "storage")]
         {
             let history = self.storage.fetch_history().await?;
@@ -1214,7 +1211,6 @@ impl Engine {
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
     pub async fn set_sources(
         &mut self,
-        _sources: &[WeightedSource], // TODO remove
         excluded: Vec<String>,
         trusted: Vec<String>,
     ) -> Result<(), Error> {
@@ -1294,11 +1290,7 @@ impl Engine {
 
     /// Adds a trusted source.
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
-    pub async fn add_trusted_source(
-        &mut self,
-        _sources: &[WeightedSource], // TODO remove
-        new_trusted: String,
-    ) -> Result<(), Error> {
+    pub async fn add_trusted_source(&mut self, new_trusted: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
             let mut trusted = self.storage.source_preference().fetch_trusted().await?;
@@ -1336,11 +1328,7 @@ impl Engine {
 
     /// Removes a trusted source.
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
-    pub async fn remove_trusted_source(
-        &mut self,
-        _sources: &[WeightedSource], // TODO remove
-        trusted: String,
-    ) -> Result<(), Error> {
+    pub async fn remove_trusted_source(&mut self, trusted: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
             let mut trusted_set = self.storage.source_preference().fetch_trusted().await?;
@@ -1368,11 +1356,7 @@ impl Engine {
 
     /// Adds an excluded source.
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
-    pub async fn add_excluded_source(
-        &mut self,
-        _sources: &[WeightedSource], // TODO remove
-        new_excluded: String,
-    ) -> Result<(), Error> {
+    pub async fn add_excluded_source(&mut self, new_excluded: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
             let mut excluded = self.storage.source_preference().fetch_excluded().await?;
@@ -1409,11 +1393,7 @@ impl Engine {
 
     /// Removes an excluded source.
     #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
-    pub async fn remove_excluded_source(
-        &mut self,
-        _sources: &[WeightedSource],
-        excluded: String,
-    ) -> Result<(), Error> {
+    pub async fn remove_excluded_source(&mut self, excluded: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
             let mut excluded_set = self.storage.source_preference().fetch_excluded().await?;

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -507,7 +507,7 @@ impl Engine {
         #[cfg(feature = "storage")]
         {
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
 
             // TODO: merge `get_feed_documents()` into this method after DB migration
             self.get_feed_documents(&history, &sources).await
@@ -770,7 +770,7 @@ impl Engine {
             #[cfg(feature = "storage")]
             let history = &self.storage.fetch_history().await?.into();
             #[cfg(feature = "storage")]
-            let sources = &self.storage.fetch_sources().await?;
+            let sources = &self.storage.fetch_weighted_sources().await?;
             if let Some(history) = history {
                 update_stacks(
                     &mut stacks,
@@ -1247,7 +1247,7 @@ impl Engine {
             }
 
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
             self.update_stacks_for_all_markets(&history, &sources, self.core_config.request_new)
                 .await
         }
@@ -1317,7 +1317,7 @@ impl Engine {
 
             *self.endpoint_config.trusted_sources.write().await = trusted.iter().cloned().collect();
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
             self.update_stacks_for_all_markets(&history, &sources, self.core_config.request_new)
                 .await
         }
@@ -1345,7 +1345,7 @@ impl Engine {
                 trusted_set.iter().cloned().collect();
 
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
             self.update_stacks_for_all_markets(&history, &sources, self.core_config.request_new)
                 .await
         }
@@ -1382,7 +1382,7 @@ impl Engine {
             self.filter_excluded_sources_for_all_stacks(&excluded).await;
 
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
             self.update_stacks_for_all_markets(&history, &sources, self.core_config.request_new)
                 .await
         }
@@ -1410,7 +1410,7 @@ impl Engine {
                 excluded_set.iter().cloned().collect();
 
             let history = self.storage.fetch_history().await?;
-            let sources = self.storage.fetch_sources().await?;
+            let sources = self.storage.fetch_weighted_sources().await?;
             self.update_stacks_for_all_markets(&history, &sources, self.core_config.request_new)
                 .await
         }

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use xayn_discovery_engine_ai::{GenericError, MalformedBytesEmbedding};
 
 use crate::{
-    document::{self, HistoricDocument, UserReaction, ViewMode},
+    document::{self, HistoricDocument, UserReaction, ViewMode, WeightedSource},
     stack,
     DartMigrationData,
     InitDbHint,
@@ -78,6 +78,8 @@ pub(crate) trait Storage {
     async fn clear_database(&self) -> Result<bool, Error>;
 
     async fn fetch_history(&self) -> Result<Vec<HistoricDocument>, Error>;
+
+    async fn fetch_sources(&self) -> Result<Vec<WeightedSource>, Error>;
 
     fn feed(&self) -> &(dyn FeedScope + Send + Sync);
 

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -79,7 +79,7 @@ pub(crate) trait Storage {
 
     async fn fetch_history(&self) -> Result<Vec<HistoricDocument>, Error>;
 
-    async fn fetch_sources(&self) -> Result<Vec<WeightedSource>, Error>;
+    async fn fetch_weighted_sources(&self) -> Result<Vec<WeightedSource>, Error>;
 
     fn feed(&self) -> &(dyn FeedScope + Send + Sync);
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -25,7 +25,7 @@ use url::Url;
 use xayn_discovery_engine_providers::Market;
 
 use crate::{
-    document::{self, HistoricDocument, UserReaction, ViewMode},
+    document::{self, HistoricDocument, UserReaction, ViewMode, WeightedSource},
     stack,
     storage::{
         models::{
@@ -361,6 +361,21 @@ impl Storage for SqliteStorage {
         tx.commit().await?;
 
         documents.into_iter().map(TryInto::try_into).collect()
+    }
+
+    async fn fetch_sources(&self) -> Result<Vec<WeightedSource>, Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let sources = sqlx::query_as::<_, QueriedSourceReaction>(
+            "SELECT source, weight, liked
+             FROM SourceReaction;",
+        )
+        .fetch_all(&mut tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(sources.into_iter().map(Into::into).collect())
     }
 
     fn feed(&self) -> &(dyn FeedScope + Send + Sync) {
@@ -923,6 +938,13 @@ struct QueriedSourceReaction {
     liked: bool,
 }
 
+impl From<QueriedSourceReaction> for WeightedSource {
+    fn from(queried_source: QueriedSourceReaction) -> Self {
+        let QueriedSourceReaction { source, weight, .. } = queried_source;
+        Self { source, weight }
+    }
+}
+
 #[async_trait]
 impl SourceReactionScope for SqliteStorage {
     async fn fetch_source_reaction(&self, source: &str) -> Result<Option<bool>, Error> {
@@ -949,7 +971,7 @@ impl SourceReactionScope for SqliteStorage {
         let mut tx = self.pool.begin().await?;
 
         sqlx::query(
-            "INSERT INTO SourceReaction (source, weight, lastUpdated, liked) VALUES (?, ?, ?, ?)",
+            "INSERT INTO SourceReaction (source, weight, lastUpdated, liked) VALUES (?, ?, ?, ?);",
         )
         .bind(source)
         .bind(weight)

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -363,7 +363,7 @@ impl Storage for SqliteStorage {
         documents.into_iter().map(TryInto::try_into).collect()
     }
 
-    async fn fetch_sources(&self) -> Result<Vec<WeightedSource>, Error> {
+    async fn fetch_weighted_sources(&self) -> Result<Vec<WeightedSource>, Error> {
         let mut tx = self.pool.begin().await?;
 
         let sources = sqlx::query_as::<_, QueriedSourceReaction>(


### PR DESCRIPTION
**Summary**

- previously #564 

ports the dart logic for source reactions to rust

- when `storage` feature is on, source reactions are fetched from the rust db.
- refactors various engine methods to exclude no longer needed `sources` argument.
- removes no longer needed source reaction repository calls on dart side. 