### PR TITLE
[Merged by Bors] - By default enable storage for local builds/test/check.

### DIFF
--- a/.env
+++ b/.env
@@ -26,3 +26,6 @@ CARGO_SORT_VERSION=1.0.7
 RUST_NIGHTLY=nightly-2022-07-16
 # cargo install will install CLI tools into this directory
 CARGO_INSTALL_ROOT=cargo-installs
+
+# by default enable the feature
+XAYN_DE_FEATURES=storage

--- a/.github/workflows/_reusable.build-android.yml
+++ b/.github/workflows/_reusable.build-android.yml
@@ -43,10 +43,10 @@ jobs:
         run: |
           ARTIFACT_DIR_BASE=${{ github.job }}
           if ${{ inputs.production }}; then
-            just compile-android-ci "${{ matrix.target }}" --prod
+            XAYN_DE_FEATURES="" just compile-android-ci "${{ matrix.target }}" --prod
             ARTIFACT_DIR_BASE="${ARTIFACT_DIR_BASE}-production"
           else
-            just compile-android-ci "${{ matrix.target }}"
+            XAYN_DE_FEATURES="" just compile-android-ci "${{ matrix.target }}"
           fi
           echo "::set-output name=artifact-dir-base::$ARTIFACT_DIR_BASE"
 

--- a/.github/workflows/_reusable.build-ios.yml
+++ b/.github/workflows/_reusable.build-ios.yml
@@ -41,10 +41,10 @@ jobs:
         run: |
           ARTIFACT_DIR_BASE=${{ github.job }}
           if ${{ inputs.production }}; then
-            just compile-ios-ci ${{ matrix.target }} --prod
+            XAYN_DE_FEATURES="" just compile-ios-ci ${{ matrix.target }} --prod
             ARTIFACT_DIR_BASE+="-production"
           else
-            just compile-ios-ci ${{ matrix.target }}
+            XAYN_DE_FEATURES="" just compile-ios-ci ${{ matrix.target }}
           fi
           echo "::set-output name=artifact-dir-base::$ARTIFACT_DIR_BASE"
 

--- a/.github/workflows/_reusable.dart.yml
+++ b/.github/workflows/_reusable.dart.yml
@@ -55,7 +55,7 @@ jobs:
           rust: true
 
       - name: Run tests without storage
-        run: just dart-test
+        run: XAYN_DE_FEATURES="" just dart-test
 
       - name: Run tests with storage
         run: XAYN_DE_FEATURES=storage just dart-test

--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -34,7 +34,7 @@ jobs:
           rust: true
 
       - name: rust check without storage
-        run: just rust-check
+        run: XAYN_DE_FEATURES="" just rust-check
 
       - name: rust check with storage
         run: XAYN_DE_FEATURES=storage just rust-check
@@ -56,7 +56,7 @@ jobs:
         run: just download-assets
 
       - name: Run tests without storage
-        run: just rust-test
+        run: XAYN_DE_FEATURES="" just rust-test
 
       - name: Run tests with storage
         run: XAYN_DE_FEATURES=storage just rust-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Generate Files
         shell: bash
-        run: just dart-build
+        run: XAYN_DE_FEATURES="" just dart-build
 
       - name: Release packages
         shell: bash


### PR DESCRIPTION
Still do not enable it for release builds.

Also still test for with and without the feature.

**Why?**

1. By now we should default to storage enabled by default for local testing.
2.  I recently ran to often into situations where I missed some merge caused problems
     which only where visible with `just check` creating additional friction.
     
**Why not check both?**

We do on CI. But locally the change->check/test loop is already WAY to long
doubling that time is IMHO just not acceptable at all.