### PR TITLE
[Merged by Bors] - TO-3324 Fix potential data loss

### DIFF
--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -49,15 +49,6 @@ pub(crate) async fn handle_user_interaction(
     db: Db,
 ) -> Result<impl warp::Reply, Rejection> {
     if let Some(document) = db.documents_by_id.get(&body.document_id) {
-        let mut user_interests = db
-            .user_state
-            .fetch(&user_id)
-            .await
-            .map_err(handle_user_state_op_error)?;
-
-        db.coi
-            .log_positive_user_reaction(&mut user_interests.positive, &document.smbert_embedding);
-
         db.user_state
             .update_positive_cois(&user_id, |positive_cois| {
                 db.coi

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -59,7 +59,10 @@ pub(crate) async fn handle_user_interaction(
             .log_positive_user_reaction(&mut user_interests.positive, &document.smbert_embedding);
 
         db.user_state
-            .update(&user_id, &user_interests)
+            .update_positive_cois(&user_id, |positive_cois| {
+                db.coi
+                    .log_positive_user_reaction(positive_cois, &document.smbert_embedding)
+            })
             .await
             .map_err(handle_user_state_op_error)?;
 

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -153,8 +153,6 @@ impl UserState {
         .execute(&mut tx)
         .await?;
 
-        sqlx::query("COMMIT;").execute(&mut tx).await?;
-
         tx.commit().await?;
 
         Ok(())


### PR DESCRIPTION
**References**:
- [TO-3324]

**Summary**:
- replaces the `update` storage method with `update_positive_cois` which `SELECT`s all users' positive Centers of Interests `for UPDATE` which locks all the rows in our db to prevent potential data loss,
- when positive user reaction is logged, the resulting Center of Interest is either `INSERT`ed or `UPDATE`d depending if reaction logging created a new center or updated position of existing one,
- afterwards the transaction is commited

[TO-3324]: https://xainag.atlassian.net/browse/TO-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ