### PR TITLE
TO-3317 Fix for engine state deserialization

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -197,19 +197,19 @@ impl NewsResource {
     }
 }
 
-/// NaiveDateTime tolerant deserialization of `DateTime<Utc>`.
+/// `NaiveDateTime` tolerant deserialization of `DateTime<Utc>`.
 fn deserialize_date_time_custom<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
+    const FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
     let s = String::deserialize(deserializer)?;
     Utc.datetime_from_str(&s, FORMAT)
         // .or(Ok(DateTime::<Utc>::MIN_UTC))
         // .map_err(|err| serde::de::Error::custom(format!("err: {}, s: {}", err, s)))
         .or_else(|_| {
-            let val = NaiveDateTime::parse_from_str(&s, FORMAT).unwrap_or(NaiveDateTime::default());
+            let val = NaiveDateTime::parse_from_str(&s, FORMAT).unwrap_or_default();
             let val = DateTime::<Utc>::from_utc(val, Utc);
             Ok(val)
         })

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -490,7 +490,7 @@ pub(crate) mod tests {
 
         assert_eq!(custom_deserializer.dt, DateTime::<Utc>::from_utc(dt, Utc));
 
-        let dt = NaiveDate::from_ymd(2022, 09, 12).and_hms(17, 28, 15);
+        let dt = NaiveDate::from_ymd(2022, 9, 12).and_hms(17, 28, 15);
         let dt = DateTime::<Utc>::from_utc(dt, Utc);
         let data = StructWithDateTime { dt };
         let bytes = bincode::serialize(&data).unwrap();

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use derive_more::Display;
 use displaydoc::Display as DisplayDoc;
@@ -202,9 +202,7 @@ fn deserialize_date_time_with_fallback<'de, D>(deserializer: D) -> Result<DateTi
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    Utc.datetime_from_str(&s, "%Y-%m-%d %H:%M:%S")
-        .or_else(|_| Ok(DateTime::<Utc>::default()))
+    DateTime::<Utc>::deserialize(deserializer).or_else(|_| Ok(DateTime::<Utc>::default()))
 }
 
 impl From<GenericArticle> for NewsResource {


### PR DESCRIPTION
**References**:
- [TO-3317]

**Summary**:
- after merging this change https://github.com/xaynetwork/xayn_discovery_engine/pull/578 old serialized engine state couldn't be deserialized without errors because of type change `NaiveDateTime` => `DateTime<Utc>`
- added a custom deserializer which doesn't return error when deserializer has parsing issues
- added test to cover this scenario

[TO-3317]: https://xainag.atlassian.net/browse/TO-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ