### PR TITLE
[Merged by Bors] - TO-3336 User API part 1

### DIFF
--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use xayn_discovery_engine_ai::Embedding;
 
-use crate::models::{DocumentId, DocumentProperties, Error, PersonalizedDocument};
+use crate::models::{DocumentId, DocumentProperties, Error, PersonalizedDocumentData};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -51,7 +51,7 @@ impl ElasticState {
     pub(crate) async fn get_documents_by_embedding(
         &self,
         params: KnnSearchParams,
-    ) -> Result<Vec<PersonalizedDocument>, Error> {
+    ) -> Result<Vec<PersonalizedDocumentData>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/knn-search.html#approximate-knn
         let body = json!({
             "size": params.size,
@@ -79,7 +79,7 @@ impl ElasticState {
     pub(crate) async fn get_documents_by_ids(
         &self,
         ids: &[String],
-    ) -> Result<Vec<PersonalizedDocument>, Error> {
+    ) -> Result<Vec<PersonalizedDocumentData>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/query-dsl-ids-query.html
         let body = json!({
             "query": {
@@ -114,12 +114,12 @@ impl ElasticState {
     }
 }
 
-fn convert_response(response: Response<ElasticDocumentData>) -> Vec<PersonalizedDocument> {
+fn convert_response(response: Response<ElasticDocumentData>) -> Vec<PersonalizedDocumentData> {
     response
         .hits
         .hits
         .into_iter()
-        .map(|hit| PersonalizedDocument {
+        .map(|hit| PersonalizedDocumentData {
             id: DocumentId(hit.id),
             score: hit.score,
             embedding: hit.source.embedding,

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -30,7 +30,7 @@ use xayn_discovery_engine_ai::{
 
 use crate::{
     elastic::KnnSearchParams,
-    models::{Error, InteractionRequestBody, UserId},
+    models::{Error, InteractionRequestBody, PersonalizedDocumentsResponse, UserId},
     state::AppState,
 };
 
@@ -128,8 +128,11 @@ pub(crate) async fn handle_ranked_documents(
 
     let max_docs = max_documents_count.min(all_documents.len());
     let documents = &all_documents[0..max_docs];
+    let response = PersonalizedDocumentsResponse {
+        documents: documents.to_vec(),
+    };
 
-    Ok(warp::reply::json(&documents))
+    Ok(warp::reply::json(&response))
 }
 
 #[instrument(skip(state))]

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[instrument(skip(state))]
-pub(crate) async fn handle_ranked_documents(
+pub(crate) async fn handle_personalized_documents(
     user_id: UserId,
     state: Arc<AppState>,
 ) -> Result<impl warp::Reply, Rejection> {
@@ -136,7 +136,7 @@ pub(crate) async fn handle_ranked_documents(
 }
 
 #[instrument(skip(state))]
-pub(crate) async fn handle_user_interaction(
+pub(crate) async fn handle_user_interactions(
     user_id: UserId,
     body: InteractionRequestBody,
     state: Arc<AppState>,

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -77,7 +77,8 @@ pub(crate) async fn handle_personalized_documents(
             error!("Error fetching interacted document ids: {err}");
             handle_user_state_op_error(err)
         })?;
-    let documents_count = query.map_or_else(|| state.max_documents_count, |params| params.count);
+    let documents_count =
+        query.map_or_else(|| state.default_documents_count, |params| params.count);
     let document_futures = cois
         .iter()
         .map(|(coi, weight)| async {

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -77,7 +77,7 @@ pub(crate) async fn handle_personalized_documents(
             error!("Error fetching interacted document ids: {err}");
             handle_user_state_op_error(err)
         })?;
-    let documents_count = query.count;
+    let documents_count = query.count.unwrap_or(state.default_documents_count);
     let document_futures = cois
         .iter()
         .map(|(coi, weight)| async {

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -43,7 +43,7 @@ use crate::{
 #[instrument(skip(state))]
 pub(crate) async fn handle_personalized_documents(
     user_id: UserId,
-    query: Option<PersonalizedDocumentsQuery>,
+    query: PersonalizedDocumentsQuery,
     state: Arc<AppState>,
 ) -> Result<impl warp::Reply, Rejection> {
     let user_interests = state.user.fetch_interests(&user_id).await.map_err(|err| {
@@ -77,8 +77,7 @@ pub(crate) async fn handle_personalized_documents(
             error!("Error fetching interacted document ids: {err}");
             handle_user_state_op_error(err)
         })?;
-    let documents_count =
-        query.map_or_else(|| state.default_documents_count, |params| params.count);
+    let documents_count = query.count;
     let document_futures = cois
         .iter()
         .map(|(coi, weight)| async {

--- a/discovery_engine_core/web-api/src/main.rs
+++ b/discovery_engine_core/web-api/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), GenericError> {
 
     let config = InitConfig {
         max_cois_for_knn: 5,
-        max_documents_count: 100,
+        default_documents_count: 10,
         pg_url,
         elastic: ElasticConfig {
             url: elastic_url,

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -12,14 +12,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::{collections::HashMap, ops::RangeInclusive, string::FromUtf8Error};
+
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, string::FromUtf8Error};
 use thiserror::Error;
 use warp::reject::Reject;
 
 use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
+
+/// The range of the count parameter.
+pub(crate) const COUNT_PARAM_RANGE: RangeInclusive<usize> = 1..=100;
 
 /// Web API errors.
 #[derive(Error, Debug, DisplayDoc)]
@@ -33,7 +37,7 @@ pub(crate) enum Error {
     /// Failed to decode [`UserId] from path param: {0}.
     UserIdUtf8Conversion(#[from] FromUtf8Error),
 
-    /// Invalid value for count param: {0}. It must be greater than 1 and less than 100.
+    /// Invalid value for count parameter: {0}. It must be in [`COUNT_PARAM_RANGE`].
     InvalidCountParam(usize),
 
     /// Elastic search error: {0}
@@ -42,6 +46,7 @@ pub(crate) enum Error {
     /// Error receiving response: {0}
     Receiving(#[source] reqwest::Error),
 }
+
 impl Reject for Error {}
 
 /// A unique identifier of a document.

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -90,6 +90,12 @@ pub(crate) struct IngestedDocument {
 /// Arbitrary properties that can be attached to a document.
 pub type DocumentProperties = HashMap<String, serde_json::Value>;
 
+/// Represents personalized documents query params.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PersonalizedDocumentsQuery {
+    pub(crate) count: usize,
+}
+
 /// Represents response from personalized documents endpoint.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct PersonalizedDocumentsResponse {

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -74,19 +74,6 @@ impl AiDocument for PersonalizedDocumentData {
     }
 }
 
-/// Represents a document sent for ingestion.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct IngestedDocument {
-    /// Unique identifier of the document.
-    pub(crate) id: String,
-
-    /// Snippet used to calculate embeddings for a document.
-    pub(crate) snippet: String,
-
-    /// Contents of the document properties.
-    pub(crate) properties: DocumentProperties,
-}
-
 /// Arbitrary properties that can be attached to a document.
 pub type DocumentProperties = HashMap<String, serde_json::Value>;
 

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -88,7 +88,7 @@ pub type DocumentProperties = HashMap<String, serde_json::Value>;
 /// Represents personalized documents query params.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct PersonalizedDocumentsQuery {
-    pub(crate) count: usize,
+    pub(crate) count: Option<usize>,
 }
 
 /// Represents response from personalized documents endpoint.

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -47,7 +47,7 @@ pub(crate) struct DocumentId(pub(crate) String);
 
 /// Represents a result from a query.
 #[derive(Debug, Clone, Serialize)]
-pub(crate) struct PersonalizedDocument {
+pub(crate) struct PersonalizedDocumentData {
     /// Unique identifier of the document.
     pub(crate) id: DocumentId,
 
@@ -62,7 +62,7 @@ pub(crate) struct PersonalizedDocument {
     pub(crate) properties: DocumentProperties,
 }
 
-impl AiDocument for PersonalizedDocument {
+impl AiDocument for PersonalizedDocumentData {
     type Id = DocumentId;
 
     fn id(&self) -> &Self::Id {
@@ -90,8 +90,15 @@ pub(crate) struct IngestedDocument {
 /// Arbitrary properties that can be attached to a document.
 pub type DocumentProperties = HashMap<String, serde_json::Value>;
 
+/// Represents response from personalized documents endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PersonalizedDocumentsResponse {
+    /// A list of documents personalized for a specific user.
+    pub(crate) documents: Vec<PersonalizedDocumentData>,
+}
+
 /// Represents user interaction request body.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub(crate) struct InteractionRequestBody {
     pub(crate) document_id: String,
 }

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -14,7 +14,7 @@
 
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, string::FromUtf8Error};
 use thiserror::Error;
 use warp::reject::Reject;
@@ -32,6 +32,9 @@ pub(crate) enum Error {
 
     /// Failed to decode [`UserId] from path param: {0}.
     UserIdUtf8Conversion(#[from] FromUtf8Error),
+
+    /// Invalid value for count param: {0}. It must be greater than 1 and less than 100.
+    InvalidCountParam(usize),
 
     /// Elastic search error: {0}
     Elastic(#[source] reqwest::Error),
@@ -80,20 +83,7 @@ pub type DocumentProperties = HashMap<String, serde_json::Value>;
 /// Represents personalized documents query params.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct PersonalizedDocumentsQuery {
-    #[serde(deserialize_with = "deserialize_count_min_max")]
     pub(crate) count: usize,
-}
-
-fn deserialize_count_min_max<'de, D>(deserializer: D) -> Result<usize, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let val = usize::deserialize(deserializer)?;
-    if (1_usize..=100_usize).contains(&val) {
-        Ok(val)
-    } else {
-        Err(de::Error::custom("count needs to be between 1 and 100"))
-    }
 }
 
 /// Represents response from personalized documents endpoint.

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -24,36 +24,36 @@ use crate::{
 pub fn api_routes(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_ranked_documents(state.clone()).or(post_user_interaction(state))
+    get_personalized_documents(state.clone()).or(post_user_interactions(state))
 }
 
-// GET /user/:user_id/documents
-fn get_ranked_documents(
+// GET /users/:user_id/personalized_documents
+fn get_personalized_documents(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     user_path()
-        .and(warp::path("documents"))
+        .and(warp::path("personalized_documents"))
         .and(warp::get())
         .and(with_state(state))
-        .and_then(handlers::handle_ranked_documents)
+        .and_then(handlers::handle_personalized_documents)
 }
 
-// POST /user/:user_id/interaction
-fn post_user_interaction(
+// PATCH /users/:user_id/interactions
+fn post_user_interactions(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     user_path()
-        .and(warp::path("interaction"))
-        .and(warp::post())
+        .and(warp::path("interactions"))
+        .and(warp::patch())
         .and(warp::body::content_length_limit(1024))
         .and(warp::body::json())
         .and(with_state(state))
-        .and_then(handlers::handle_user_interaction)
+        .and_then(handlers::handle_user_interactions)
 }
 
-// PATH /user/:user_id
+// PATH /users/:user_id
 fn user_path() -> impl Filter<Extract = (UserId,), Error = Rejection> + Clone {
-    warp::path("user")
+    warp::path("users")
         .and(warp::path::param::<String>())
         .and_then(|user_id: String| async move {
             urlencoding::decode(&user_id)

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -17,7 +17,7 @@ use warp::{self, Filter, Rejection, Reply};
 
 use crate::{
     handlers,
-    models::{Error, UserId},
+    models::{Error, PersonalizedDocumentsQuery, UserId},
     state::AppState,
 };
 
@@ -34,6 +34,7 @@ fn get_personalized_documents(
     user_path()
         .and(warp::path("personalized_documents"))
         .and(warp::get())
+        .and(warp::query::<Option<PersonalizedDocumentsQuery>>())
         .and(with_state(state))
         .and_then(handlers::handle_personalized_documents)
 }

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -17,7 +17,7 @@ use warp::{self, Filter, Rejection, Reply};
 
 use crate::{
     handlers,
-    models::{Error, PersonalizedDocumentsQuery, UserId},
+    models::{Error, PersonalizedDocumentsQuery, UserId, COUNT_PARAM_RANGE},
     state::AppState,
 };
 
@@ -74,7 +74,7 @@ fn with_count_query_param(
                 count: default_documents_count,
             });
 
-            if (1_usize..=100_usize).contains(&params.count) {
+            if COUNT_PARAM_RANGE.contains(&params.count) {
                 Ok(params)
             } else {
                 Err(warp::reject::custom(Error::InvalidCountParam(params.count)))

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -34,7 +34,7 @@ fn get_personalized_documents(
     user_path()
         .and(warp::path("personalized_documents"))
         .and(warp::get())
-        .and(warp::query::<Option<PersonalizedDocumentsQuery>>())
+        .and(with_count_query_param(state.default_documents_count))
         .and(with_state(state))
         .and_then(handlers::handle_personalized_documents)
 }
@@ -62,6 +62,25 @@ fn user_path() -> impl Filter<Extract = (UserId,), Error = Rejection> + Clone {
                 .and_then(UserId::new)
                 .map_err(warp::reject::custom)
         })
+}
+
+/// Extract a "count" from query params and check if within bounds, or reject with InvalidCountParam error.
+fn with_count_query_param(
+    default_documents_count: usize,
+) -> impl Filter<Extract = (PersonalizedDocumentsQuery,), Error = Rejection> + Copy {
+    warp::query().and_then(
+        move |params: Option<PersonalizedDocumentsQuery>| async move {
+            let params = params.unwrap_or(PersonalizedDocumentsQuery {
+                count: default_documents_count,
+            });
+
+            if (1_usize..=100_usize).contains(&params.count) {
+                Ok(params)
+            } else {
+                Err(warp::reject::custom(Error::InvalidCountParam(params.count)))
+            }
+        },
+    )
 }
 
 fn with_state(

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -24,7 +24,7 @@ use crate::{
 pub fn api_routes(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_personalized_documents(state.clone()).or(post_user_interactions(state))
+    get_personalized_documents(state.clone()).or(patch_user_interactions(state))
 }
 
 // GET /users/:user_id/personalized_documents
@@ -40,7 +40,7 @@ fn get_personalized_documents(
 }
 
 // PATCH /users/:user_id/interactions
-fn post_user_interactions(
+fn patch_user_interactions(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     user_path()

--- a/discovery_engine_core/web-api/src/state.rs
+++ b/discovery_engine_core/web-api/src/state.rs
@@ -26,7 +26,7 @@ pub struct InitConfig {
     /// Max nb of Positive CoIs to use in knn search.
     pub max_cois_for_knn: usize,
     /// Max nb of documents to return using personalized documents endpoint.
-    pub max_documents_count: usize,
+    pub default_documents_count: usize,
 }
 
 pub struct AppState {
@@ -39,7 +39,7 @@ pub struct AppState {
     /// Max nb of Positive CoIs to use in knn search.
     pub(crate) max_cois_for_knn: usize,
     /// Max nb of documents to return using personalized documents endpoint.
-    pub(crate) max_documents_count: usize,
+    pub(crate) default_documents_count: usize,
 }
 
 impl AppState {
@@ -54,7 +54,7 @@ impl AppState {
             elastic,
             user,
             max_cois_for_knn: config.max_cois_for_knn,
-            max_documents_count: config.max_documents_count,
+            default_documents_count: config.default_documents_count,
         };
 
         Ok(Arc::new(app_state))

--- a/discovery_engine_core/web-api/src/state.rs
+++ b/discovery_engine_core/web-api/src/state.rs
@@ -15,7 +15,12 @@
 use std::sync::Arc;
 use xayn_discovery_engine_ai::{CoiConfig, CoiSystem, GenericError};
 
-use crate::{elastic, elastic::ElasticState, storage::UserState};
+use crate::{
+    elastic,
+    elastic::ElasticState,
+    models::{Error, COUNT_PARAM_RANGE},
+    storage::UserState,
+};
 
 #[derive(Clone, Debug)]
 pub struct InitConfig {
@@ -49,12 +54,16 @@ impl AppState {
 
         let coi = CoiConfig::default().build();
         let elastic = ElasticState::new(config.elastic);
+        let default_documents_count = COUNT_PARAM_RANGE
+            .contains(&config.default_documents_count)
+            .then(|| config.default_documents_count)
+            .ok_or(Error::InvalidCountParam(config.default_documents_count))?;
         let app_state = AppState {
             coi,
             elastic,
             user,
             max_cois_for_knn: config.max_cois_for_knn,
-            default_documents_count: config.default_documents_count,
+            default_documents_count,
         };
 
         Ok(Arc::new(app_state))

--- a/discovery_engine_core/web-api/src/state.rs
+++ b/discovery_engine_core/web-api/src/state.rs
@@ -38,7 +38,7 @@ pub struct AppState {
     pub(crate) user: UserState,
     /// Max nb of Positive CoIs to use in knn search.
     pub(crate) max_cois_for_knn: usize,
-    /// Max nb of documents to return using personalized documents endpoint.
+    /// Default nb of documents to return using personalized documents endpoint.
     pub(crate) default_documents_count: usize,
 }
 


### PR DESCRIPTION
**References**:
- [TO-3337]
- [TO-3338]
- [TO-3304]
- followed by #626

**Summary**:
- [x] adjusted personalized documents response
- [x] adjusted endpoint names and type
- [x] added `count` query param to personalized documents endpoint

[TO-3337]: https://xainag.atlassian.net/browse/TO-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-3338]: https://xainag.atlassian.net/browse/TO-3338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TO-3304]: https://xainag.atlassian.net/browse/TO-3304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ