### PR TITLE
[Merged by Bors] - TO-3323 remove liked column from source reaction table

### DIFF
--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -312,6 +312,7 @@ pub struct HistoricDocument {
 
 /// A source domain with an associated weight.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct WeightedSource {
     /// Source domain.
     pub source: String,

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -178,7 +178,7 @@ pub(crate) trait SourceReactionScope {
 
     async fn create_source_reaction(&self, source: &str, like: bool) -> Result<(), Error>;
 
-    async fn update_source_weight(&self, source: &str) -> Result<(), Error>;
+    async fn update_source_weight(&self, source: &str, add_weight: i32) -> Result<(), Error>;
 
     async fn delete_source_reaction(&self, source: &str) -> Result<(), Error>;
 }

--- a/discovery_engine_core/core/src/storage/migrations/20220823100617_source_reaction.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220823100617_source_reaction.sql
@@ -17,6 +17,4 @@ CREATE TABLE IF NOT EXISTS SourceReaction (
     weight INTEGER NOT NULL,
     -- format should be RFC3339/ISO8601 & sqlite compliant
     lastUpdated TEXT NOT NULL,
-    -- 0 = FALSE, 1 = TRUE
-    liked INTEGER NOT NULL
 );

--- a/discovery_engine_core/core/src/storage/migrations/20220823100617_source_reaction.sql
+++ b/discovery_engine_core/core/src/storage/migrations/20220823100617_source_reaction.sql
@@ -16,5 +16,5 @@ CREATE TABLE IF NOT EXISTS SourceReaction (
     source TEXT NOT NULL PRIMARY KEY,
     weight INTEGER NOT NULL,
     -- format should be RFC3339/ISO8601 & sqlite compliant
-    lastUpdated TEXT NOT NULL,
+    lastUpdated TEXT NOT NULL
 );

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -367,7 +367,7 @@ impl Storage for SqliteStorage {
         let mut tx = self.pool.begin().await?;
 
         let sources = sqlx::query_as::<_, QueriedSourceReaction>(
-            "SELECT source, weight, liked
+            "SELECT source, weight
              FROM SourceReaction;",
         )
         .fetch_all(&mut tx)


### PR DESCRIPTION
**Summary**

- reference: #584

removes redundant column `liked` from source reaction table and adjusts db logic accordingly.
based on [this suggestion](https://github.com/xaynetwork/xayn_discovery_engine/pull/584#pullrequestreview-1103920219).

also adds an overdue `test_source_reaction`.