### PR TITLE
[Merged by Bors] - Decode user id in path only in route

### DIFF
--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -15,7 +15,7 @@
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, str::FromStr, string::FromUtf8Error};
+use std::{collections::HashMap, string::FromUtf8Error};
 use thiserror::Error;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
@@ -110,24 +110,16 @@ pub(crate) struct InteractionRequestBody {
 pub(crate) struct UserId(String);
 
 impl UserId {
-    fn new(value: &str) -> Result<Self, Error> {
-        let value = urlencoding::decode(value).map_err(Error::UserIdUtf8Conversion)?;
+    pub(crate) fn new(id: impl AsRef<str>) -> Result<Self, Error> {
+        let id = id.as_ref();
 
-        if value.trim().is_empty() {
+        if id.is_empty() {
             Err(Error::UserIdEmpty)
-        } else if value.contains('\u{0000}') {
+        } else if id.contains('\u{0000}') {
             Err(Error::UserIdContainsNul)
         } else {
-            Ok(Self(value.to_string()))
+            Ok(Self(id.to_string()))
         }
-    }
-}
-
-impl FromStr for UserId {
-    type Err = Error;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        UserId::new(value)
     }
 }
 

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -17,6 +17,7 @@ use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, string::FromUtf8Error};
 use thiserror::Error;
+use warp::reject::Reject;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
 
@@ -38,6 +39,7 @@ pub(crate) enum Error {
     /// Error receiving response: {0}
     Receiving(#[source] reqwest::Error),
 }
+impl Reject for Error {}
 
 /// A unique identifier of a document.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash, Display, AsRef)]

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -53,7 +53,7 @@ fn user_path() -> impl Filter<Extract = (UserId,), Error = Rejection> + Clone {
             urlencoding::decode(&user_id)
                 .map_err(Error::UserIdUtf8Conversion)
                 .and_then(UserId::new)
-                .map_err(|_| warp::reject())
+                .map_err(warp::reject::custom)
         })
 }
 


### PR DESCRIPTION
The entity `UserId` can be constructed from any string that is non-empty and does not contain the null byte.

This PR move the decoding of the URL parameter in the route definition.