### PR TITLE
[Merged by Bors] - TO-3388 new format for interactions batch

### DIFF
--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -78,7 +78,7 @@ impl ElasticState {
 
     pub(crate) async fn get_documents_by_ids(
         &self,
-        ids: &[String],
+        ids: &[&DocumentId],
     ) -> Result<Vec<PersonalizedDocumentData>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/query-dsl-ids-query.html
         let body = json!({

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -50,7 +50,7 @@ pub(crate) enum Error {
 impl Reject for Error {}
 
 /// A unique identifier of a document.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash, Display, AsRef)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display, AsRef)]
 pub(crate) struct DocumentId(pub(crate) String);
 
 /// Represents a result from a query.
@@ -98,13 +98,18 @@ pub(crate) struct PersonalizedDocumentsResponse {
     pub(crate) documents: Vec<PersonalizedDocumentData>,
 }
 
-/// Represents user interaction request body.
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct InteractionRequestBody {
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct InteractionData {
     #[serde(rename = "id")]
-    pub(crate) document_id: String,
+    pub(crate) document_id: DocumentId,
     #[serde(rename = "type")]
     pub(crate) user_interaction: UserInteraction,
+}
+
+/// Represents user interaction request body.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct InteractionRequestBody {
+    pub(crate) documents: Vec<InteractionData>,
 }
 
 /// Unique identifier for the user.


### PR DESCRIPTION
**References**

- [TO-3388]
- requires #626
- followed by #632

**Summary**

- change `InteractionRequestBody` to hold a `Vec<InteractionData>`
- query elastic for all ids and fail fast before coi updates if an id is missing
- update cois for all interactions


[TO-3388]: https://xainag.atlassian.net/browse/TO-3388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ