### PR TITLE
Add test that opens a second search after the first one

### DIFF
--- a/discovery_engine/test/integration/active_search_test.dart
+++ b/discovery_engine/test/integration/active_search_test.dart
@@ -203,6 +203,9 @@ void main() {
         (response2 as ActiveSearchRequestSucceeded).items,
         isNotEmpty,
       );
+
+      final restoreResponse = await engine.restoreActiveSearch();
+      expect(restoreResponse, isA<RestoreActiveSearchSucceeded>());
     });
   });
 }

--- a/discovery_engine/test/integration/active_search_test.dart
+++ b/discovery_engine/test/integration/active_search_test.dart
@@ -176,5 +176,33 @@ void main() {
         equals(SearchFailureReason.openActiveSearch),
       );
     });
+
+    test('start second search works', () async {
+      final response1 = await engine.requestQuerySearch('first search');
+
+      expect(response1, isA<ActiveSearchRequestSucceeded>());
+      expect(
+        (response1 as ActiveSearchRequestSucceeded).items,
+        isNotEmpty,
+      );
+
+      final closeResponse = await engine.closeActiveSearch();
+      expect(closeResponse, isA<ActiveSearchClosedSucceeded>());
+
+      final response = await engine.restoreActiveSearch();
+      expect(response, isA<RestoreActiveSearchFailed>());
+      expect(
+        (response as RestoreActiveSearchFailed).reason,
+        equals(SearchFailureReason.noActiveSearch),
+      );
+
+      final response2 = await engine.requestQuerySearch('second search');
+
+      expect(response2, isA<ActiveSearchRequestSucceeded>());
+      expect(
+        (response2 as ActiveSearchRequestSucceeded).items,
+        isNotEmpty,
+      );
+    });
   });
 }


### PR DESCRIPTION
We have a problem within the app with this use case.