### PR TITLE
[Merged by Bors] - TO-3301 Storage layer for ES

### DIFF
--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -1,0 +1,150 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use ndarray::Array;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use xayn_discovery_engine_ai::Embedding;
+
+use crate::models::{DocumentId, DocumentProperties, Error, PersonalizedDocument};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Config {
+    pub(crate) url: String,
+    pub(crate) index_name: String,
+    pub(crate) user: String,
+    pub(crate) password: String,
+}
+
+pub(crate) struct ElasticState {
+    config: Config,
+    client: Client,
+}
+
+#[allow(dead_code)]
+impl ElasticState {
+    pub(crate) fn new(config: Config) -> Self {
+        let client = Client::new();
+        Self { config, client }
+    }
+
+    pub(crate) async fn get_documents_by_embedding(
+        &self,
+        embedding: Embedding,
+    ) -> Result<Vec<PersonalizedDocument>, Error> {
+        // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/knn-search.html#approximate-knn
+        let body = json!({
+            "knn": {
+                "field": "embedding",
+                "query_vector": embedding.to_vec(),
+                // TODO: make below configurable
+                "k": 10,
+                "num_candidates": 100,
+            }
+        });
+
+        let response = self.query_elastic_search(body).await?;
+        Ok(convert_response(response))
+    }
+
+    pub(crate) async fn get_documents_by_ids(
+        &self,
+        ids: Vec<String>,
+    ) -> Result<Vec<PersonalizedDocument>, Error> {
+        // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/query-dsl-ids-query.html
+        let body = json!({
+            "query": {
+                "ids" : {
+                    "values" : ids
+                }
+            }
+        });
+
+        let response = self.query_elastic_search(body).await?;
+        Ok(convert_response(response))
+    }
+
+    async fn query_elastic_search(
+        &self,
+        body: Value,
+    ) -> Result<Response<ElasticDocumentData>, Error> {
+        let url = format!("{}/{}/_search", self.config.url, self.config.index_name,);
+
+        let res = self
+            .client
+            .post(url)
+            .basic_auth(&self.config.user, Some(&self.config.password))
+            .json(&body)
+            .send()
+            .await
+            .map_err(Error::Elastic)?
+            .error_for_status()
+            .map_err(Error::Elastic)?;
+
+        res.json().await.map_err(Error::Receiving)
+    }
+}
+
+fn convert_response(response: Response<ElasticDocumentData>) -> Vec<PersonalizedDocument> {
+    response
+        .hits
+        .hits
+        .into_iter()
+        .map(|hit| PersonalizedDocument {
+            id: DocumentId(hit.id),
+            score: hit.score,
+            embedding: Embedding::from(Array::from_vec(hit.source.embedding)),
+            properties: hit.source.properties,
+        })
+        .collect()
+}
+
+/// Represents a document with calculated embeddings that is stored in Elastic Search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ElasticDocumentData {
+    snippet: String,
+    properties: DocumentProperties,
+    embedding: Vec<f32>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[allow(dead_code)]
+struct Response<T> {
+    hits: Hits<T>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[allow(dead_code)]
+struct Hits<T> {
+    hits: Vec<Hit<T>>,
+    total: Total,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[allow(dead_code)]
+struct Hit<T> {
+    #[serde(rename(deserialize = "_id"))]
+    id: String,
+    #[serde(rename(deserialize = "_source"))]
+    source: T,
+    #[serde(rename(deserialize = "_score"))]
+    score: f32,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+#[allow(dead_code)]
+struct Total {
+    value: usize,
+}

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -18,7 +18,7 @@ use xayn_discovery_engine_ai::{utils::rank, GenericError};
 
 use crate::{
     db::Db,
-    models::{Article, InteractionRequestBody, UserId},
+    models::{InteractionRequestBody, UserId},
 };
 
 pub(crate) async fn handle_ranked_documents(
@@ -37,12 +37,7 @@ pub(crate) async fn handle_ranked_documents(
     let scores = db.coi.score(&documents, &user_interests).unwrap();
     rank(&mut documents, &scores);
 
-    let articles = documents
-        .into_iter()
-        .map(Article::from)
-        .collect::<Vec<Article>>();
-
-    Ok(warp::reply::json(&articles))
+    Ok(warp::reply::json(&documents))
 }
 
 pub(crate) async fn handle_user_interaction(
@@ -54,7 +49,7 @@ pub(crate) async fn handle_user_interaction(
         db.user_state
             .update_positive_cois(&user_id, |positive_cois| {
                 db.coi
-                    .log_positive_user_reaction(positive_cois, &document.smbert_embedding)
+                    .log_positive_user_reaction(positive_cois, &document.embedding)
             })
             .await
             .map_err(handle_user_state_op_error)?;

--- a/discovery_engine_core/web-api/src/main.rs
+++ b/discovery_engine_core/web-api/src/main.rs
@@ -38,6 +38,7 @@ use routes::api_routes;
 use storage::UserState;
 
 mod db;
+mod elastic;
 mod handlers;
 mod models;
 mod routes;
@@ -60,6 +61,11 @@ async fn main() -> Result<(), GenericError> {
         .unwrap_or_else(|_| "0.0.0.0".to_string())
         .parse::<IpAddr>()?;
 
+    let elastic_url = env::var("ELASTIC_URL")?;
+    let elastic_index_name = env::var("ELASTIC_INDEX_NAME")?;
+    let elastic_user = env::var("ELASTIC_USER")?;
+    let elastic_password = env::var("ELASTIC_PASSWORD")?;
+
     let user_state = UserState::connect(&pg_url).await?;
     user_state.init_database().await?;
 
@@ -68,6 +74,12 @@ async fn main() -> Result<(), GenericError> {
         smbert_model,
         data_store,
         user_state,
+        elastic: elastic::Config {
+            url: elastic_url,
+            index_name: elastic_index_name,
+            user: elastic_user,
+            password: elastic_password,
+        },
     };
     let db = init_db(&config)?;
     let routes = api_routes(db);

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -17,10 +17,8 @@ use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr, string::FromUtf8Error};
 use thiserror::Error;
-use uuid::Uuid;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
-use xayn_discovery_engine_core::document::Id;
 
 /// Web API errors.
 #[derive(Error, Debug, DisplayDoc)]
@@ -73,8 +71,8 @@ impl PersonalizedDocument {
     }
 }
 
-impl AiDocument for Document {
-    type Id = Id;
+impl AiDocument for PersonalizedDocument {
+    type Id = DocumentId;
 
     fn id(&self) -> &Self::Id {
         &self.id


### PR DESCRIPTION
**References**:
- [TO-3301]

**Follow-up**:
- #610

**Summary**:
- adds storage layer for fetching data from Elastic Search
- adopts some data models to be compliant with API spec
- adjusts code in preparation for [TO-3302] and [TO-3303]

[TO-3301]: https://xainag.atlassian.net/browse/TO-3301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-3302]: https://xainag.atlassian.net/browse/TO-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-3303]: https://xainag.atlassian.net/browse/TO-3303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ