### PR TITLE
[Merged by Bors] - TO-3341 new format for interactions type

### DIFF
--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -101,7 +101,10 @@ pub(crate) struct PersonalizedDocumentsResponse {
 /// Represents user interaction request body.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct InteractionRequestBody {
+    #[serde(rename = "id")]
     pub(crate) document_id: String,
+    #[serde(rename = "type")]
+    pub(crate) user_interaction: UserInteraction,
 }
 
 /// Unique identifier for the user.
@@ -122,9 +125,8 @@ impl UserId {
     }
 }
 
-#[repr(u8)]
-pub(crate) enum UserReaction {
-    Positive = xayn_discovery_engine_core::document::UserReaction::Positive as u8,
-    #[allow(dead_code)]
-    Negative = xayn_discovery_engine_core::document::UserReaction::Negative as u8,
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub(crate) enum UserInteraction {
+    #[serde(rename = "positive")]
+    Positive = xayn_discovery_engine_core::document::UserReaction::Positive as isize,
 }

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -33,7 +33,7 @@ use xayn_discovery_engine_ai::{
     UserInterests,
 };
 
-use crate::models::{DocumentId, UserId, UserReaction};
+use crate::models::{DocumentId, UserId, UserInteraction};
 
 #[derive(Debug, Clone)]
 pub struct UserState {
@@ -164,7 +164,7 @@ impl UserState {
         .bind(doc_id.as_ref())
         .bind(user_id.as_ref())
         .bind(timestamp)
-        .bind(UserReaction::Positive as i16)
+        .bind(UserInteraction::Positive as i16)
         .execute(&mut tx)
         .await?;
 


### PR DESCRIPTION
**References**

- [TO-3341]
- requires #624
- followed by #627

**Summary**

- change `UserInteraction` enum to match the spec
- add user interaction to `InteractionRequestBody` & use it in the handler
- change handler success code to 204


[TO-3341]: https://xainag.atlassian.net/browse/TO-3341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ