### PR TITLE
Add DocumentId as String

### DIFF
--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -11,7 +11,7 @@ name = "ingestion"
 bincode = "1.3.3"
 bytes = { version = "1.2.1", features = ["serde"] }
 chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "as_ref"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from", "as_ref"] }
 displaydoc = "0.2.3"
 dotenvy = "0.15.1"
 envconfig = "0.10.0"

--- a/discovery_engine_core/web-api/src/db.rs
+++ b/discovery_engine_core/web-api/src/db.rs
@@ -19,7 +19,7 @@ use xayn_discovery_engine_bert::{AveragePooler, SMBert, SMBertConfig};
 use xayn_discovery_engine_tokenizer::{AccentChars, CaseChars};
 
 use crate::{
-    models::{Article, Document},
+    models::{Article, Document, DocumentId},
     storage::UserState,
 };
 
@@ -99,7 +99,7 @@ pub(crate) fn init_db(config: &InitConfig) -> Result<Db, GenericError> {
                 .as_str()
                 .expect("The 'description' field needs to be represented as String");
             let embedding = smbert.run(description).unwrap();
-            let document = Document::new((article, embedding));
+            let document = Document::new(DocumentId::new(article_id.clone()).unwrap(/* checked above. This code will be removed */), article, embedding);
             (article_id, document)
         })
         .collect();

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -114,7 +114,7 @@ pub(crate) struct UserId(String);
 
 impl UserId {
     fn new(id: &str) -> Result<Self, IdValidationError> {
-        let id = urlencoding::decode(&id).map_err(IdValidationError::InvalidUtf8)?;
+        let id = urlencoding::decode(id).map_err(IdValidationError::InvalidUtf8)?;
 
         validate_id_from_string(&*id)?;
 

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -113,7 +113,7 @@ pub(crate) struct InteractionRequestBody {
 pub(crate) struct UserId(String);
 
 impl UserId {
-    fn new(id: String) -> Result<Self, IdValidationError> {
+    fn new(id: &str) -> Result<Self, IdValidationError> {
         let id = urlencoding::decode(&id).map_err(IdValidationError::InvalidUtf8)?;
 
         validate_id_from_string(&*id)?;
@@ -126,6 +126,6 @@ impl FromStr for UserId {
     type Err = IdValidationError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        UserId::new(value.to_string())
+        UserId::new(value)
     }
 }


### PR DESCRIPTION
For the web api we use ids that are strings.
This adds a DocumentId that wraps a String and removes the need to use uuid.

This is based on #612.