### PR TITLE
[Merged by Bors] - TO-3076 adjust dart source reaction logic when storage flag set

### DIFF
--- a/discovery_engine/lib/src/domain/document_manager.dart
+++ b/discovery_engine/lib/src/domain/document_manager.dart
@@ -79,8 +79,7 @@ class DocumentManager {
     if (cfgFeatureStorage) {
       final document = await _engine.userReacted(
         null,
-        //FIXME sources are not yet migrated
-        await _sourceRepo.fetchAll(),
+        [],
         // The engine will ignore all fields except the id and reaction,
         // but while we have feature flags we will still have to keep the
         // other fields intact. But we can pass dummy data.

--- a/discovery_engine/lib/src/domain/engine/engine.dart
+++ b/discovery_engine/lib/src/domain/engine/engine.dart
@@ -134,11 +134,11 @@ abstract class Engine {
 
   /// Process the user's reaction to a document.
   ///
-  /// The history is only required if the reaction is positive and if
+  /// The history and sources are required only if the reaction is positive and
   /// `cfgFeatureStorage` is disabled.
   ///
   /// The returned `Document` will only be consistent if `cfgFeatureStorage`
-  /// is enabled. The history and most fields of `UserReacted` can
+  /// is enabled. The history, sources and most fields of `userReacted` can
   /// be empty/dummy data if `cfgFeatureStorage` feature is enabled.
   Future<Document> userReacted(
     List<HistoricDocument>? history,

--- a/discovery_engine_core/bindings/src/lib.rs
+++ b/discovery_engine_core/bindings/src/lib.rs
@@ -203,7 +203,7 @@ impl XaynDiscoveryEngineAsyncFfi {
 
     /// Processes user reaction.
     ///
-    /// The history is only required for positive reactions.
+    /// The history and sources are required only for positive reactions.
     #[allow(clippy::box_collection)]
     pub async fn user_reacted(
         engine: &SharedEngine,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -668,7 +668,7 @@ impl Engine {
 
     /// Process the feedback about the user reacting to a document.
     ///
-    /// The history is only required for positive reactions.
+    /// The history and sources are required only for positive reactions.
     #[instrument(skip(self), level = "debug")]
     pub async fn user_reacted(
         &mut self,


### PR DESCRIPTION
**Summary**

- previously #584

the previous pr adjusted several methods in the feed manager to remove the fetching of source reactions from the repository which were no longer needed when the storage flag is set.

this pr similarly adjusts the document manager's `updateUserReaction` method