### PR TITLE
TO-3325 save interacted documents

### DIFF
--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -52,7 +52,7 @@ pub(crate) async fn handle_user_interaction(
 ) -> Result<impl warp::Reply, Rejection> {
     if let Some(document) = db.documents_by_id.get(&body.document_id) {
         db.user_state
-            .update_positive_cois(&user_id, |positive_cois| {
+            .update_positive_cois(&body.document_id, &user_id, |positive_cois| {
                 db.coi
                     .log_positive_user_reaction(positive_cois, &document.smbert_embedding)
             })

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -52,7 +52,7 @@ pub(crate) async fn handle_user_interaction(
 ) -> Result<impl warp::Reply, Rejection> {
     if let Some(document) = db.documents_by_id.get(&body.document_id) {
         db.user_state
-            .update_positive_cois(&body.document_id, &user_id, |positive_cois| {
+            .update_positive_cois(&document.id, &user_id, |positive_cois| {
                 db.coi
                     .log_positive_user_reaction(positive_cois, &document.smbert_embedding)
             })

--- a/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
@@ -17,3 +17,6 @@ CREATE TABLE IF NOT EXISTS document (
     user_id TEXT NOT NULL,
     PRIMARY KEY (doc_id, user_id)
 );
+
+CREATE INDEX IF NOT EXISTS idx_doc_by_user_id
+    ON document(user_id);

--- a/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
@@ -12,12 +12,12 @@
 --  You should have received a copy of the GNU Affero General Public License
 --  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-CREATE TABLE IF NOT EXISTS document (
+CREATE TABLE IF NOT EXISTS interaction (
     doc_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
-    last_view TIMESTAMPTZ NOT NULL DEFAULT Now(),
-    user_reaction SMALLINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (doc_id, user_id)
+    time_stamp TIMESTAMPTZ NOT NULL DEFAULT Now(),
+    user_reaction SMALLINT NOT NULL,
+    PRIMARY KEY (doc_id, user_id, time_stamp)
 );
 
 CREATE INDEX IF NOT EXISTS idx_doc_by_user_id

--- a/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
@@ -1,0 +1,19 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS document (
+    doc_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    PRIMARY KEY (doc_id, user_id)
+);

--- a/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api/src/migrations/20220926145400_document.sql
@@ -15,6 +15,8 @@
 CREATE TABLE IF NOT EXISTS document (
     doc_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
+    last_view TIMESTAMPTZ NOT NULL DEFAULT Now(),
+    user_reaction SMALLINT NOT NULL DEFAULT 0,
     PRIMARY KEY (doc_id, user_id)
 );
 

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -129,3 +129,10 @@ impl FromStr for UserId {
         UserId::new(value)
     }
 }
+
+#[repr(u8)]
+pub(crate) enum UserReaction {
+    Positive = xayn_discovery_engine_core::document::UserReaction::Positive as u8,
+    #[allow(dead_code)]
+    Negative = xayn_discovery_engine_core::document::UserReaction::Negative as u8,
+}

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -47,7 +47,7 @@ fn validate_id_from_string(id: impl AsRef<str>) -> Result<(), IdValidationError>
 }
 
 /// Unique document for the user.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display, Deref)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display, Deref, AsRef)]
 pub(crate) struct DocumentId(String);
 
 impl DocumentId {

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -31,9 +31,8 @@ use xayn_discovery_engine_ai::{
     PositiveCoi,
     UserInterests,
 };
-use xayn_discovery_engine_core::document::UserReaction;
 
-use crate::models::UserId;
+use crate::models::{UserId, UserReaction};
 
 #[derive(Debug, Clone)]
 pub(crate) struct UserState {
@@ -156,10 +155,9 @@ impl UserState {
         .await?;
 
         sqlx::query(
-            "INSERT INTO document (doc_id, user_id, last_view, user_reaction)
+            "INSERT INTO interaction (doc_id, user_id, time_stamp, user_reaction)
             VALUES ($1, $2, $3, $4)
-            ON CONFLICT (doc_id, user_id) DO UPDATE SET
-                last_view = EXCLUDED.last_view,
+            ON CONFLICT (doc_id, user_id, time_stamp) DO UPDATE SET
                 user_reaction = EXCLUDED.user_reaction;",
         )
         .bind(doc_id)
@@ -182,7 +180,7 @@ impl UserState {
             .await?
             .rows_affected()
             > 0;
-        let deletion = sqlx::query("DELETE FROM document;")
+        let deletion = sqlx::query("DELETE FROM interaction;")
             .execute(&mut tx)
             .await?
             .rows_affected()

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -31,6 +31,7 @@ use xayn_discovery_engine_ai::{
     PositiveCoi,
     UserInterests,
 };
+use xayn_discovery_engine_core::document::UserReaction;
 
 use crate::models::UserId;
 
@@ -155,12 +156,16 @@ impl UserState {
         .await?;
 
         sqlx::query(
-            "INSERT INTO document (doc_id, user_id)
-            VALUES ($1, $2)
-            ON CONFLICT (doc_id, user_id) DO NOTHING;",
+            "INSERT INTO document (doc_id, user_id, last_view, user_reaction)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (doc_id, user_id) DO UPDATE SET
+                last_view = EXCLUDED.last_view,
+                user_reaction = EXCLUDED.user_reaction;",
         )
         .bind(doc_id)
         .bind(user_id.as_ref())
+        .bind(timestamp)
+        .bind(UserReaction::Positive as i16)
         .execute(&mut tx)
         .await?;
 

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -32,7 +32,7 @@ use xayn_discovery_engine_ai::{
     UserInterests,
 };
 
-use crate::models::{UserId, UserReaction};
+use crate::models::{DocumentId, UserId, UserReaction};
 
 #[derive(Debug, Clone)]
 pub(crate) struct UserState {
@@ -97,7 +97,7 @@ impl UserState {
 
     pub(crate) async fn update_positive_cois<F>(
         &self,
-        doc_id: &str,
+        doc_id: &DocumentId,
         user_id: &UserId,
         update_cois: F,
     ) -> Result<(), GenericError>
@@ -160,7 +160,7 @@ impl UserState {
             ON CONFLICT (doc_id, user_id, time_stamp) DO UPDATE SET
                 user_reaction = EXCLUDED.user_reaction;",
         )
-        .bind(doc_id)
+        .bind(doc_id.as_ref())
         .bind(user_id.as_ref())
         .bind(timestamp)
         .bind(UserReaction::Positive as i16)


### PR DESCRIPTION
**References**

- [TO-3325]
- requires #616

**Summary**

- store interacted document and user ids in a table via a n:n relation


[TO-3325]: https://xainag.atlassian.net/browse/TO-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ