### PR TITLE
[Merged by Bors] - Remove DELETE /internal_state

### DIFF
--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -60,14 +60,6 @@ pub(crate) async fn handle_user_interaction(
     }
 }
 
-pub(crate) async fn handle_clean_state(db: Db) -> Result<impl warp::Reply, Rejection> {
-    db.user_state
-        .clear()
-        .await
-        .map_err(handle_user_state_op_error)?;
-    Ok(StatusCode::OK)
-}
-
 fn handle_user_state_op_error(_: GenericError) -> Rejection {
     warp::reject::custom(UserStateOpError)
 }

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -18,9 +18,7 @@ use warp::{self, Filter, Rejection, Reply};
 use crate::{db::Db, handlers, models::UserId};
 
 pub(crate) fn api_routes(db: Db) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_ranked_documents(db.clone())
-        .or(post_user_interaction(db.clone()))
-        .or(delete_internal_state(db))
+    get_ranked_documents(db.clone()).or(post_user_interaction(db))
 }
 
 // GET /user/:user_id/documents
@@ -41,14 +39,6 @@ fn post_user_interaction(db: Db) -> impl Filter<Extract = impl Reply, Error = Re
         .and(warp::body::json())
         .and(with_db(db))
         .and_then(handlers::handle_user_interaction)
-}
-
-// DELETE /internal-state
-fn delete_internal_state(db: Db) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    warp::path("internal-state")
-        .and(warp::delete())
-        .and(with_db(db))
-        .and_then(handlers::handle_clean_state)
 }
 
 // PATH /user/:user_id

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -157,18 +157,6 @@ impl UserState {
 
         Ok(())
     }
-
-    pub(crate) async fn clear(&self) -> Result<bool, GenericError> {
-        let mut tx = self.pool.begin().await?;
-
-        let deletion = sqlx::query("DELETE FROM center_of_interest;")
-            .execute(&mut tx)
-            .await?;
-
-        tx.commit().await?;
-
-        Ok(deletion.rows_affected() > 0)
-    }
 }
 
 #[derive(FromRow)]


### PR DESCRIPTION
Clearing the internal state was there for the demo.
An endpoint like this does not have a place in a production system.