### PR TITLE
TO-3318 return request id on error

### DIFF
--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -177,6 +177,9 @@ macro_rules! handle4 {
             $handle(t1, t2, t3, t4)
                 .instrument(span)
                 .await
+                //FIXME handle our errors here, and then handle rejection separately
+                // by turning them into Reponses and then grabbing the status code
+                // and the text body from the response to create our response.
                 .or_else(|err| handle_rejection(err, id))
         }
     };

--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -357,7 +357,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     // Requires the request to be wrapped into a
     // span with a `log.id` field.
     let log_id = Span::current()
-        .field("log.id")
+        .field("log_id")
         .map(|f| f.to_string())
         .unwrap_or_default();
 
@@ -379,9 +379,9 @@ fn trace_requests_with_random_id(request_info: warp::trace::Info<'_>) -> Span {
         path = %request_info.path(),
         version = ?request_info.version(),
         // Linked to rejection handling which will include
-        // the spans "log.id" field in error response bodies.
+        // the spans "log_id" field in error response bodies.
         //FIXME use v6/v7 once supported/standardized
-        log.id = %Uuid::new_v4(),
+        log_id = %Uuid::new_v4(),
     );
 
     //keep same wording as in `warp::trace::request()` for forward/backward compatibility


### PR DESCRIPTION
Adds a random per-request uuid to all log messages and return it in case of an error.

There will be an follow up PR to improve/fix some other aspects of the error handling.

With the refactoring needed for [TO-3305] this will be made available for all endpoints instead of just the ingestion endpoint.

**References:**
- [TO-3318]

[TO-3318]: https://xainag.atlassian.net/browse/TO-3318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TO-3305]: https://xainag.atlassian.net/browse/TO-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ