### PR TITLE
[Merged by Bors] - more general coi system

### DIFF
--- a/discovery_engine_core/ai/ai/src/coi/context.rs
+++ b/discovery_engine_core/ai/ai/src/coi/context.rs
@@ -34,7 +34,7 @@ use crate::{
 
 #[derive(Error, Debug, Display)]
 #[allow(clippy::enum_variant_names)]
-pub(crate) enum Error {
+pub enum Error {
     /// Not enough cois
     NotEnoughCois,
     /// Failed to find the closest cois

--- a/discovery_engine_core/ai/ai/src/coi/context.rs
+++ b/discovery_engine_core/ai/ai/src/coi/context.rs
@@ -30,7 +30,6 @@ use crate::{
     document::Document,
     embedding::Embedding,
     utils::system_time_now,
-    DocumentId,
 };
 
 #[derive(Error, Debug, Display)]
@@ -179,11 +178,11 @@ fn has_enough_cois(
 ///
 /// # Errors
 /// Fails if the required number of positive or negative cois is not present.
-pub(crate) fn compute_scores_for_docs(
-    documents: &[impl Document],
+pub(crate) fn compute_scores_for_docs<T: Document>(
+    documents: &[T],
     user_interests: &UserInterests,
     config: &Config,
-) -> Result<HashMap<DocumentId, f32>, Error> {
+) -> Result<HashMap<T::Id, f32>, Error> {
     if !has_enough_cois(
         user_interests,
         config.min_positive_cois(),

--- a/discovery_engine_core/ai/ai/src/coi/context.rs
+++ b/discovery_engine_core/ai/ai/src/coi/context.rs
@@ -201,7 +201,7 @@ pub(crate) fn compute_scores_for_docs<T: Document>(
                 config.horizon(),
                 now,
             )?;
-            Ok((document.id(), score))
+            Ok((document.id().clone(), score))
         })
         .collect()
 }

--- a/discovery_engine_core/ai/ai/src/coi/system.rs
+++ b/discovery_engine_core/ai/ai/src/coi/system.rs
@@ -94,7 +94,7 @@ impl System {
     /// Return the score of each document given the interests of the user.
     pub fn score<D>(
         &self,
-        documents: &mut [D],
+        documents: &[D],
         user_interests: &UserInterests,
     ) -> Result<HashMap<D::Id, f32>, context::Error>
     where
@@ -196,18 +196,18 @@ mod tests {
             .with_min_negative_cois(1)
             .build();
 
-        let scores = system.score(&mut documents, &user_interests).unwrap();
+        let scores = system.score(&documents, &user_interests).unwrap();
         utils::rank(&mut documents, &scores);
 
-        assert_eq!(documents[0].id(), DocumentId::from_u128(1));
-        assert_eq!(documents[1].id(), DocumentId::from_u128(3));
-        assert_eq!(documents[2].id(), DocumentId::from_u128(2));
-        assert_eq!(documents[3].id(), DocumentId::from_u128(0));
+        assert_eq!(*documents[0].id(), DocumentId::from_u128(1));
+        assert_eq!(*documents[1].id(), DocumentId::from_u128(3));
+        assert_eq!(*documents[2].id(), DocumentId::from_u128(2));
+        assert_eq!(*documents[3].id(), DocumentId::from_u128(0));
     }
 
     #[test]
     fn test_rank_no_user_interests() {
-        let mut documents = vec![
+        let documents = vec![
             TestDocument::new(0, arr1(&[0., 0., 0.])),
             TestDocument::new(1, arr1(&[0., 0., 0.])),
             TestDocument::new(2, arr1(&[0., 0., 0.])),
@@ -215,6 +215,6 @@ mod tests {
         let user_interests = UserInterests::default();
         let system = Config::default().with_min_positive_cois(1).unwrap().build();
 
-        assert!(system.score(&mut documents, &user_interests).is_err());
+        assert!(system.score(&documents, &user_interests).is_err());
     }
 }

--- a/discovery_engine_core/ai/ai/src/document.rs
+++ b/discovery_engine_core/ai/ai/src/document.rs
@@ -30,8 +30,10 @@ impl From<Uuid> for DocumentId {
 
 /// Common document properties.
 pub trait Document {
+    type Id: std::fmt::Display + std::fmt::Debug + Eq + std::hash::Hash;
+
     /// Gets the document id.
-    fn id(&self) -> DocumentId;
+    fn id(&self) -> Self::Id;
 
     /// Gets the `SMBert` embedding of the document.
     fn smbert_embedding(&self) -> &Embedding;
@@ -72,7 +74,9 @@ pub(crate) mod tests {
     }
 
     impl Document for TestDocument {
-        fn id(&self) -> DocumentId {
+        type Id = DocumentId;
+
+        fn id(&self) -> Self::Id {
             self.id
         }
 

--- a/discovery_engine_core/ai/ai/src/document.rs
+++ b/discovery_engine_core/ai/ai/src/document.rs
@@ -12,7 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, Utc};
 use derive_more::Display;
 use uuid::Uuid;
 
@@ -37,9 +36,6 @@ pub trait Document {
 
     /// Gets the `SMBert` embedding of the document.
     fn smbert_embedding(&self) -> &Embedding;
-
-    /// Gets the publishing date.
-    fn date_published(&self) -> DateTime<Utc>;
 }
 
 #[cfg(test)]
@@ -56,19 +52,13 @@ pub(crate) mod tests {
     pub(crate) struct TestDocument {
         pub(crate) id: DocumentId,
         pub(crate) smbert_embedding: Embedding,
-        pub(crate) date_published: DateTime<Utc>,
     }
 
     impl TestDocument {
-        pub(crate) fn new(
-            id: u128,
-            embedding: impl Into<Embedding>,
-            date_published: DateTime<Utc>,
-        ) -> Self {
+        pub(crate) fn new(id: u128, embedding: impl Into<Embedding>) -> Self {
             Self {
                 id: DocumentId::from_u128(id),
                 smbert_embedding: embedding.into(),
-                date_published,
             }
         }
     }
@@ -82,10 +72,6 @@ pub(crate) mod tests {
 
         fn smbert_embedding(&self) -> &Embedding {
             &self.smbert_embedding
-        }
-
-        fn date_published(&self) -> DateTime<Utc> {
-            self.date_published
         }
     }
 }

--- a/discovery_engine_core/ai/ai/src/document.rs
+++ b/discovery_engine_core/ai/ai/src/document.rs
@@ -29,10 +29,10 @@ impl From<Uuid> for DocumentId {
 
 /// Common document properties.
 pub trait Document {
-    type Id: std::fmt::Display + std::fmt::Debug + Eq + std::hash::Hash;
+    type Id: std::fmt::Display + std::fmt::Debug + Eq + std::hash::Hash + Clone;
 
     /// Gets the document id.
-    fn id(&self) -> Self::Id;
+    fn id(&self) -> &Self::Id;
 
     /// Gets the `SMBert` embedding of the document.
     fn smbert_embedding(&self) -> &Embedding;
@@ -66,8 +66,8 @@ pub(crate) mod tests {
     impl Document for TestDocument {
         type Id = DocumentId;
 
-        fn id(&self) -> Self::Id {
-            self.id
+        fn id(&self) -> &Self::Id {
+            &self.id
         }
 
         fn smbert_embedding(&self) -> &Embedding {

--- a/discovery_engine_core/ai/ai/src/lib.rs
+++ b/discovery_engine_core/ai/ai/src/lib.rs
@@ -36,7 +36,7 @@ mod document;
 mod embedding;
 mod error;
 mod kps;
-mod utils;
+pub mod utils;
 
 pub use crate::{
     coi::{

--- a/discovery_engine_core/ai/ai/src/utils.rs
+++ b/discovery_engine_core/ai/ai/src/utils.rs
@@ -82,10 +82,10 @@ pub(crate) fn system_time_now() -> SystemTime {
 pub fn rank<D, S>(documents: &mut [D], scores: &HashMap<D::Id, f32, S>)
 where
     D: Document,
-    S: ::std::hash::BuildHasher,
+    S: std::hash::BuildHasher,
 {
     documents.sort_unstable_by(|a, b| {
-        nan_safe_f32_cmp_desc(scores.get(&a.id()).unwrap(), scores.get(&b.id()).unwrap())
+        nan_safe_f32_cmp_desc(scores.get(a.id()).unwrap(), scores.get(b.id()).unwrap())
     });
 }
 

--- a/discovery_engine_core/ai/ai/src/utils.rs
+++ b/discovery_engine_core/ai/ai/src/utils.rs
@@ -12,7 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, time::SystemTime};
+use std::{cmp::Ordering, collections::HashMap, time::SystemTime};
+
+use crate::Document;
 
 /// Pretend that f32 has a total ordering.
 ///
@@ -71,6 +73,20 @@ pub(crate) const SECONDS_PER_DAY_U64: u64 = 86400;
 #[inline]
 pub(crate) fn system_time_now() -> SystemTime {
     SystemTime::now()
+}
+
+/// Rank documents based on their score.
+///
+/// # Panics
+/// This function will panic if a score for a document is missing.
+pub fn rank<D, S>(documents: &mut [D], scores: &HashMap<D::Id, f32, S>)
+where
+    D: Document,
+    S: ::std::hash::BuildHasher,
+{
+    documents.sort_unstable_by(|a, b| {
+        nan_safe_f32_cmp_desc(scores.get(&a.id()).unwrap(), scores.get(&b.id()).unwrap())
+    });
 }
 
 pub(crate) mod serde_duration_as_days {

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use chrono::{offset::Utc, DateTime};
 use derivative::Derivative;
 use derive_more::Display;
 use displaydoc::Display as DisplayDoc;
@@ -134,10 +134,6 @@ impl AiDocument for Document {
 
     fn smbert_embedding(&self) -> &Embedding {
         &self.smbert_embedding
-    }
-
-    fn date_published(&self) -> DateTime<Utc> {
-        self.resource.date_published
     }
 }
 
@@ -361,11 +357,6 @@ impl AiDocument for TrendingTopic {
 
     fn smbert_embedding(&self) -> &Embedding {
         &self.smbert_embedding
-    }
-
-    fn date_published(&self) -> DateTime<Utc> {
-        // return a default value as there is no `date_published` for trending topics
-        DateTime::<Utc>::MIN_UTC
     }
 }
 

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -126,7 +126,9 @@ impl TryFrom<(GenericArticle, StackId, Embedding)> for Document {
 }
 
 impl AiDocument for Document {
-    fn id(&self) -> DocumentId {
+    type Id = DocumentId;
+
+    fn id(&self) -> Self::Id {
         self.id.into()
     }
 
@@ -351,7 +353,9 @@ impl TryFrom<(BingTopic, Embedding)> for TrendingTopic {
 }
 
 impl AiDocument for TrendingTopic {
-    fn id(&self) -> DocumentId {
+    type Id = DocumentId;
+
+    fn id(&self) -> Self::Id {
         self.id.into()
     }
 

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -126,10 +126,10 @@ impl TryFrom<(GenericArticle, StackId, Embedding)> for Document {
 }
 
 impl AiDocument for Document {
-    type Id = DocumentId;
+    type Id = Id;
 
-    fn id(&self) -> Self::Id {
-        self.id.into()
+    fn id(&self) -> &Self::Id {
+        &self.id
     }
 
     fn smbert_embedding(&self) -> &Embedding {
@@ -349,10 +349,10 @@ impl TryFrom<(BingTopic, Embedding)> for TrendingTopic {
 }
 
 impl AiDocument for TrendingTopic {
-    type Id = DocumentId;
+    type Id = Id;
 
-    fn id(&self) -> Self::Id {
-        self.id.into()
+    fn id(&self) -> &Self::Id {
+        &self.id
     }
 
     fn smbert_embedding(&self) -> &Embedding {

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -33,14 +33,34 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument, Level};
 
 use xayn_discovery_engine_ai::{
-    self, cosine_similarity, nan_safe_f32_cmp, CoiConfig, CoiSystem, Document as AiDocument,
-    Embedding, GenericError, KeyPhrase, KeyPhrases, KpsConfig, KpsSystem, UserInterests,
+    self,
+    cosine_similarity,
+    nan_safe_f32_cmp,
+    CoiConfig,
+    CoiSystem,
+    Document as AiDocument,
+    Embedding,
+    GenericError,
+    KeyPhrase,
+    KeyPhrases,
+    KpsConfig,
+    KpsSystem,
+    UserInterests,
 };
 use xayn_discovery_engine_bert::{AveragePooler, SMBert, SMBertConfig};
 use xayn_discovery_engine_kpe::{Config as KpeConfig, Pipeline as KPE};
 use xayn_discovery_engine_providers::{
-    clean_query, Filter, GenericArticle, HeadlinesQuery, Market, NewsQuery, Providers, RankLimit,
-    SimilarNewsQuery, TrendingTopic as BingTopic, TrendingTopicsQuery,
+    clean_query,
+    Filter,
+    GenericArticle,
+    HeadlinesQuery,
+    Market,
+    NewsQuery,
+    Providers,
+    RankLimit,
+    SimilarNewsQuery,
+    TrendingTopic as BingTopic,
+    TrendingTopicsQuery,
 };
 use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 
@@ -48,11 +68,24 @@ use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 use crate::storage::{self, sqlite::SqliteStorage, BoxedStorage, Storage};
 use crate::{
     config::{
-        de_config_from_json, de_config_from_json_with_defaults, CoreConfig, EndpointConfig,
-        ExplorationConfig, FeedConfig, InitConfig, SearchConfig, StackConfig,
+        de_config_from_json,
+        de_config_from_json_with_defaults,
+        CoreConfig,
+        EndpointConfig,
+        ExplorationConfig,
+        FeedConfig,
+        InitConfig,
+        SearchConfig,
+        StackConfig,
     },
     document::{
-        self, Document, HistoricDocument, TimeSpent, TrendingTopic, UserReacted, UserReaction,
+        self,
+        Document,
+        HistoricDocument,
+        TimeSpent,
+        TrendingTopic,
+        UserReacted,
+        UserReaction,
         WeightedSource,
     },
     mab::{self, BetaSampler, Bucket, SelectionIter, UniformSampler},
@@ -60,13 +93,26 @@ use crate::{
         self,
         exploration::Stack as Exploration,
         filters::{
-            filter_semantically, ArticleFilter, Criterion, DuplicateFilter, MalformedFilter,
+            filter_semantically,
+            ArticleFilter,
+            Criterion,
+            DuplicateFilter,
+            MalformedFilter,
             SemanticFilterConfig,
         },
-        BoxedOps, BreakingNews, Data as StackData, Id as StackId, Id, NewItemsError, Ops,
-        PersonalizedNews, Stack, TrustedNews,
+        BoxedOps,
+        BreakingNews,
+        Data as StackData,
+        Id as StackId,
+        Id,
+        NewItemsError,
+        Ops,
+        PersonalizedNews,
+        Stack,
+        TrustedNews,
     },
-    DartMigrationData, InitDbHint,
+    DartMigrationData,
+    InitDbHint,
 };
 
 /// Discovery engine errors.
@@ -1403,7 +1449,12 @@ fn rank_documents(coi: &CoiSystem, user_interests: &UserInterests, documents: &m
     rank(
         coi,
         user_interests,
-    |a, b| a.resource.date_published.cmp(&b.resource.date_published).reverse(),
+        |a, b| {
+            a.resource
+                .date_published
+                .cmp(&b.resource.date_published)
+                .reverse()
+        },
         documents,
     );
 }
@@ -1711,12 +1762,14 @@ pub(crate) mod tests {
     use std::mem::size_of;
 
     use async_once_cell::OnceCell;
-    use chrono::{TimeZone, Utc, Datelike};
+    use chrono::{Datelike, TimeZone, Utc};
     use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
     use url::Url;
     use wiremock::{
         matchers::{method, path_regex},
-        Mock, MockServer, ResponseTemplate,
+        Mock,
+        MockServer,
+        ResponseTemplate,
     };
 
     use crate::{document::tests::mock_generic_article, stack::ops::MockOps};
@@ -2243,11 +2296,7 @@ pub(crate) mod tests {
         let coi = CoiConfig::default().build();
         let user_interests = UserInterests::default();
 
-        rank_documents(
-            &coi,
-            &user_interests,
-            &mut documents,
-        );
+        rank_documents(&coi, &user_interests, &mut documents);
 
         assert_eq!(documents[0].resource.date_published.year(), 2022);
         assert_eq!(documents[1].resource.date_published.year(), 2021);

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -14,7 +14,7 @@
 
 use warp::{hyper::StatusCode, reject::Reject, Rejection};
 
-use xayn_discovery_engine_ai::GenericError;
+use xayn_discovery_engine_ai::{utils::rank, GenericError};
 
 use crate::{
     db::Db,
@@ -33,7 +33,9 @@ pub(crate) async fn handle_ranked_documents(
 
     let mut documents = db.documents.clone();
 
-    db.coi.rank(&mut documents, &user_interests);
+    // TODO TO-3339: Return 500 with the correct kind if this fail
+    let scores = db.coi.score(&mut documents, &user_interests).unwrap();
+    rank(&mut documents, &scores);
 
     let articles = documents
         .into_iter()

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -34,7 +34,7 @@ pub(crate) async fn handle_ranked_documents(
     let mut documents = db.documents.clone();
 
     // TODO TO-3339: Return 500 with the correct kind if this fail
-    let scores = db.coi.score(&mut documents, &user_interests).unwrap();
+    let scores = db.coi.score(&documents, &user_interests).unwrap();
     rank(&mut documents, &scores);
 
     let articles = documents

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, str::FromStr, string::FromUtf8Error};
 use thiserror::Error;
 use uuid::Uuid;
 
-use xayn_discovery_engine_ai::{Document as AiDocument, DocumentId, Embedding};
+use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
 use xayn_discovery_engine_core::document::Id;
 
 /// Web API errors.
@@ -61,8 +61,10 @@ impl Document {
 }
 
 impl AiDocument for Document {
-    fn id(&self) -> DocumentId {
-        self.id.into()
+    type Id = Id;
+
+    fn id(&self) -> Self::Id {
+        self.id
     }
 
     fn smbert_embedding(&self) -> &Embedding {

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -12,7 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use chrono::{DateTime, Utc};
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
@@ -69,10 +68,6 @@ impl AiDocument for Document {
 
     fn smbert_embedding(&self) -> &Embedding {
         &self.smbert_embedding
-    }
-
-    fn date_published(&self) -> DateTime<Utc> {
-        Utc::now()
     }
 }
 

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -62,8 +62,8 @@ impl Document {
 impl AiDocument for Document {
     type Id = Id;
 
-    fn id(&self) -> Self::Id {
-        self.id
+    fn id(&self) -> &Self::Id {
+        &self.id
     }
 
     fn smbert_embedding(&self) -> &Embedding {


### PR DESCRIPTION
This PR:
* allows using an arbitrary type for the id in the coi system
* it removed `published_date` field from the trait `Document`. To do this now the CoI system does not handle the ranking anymore it only returns the score. Ranking is done in a util function that can be used in both the web-api and the engine. In the engine, we handle the case where we use the published date as default when we don't have enough coi.

The PR is divided in two commits, one for each point above.