### PR TITLE
[Merged by Bors] - TO-3292 adjust deep search to use mlt instead of kpe

### DIFF
--- a/discovery_engine/test/integration/utils/local_newsapi_server.dart
+++ b/discovery_engine/test/integration/utils/local_newsapi_server.dart
@@ -71,6 +71,7 @@ class LocalNewsApiServer {
         case ReplyWith.data:
           switch (request.uri.path) {
             case '/newscatcher/v1/search-news':
+            case '/_mlt':
               await _replyWithData(
                 request,
                 _snFiles.asMap()[_snCounter++] ?? 'search-news-empty.json',


### PR DESCRIPTION
**Summary**

deep search still uses kpe on the search term, followed by a query to the news provider.
this adjusts the method to bypass kpe and use the similar news provider instead.