### PR TITLE
[Merged by Bors] - Update rust toolchain 1.64.0

### DIFF
--- a/.env
+++ b/.env
@@ -20,10 +20,10 @@ IOS_LIB_BASE="libxayn_discovery_engine_bindings"
 
 PRODUCTION_RUSTFLAGS="-Ccodegen-units=1 -Clto=on -Cembed-bitcode=yes"
 
-JUST_VERSION=1.3.0
+JUST_VERSION=1.5.0
 CARGO_SORT_VERSION=1.0.7
 # In the cases we want to use nightly we use the following version
-RUST_NIGHTLY=nightly-2022-07-16
+RUST_NIGHTLY=nightly-2022-09-22
 # cargo install will install CLI tools into this directory
 CARGO_INSTALL_ROOT=cargo-installs
 

--- a/.github/actions/setup-job-docker/action.yml
+++ b/.github/actions/setup-job-docker/action.yml
@@ -24,9 +24,9 @@ runs:
       uses: xom9ikk/dotenv@d3ff95524814ceac377510f30f4af6296ea612c1 #v1.0.2
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@884cf5c591490f86b788d68b6f585f26235578d6 # v1.12
+      uses: jwlawson/actions-setup-cmake@48fb828056dab1f20e7f97159f2711efb1742ba1 # v1.12.1
 
-    - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # v1.4.0
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       if: inputs.rust != 'false'
       with:
         key: ${{ inputs.cache-key }}

--- a/.github/actions/setup-job-docker/action.yml
+++ b/.github/actions/setup-job-docker/action.yml
@@ -30,7 +30,7 @@ runs:
       if: inputs.rust != 'false'
       with:
         key: ${{ inputs.cache-key }}
-        working-directory: ${{ env.RUST_WORKSPACE }}
+        workspaces: ${{ env.RUST_WORKSPACE }} -> target
 
     - name: Configure cargo
       shell: bash

--- a/.github/actions/setup-job-macos/action.yml
+++ b/.github/actions/setup-job-macos/action.yml
@@ -98,7 +98,7 @@ runs:
     - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       with:
         key: ${{ inputs.cache-key }}
-        working-directory: ${{ env.RUST_WORKSPACE }}
+        workspaces: ${{ env.RUST_WORKSPACE }} -> target
 
     - name: Install rust deps
       working-directory: ${{ env.RUST_WORKSPACE }}

--- a/.github/actions/setup-job-macos/action.yml
+++ b/.github/actions/setup-job-macos/action.yml
@@ -40,7 +40,7 @@ runs:
       uses: xom9ikk/dotenv@d3ff95524814ceac377510f30f4af6296ea612c1 #v1.0.2
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@884cf5c591490f86b788d68b6f585f26235578d6 # v1.12
+      uses: jwlawson/actions-setup-cmake@48fb828056dab1f20e7f97159f2711efb1742ba1 # v1.12.1
 
     - name: Install just
       uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb #v1.4.0
@@ -51,7 +51,7 @@ runs:
 
     - name: Install flutter
       if: inputs.flutter == 'true'
-      uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf # v2.4.0
+      uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
 
@@ -95,7 +95,7 @@ runs:
       shell: bash
       run: rustup target add ${{ inputs.rust-target }}
 
-    - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c # v1.4.0
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       with:
         key: ${{ inputs.cache-key }}
         working-directory: ${{ env.RUST_WORKSPACE }}

--- a/.github/workflows/_reusable.build-android.yml
+++ b/.github/workflows/_reusable.build-android.yml
@@ -17,7 +17,7 @@ jobs:
   build-android-libs:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 45
     strategy:
       matrix:

--- a/.github/workflows/_reusable.build-android.yml
+++ b/.github/workflows/_reusable.build-android.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       artifact-dir-base: ${{ steps.build.outputs.artifact-dir-base }}
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust CI.
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/_reusable.build-flutter-example.yml
+++ b/.github/workflows/_reusable.build-flutter-example.yml
@@ -20,7 +20,7 @@ jobs:
         shell: bash
         run: rm -rf *
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the CI.
         uses: ./.github/actions/setup-job-macos
@@ -50,7 +50,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the CI.
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/_reusable.build-flutter-example.yml
+++ b/.github/workflows/_reusable.build-flutter-example.yml
@@ -47,7 +47,7 @@ jobs:
     # that needs to exist during the linking process.
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2

--- a/.github/workflows/_reusable.build-ios.yml
+++ b/.github/workflows/_reusable.build-ios.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: rm -rf *
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust CI
         uses: ./.github/actions/setup-job-macos

--- a/.github/workflows/_reusable.dart.yml
+++ b/.github/workflows/_reusable.dart.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the dart CI.
         uses: ./.github/actions/setup-job-docker
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust/dart CI.
         uses: ./.github/actions/setup-job-docker
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust/dart CI.
         uses: ./.github/actions/setup-job-docker
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the dart CI.
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/_reusable.dart.yml
+++ b/.github/workflows/_reusable.dart.yml
@@ -7,7 +7,7 @@ jobs:
   dart-format:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
   dart-analyze:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -42,7 +42,7 @@ jobs:
   dart-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -63,7 +63,7 @@ jobs:
   dart-doc:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/_reusable.flutter.yml
+++ b/.github/workflows/_reusable.flutter.yml
@@ -7,7 +7,7 @@ jobs:
   flutter-analyze:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
   flutter-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 15
     steps:
       - name: Checkout repository

--- a/.github/workflows/_reusable.flutter.yml
+++ b/.github/workflows/_reusable.flutter.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the CI
         uses: ./.github/actions/setup-job-docker
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the CI
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -7,7 +7,7 @@ jobs:
   cargo-format:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -23,7 +23,7 @@ jobs:
   cargo-clippy:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -42,7 +42,7 @@ jobs:
   cargo-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -64,7 +64,7 @@ jobs:
   cargo-doc:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2

--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -10,7 +10,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the CI.
         uses: ./.github/actions/setup-job-docker
@@ -26,7 +26,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust CI.
         uses: ./.github/actions/setup-job-docker
@@ -45,7 +45,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust CI.
         uses: ./.github/actions/setup-job-docker
@@ -67,7 +67,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup the rust CI.
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -45,7 +45,7 @@ jobs:
       - build-flutter-example
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 5
     if: ${{ always() }}
     steps:

--- a/.github/workflows/ingestion-service.yml
+++ b/.github/workflows/ingestion-service.yml
@@ -17,7 +17,7 @@ jobs:
   rust-build:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/ingestion-service.yml
+++ b/.github/workflows/ingestion-service.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup job
         uses: ./.github/actions/setup-job-docker
@@ -63,10 +63,10 @@ jobs:
     needs: [rust-build]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.0.0
 
       - name: Download artifacts
         id: artifacts

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
   selection:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     outputs:
       dart: ${{ steps.filter.outputs.dart }}
       rust: ${{ steps.filter.outputs.rust }}
@@ -64,7 +64,7 @@ jobs:
     if: ${{ always() }}
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
         id: filter
@@ -67,7 +67,7 @@ jobs:
       image: xaynetci/yellow:v5
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Check copyright
         run: .github/scripts/copyright.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   release:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 10
     needs: [build-ios-libs, build-android-libs]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
 
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup job
         uses: ./.github/actions/setup-job-docker

--- a/.github/workflows/scheduled_cleanup.yaml
+++ b/.github/workflows/scheduled_cleanup.yaml
@@ -19,7 +19,7 @@ jobs:
      name: install jfrog cli
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
        - uses: jfrog/setup-jfrog-cli@v2
          env:
            JF_ENV_DEVOPS: ${{secrets.JF_SECRET_ENV_DEVOPS}}

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup job
         uses: ./.github/actions/setup-job-docker
@@ -59,10 +59,10 @@ jobs:
     needs: [rust-build]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.0.0
 
       - name: Download artifacts
         id: artifacts

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -17,7 +17,7 @@ jobs:
   rust-build:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v4
+      image: xaynetci/yellow:v5
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#63f02b0e5b54684f20d1910a0588ce727da2f1c5"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#6f87a7f1a9d2e71ca29f24c2edbf1a2dc537aa01"
 dependencies = [
  "displaydoc",
  "once_cell",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "xayn-dart-api-dl-sys"
 version = "0.3.0+2.0.0"
-source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#63f02b0e5b54684f20d1910a0588ce727da2f1c5"
+source = "git+https://github.com/xaynetwork/xayn_dart_api_dl.git?branch=main#6f87a7f1a9d2e71ca29f24c2edbf1a2dc537aa01"
 dependencies = [
  "bindgen",
  "cc",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1702,16 +1702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "mapr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1733,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3346,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8607d925cd49669267317730ca1734975a5a33bcc41d4643bf27d82b95ddf226"
+checksum = "ef5c8de4f6f56e061b7823a2d975e85d1eee62b875a4f9eec254d19195bda260"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -3369,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68536908a67bd972419c5a804c77224d965c7ef3cc8744244df381584e3cbddd"
+checksum = "b4bca2b5c9dbeabeef01f14f069c1b43ae4bde81dcabf87b42b8219ed05de073"
 dependencies = [
  "anyhow",
  "educe",
@@ -3389,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d4da39a2cbef4604b8b6d2b679d58cccbcff0991d9f1568c51e3d1c8fa4e"
+checksum = "0df9e897b9cbb2bb01a81bf9e73fdc1beb64d4d332fa5f39c0b25c41cc8765f4"
 dependencies = [
  "derive-new",
  "educe",
@@ -3401,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70d8cdac3b2022c0fa6b038dd40ebafe14408a6eabdf6d54926c72ea69c8182"
+checksum = "1e2624f375aaa235ae87928c40d2c814c548068494d8b6ecbf09bf06cf315c10"
 dependencies = [
  "cc",
  "derive-new",
@@ -3411,7 +3410,6 @@ dependencies = [
  "dyn-clone",
  "half 2.1.0",
  "lazy_static",
- "libc",
  "liquid",
  "liquid-core",
  "log",
@@ -3426,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b62c5eab99dc19ef56504eeab635df1e4f03c494aa309e7fe43c1769b3e9a4b"
+checksum = "b2d4d55271b76380927b976e18e6c98b9c4b0dce15c2725ed49037ef80ec3860"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3441,15 +3439,15 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd5c19898d8053eca69217a6a438a714872773a8d2d4f553d0e081de3e1b071"
+checksum = "a3f7fb7e95d59da09fd5001e5059584d98bc16f45c14752e57d76e6692602467"
 dependencies = [
  "bytes",
  "derive-new",
  "educe",
  "log",
- "mapr",
+ "memmap2",
  "num-integer",
  "prost",
  "smallvec",
@@ -3460,12 +3458,13 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.17.8"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5648433de89884efe3c7519081fefb854a4bd9df9b289bd55cf8d32da9f860"
+checksum = "ec85e5c61e1354d1bd5e7e3afcc090abba025b5b00ad389e91f410862ddb6ecb"
 dependencies = [
  "educe",
  "getrandom 0.2.7",
+ "log",
  "rand 0.8.5",
  "tract-nnef",
 ]

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -36,9 +36,9 @@ checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "anymap2"
@@ -104,7 +104,7 @@ dependencies = [
  "anyhow",
  "handlebars",
  "heck 0.4.0",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "once_cell",
  "regex",
  "serde",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -198,7 +198,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 3.2.17",
+ "clap 3.2.22",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -235,18 +235,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -275,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -333,7 +324,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap 3.2.17",
+ "clap 3.2.22",
  "heck 0.4.0",
  "indexmap",
  "log",
@@ -388,9 +379,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -414,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -426,14 +417,14 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -452,15 +443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,13 +453,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -491,9 +473,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -533,7 +515,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -555,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools 0.10.3",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -581,15 +563,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
@@ -605,12 +586,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -771,20 +751,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
-dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -837,9 +808,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
 dependencies = [
  "dirs 4.0.0",
 ]
@@ -858,9 +829,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "educe"
@@ -876,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -911,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -965,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "figment"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
+checksum = "4e56602b469b2201400dec66a66aec5a9b8761ee97cd1b8c96ab2483fcc16cc9"
 dependencies = [
  "atomic",
  "serde",
@@ -987,12 +958,6 @@ dependencies = [
  "redox_syscall",
  "windows-sys",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1033,11 +998,10 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1208,9 +1172,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1221,7 +1185,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1243,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.3"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360d9740069b2f6cbb63ce2dbaa71a20d3185350cbb990d7bebeb9318415eb17"
+checksum = "433e4ab33f1213cdc25b5fa45c76881240cfe79284cf2b395e8b9e312a30a2fd"
 dependencies = [
  "log",
  "pest",
@@ -1266,18 +1230,18 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "headers"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64",
  "bitflags",
@@ -1286,7 +1250,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha-1 0.10.0",
+ "sha1",
 ]
 
 [[package]]
@@ -1346,7 +1310,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -1357,7 +1321,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -1394,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1425,7 +1389,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1449,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1468,11 +1432,10 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1489,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
 dependencies = [
  "console",
  "number_prefix",
@@ -1539,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1554,15 +1517,15 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1600,9 +1563,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -1616,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1651,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93764837aeac37f14b74708cd88a44d82edfa9ad2b1bcd9a3b4d8802fdd9f98"
 dependencies = [
  "anymap2",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "kstring",
  "liquid-derive",
  "num-traits",
@@ -1659,7 +1622,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time 0.3.12",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -1679,20 +1642,20 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd06ca30ae026d26ee7fa8596f9590959e2d3726bc5a0f16a21ac4f050ec83c0"
 dependencies = [
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "liquid-core",
  "once_cell",
  "percent-encoding",
  "regex",
- "time 0.3.12",
+ "time 0.3.15",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1749,12 +1712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,11 +1722,11 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -1811,9 +1768,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
@@ -1856,12 +1813,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multipart"
@@ -1989,9 +1940,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "onig"
@@ -2047,16 +1998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking"
@@ -2091,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "peeking_take_while"
@@ -2103,15 +2048,15 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2119,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13570633aff33c6d22ce47dd566b10a3b9122c2fe9d8e7501895905be532b91"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2129,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c567e5702efdc79fb18859ea74c3eb36e14c43da7b8c1f098a4ed6514ec7a0"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2142,39 +2087,29 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb32be5ee3bbdafa8c7a18b0a8a8d962b66cfa2ceee4037f49267a50ee821fe"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1 0.10.0",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
+ "sha1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2201,9 +2136,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2220,9 +2155,9 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -2241,7 +2176,7 @@ checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -2295,9 +2230,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2328,57 +2263,25 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck 0.4.0",
- "itertools 0.10.3",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -2417,7 +2320,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2437,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2451,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
 ]
@@ -2575,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64",
  "bytes",
@@ -2591,13 +2494,13 @@ dependencies = [
  "hyper-rustls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2658,6 +2561,15 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -2723,15 +2635,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -2748,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2763,7 +2675,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -2806,22 +2718,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2832,18 +2731,29 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -2872,15 +2782,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -2915,20 +2825,20 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788841def501aabde58d3666fcea11351ec3962e6ea75dbcd05c84a71d68bcd1"
+checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2936,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d3b5e7cadfe9ba7cdc1295f72cc556c750b4419c27c219c0693198901f8e"
+checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
@@ -2964,7 +2874,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "indexmap",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "libc",
  "libsqlite3-sys",
  "log",
@@ -2975,10 +2885,10 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
- "sha-1 0.10.0",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlformat",
@@ -2994,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adfd2df3557bddd3b91377fc7893e8fa899e9b4061737cbade4e1bb85f1b45c"
+checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
@@ -3013,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be52fc7c96c136cedea840ed54f7d446ff31ad670c9dea95ebcb998530971a3"
+checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
 dependencies = [
  "once_cell",
  "tokio",
@@ -3088,9 +2998,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3158,24 +3068,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3204,12 +3114,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
- "itoa 1.0.2",
- "js-sys",
+ "itoa 1.0.3",
  "libc",
  "num_threads",
  "time-macros",
@@ -3279,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3289,7 +3198,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -3320,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3331,36 +3239,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.15.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "pin-project",
  "tokio",
  "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3492,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a144e86dde49212227969d9c8e445f4e4397608ee68497e5a015a7c4e74553"
+checksum = "8607d925cd49669267317730ca1734975a5a33bcc41d4643bf27d82b95ddf226"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -3515,14 +3408,14 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7233d5c8fd58903e4606614cadecdbb9d29ae960cca26772825cd89ea7db1e"
+checksum = "68536908a67bd972419c5a804c77224d965c7ef3cc8744244df381584e3cbddd"
 dependencies = [
  "anyhow",
  "educe",
  "half 2.1.0",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "lazy_static",
  "maplit",
  "ndarray",
@@ -3535,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22490aebf54448688676cb5ca5809f096afd19fca779a446f99b96c2221114ff"
+checksum = "49a9d4da39a2cbef4604b8b6d2b679d58cccbcff0991d9f1568c51e3d1c8fa4e"
 dependencies = [
  "derive-new",
  "educe",
@@ -3547,15 +3440,14 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f1c0f50ae7e30ee70bfe9d49e57821771762d9a6064f1695607d631c5d5ae7"
+checksum = "a70d8cdac3b2022c0fa6b038dd40ebafe14408a6eabdf6d54926c72ea69c8182"
 dependencies = [
  "cc",
  "derive-new",
  "downcast-rs",
  "dyn-clone",
- "educe",
  "half 2.1.0",
  "lazy_static",
  "libc",
@@ -3573,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07958ce7d81f3b7adf594482515a992a2fc1898fbe513010b724973a2bb270ca"
+checksum = "5b62c5eab99dc19ef56504eeab635df1e4f03c494aa309e7fe43c1769b3e9a4b"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3588,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142c21a6f3fd8a88fa23edd4a559c7f2fa94d0b3086cc613f5ed61fb06bfa75e"
+checksum = "dbd5c19898d8053eca69217a6a438a714872773a8d2d4f553d0e081de3e1b071"
 dependencies = [
  "bytes",
  "derive-new",
@@ -3599,7 +3491,6 @@ dependencies = [
  "mapr",
  "num-integer",
  "prost",
- "prost-build",
  "smallvec",
  "tract-hir",
  "tract-nnef",
@@ -3608,11 +3499,13 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.17.3"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49770cff107f7dd6e0a14dc6f04d0515b8ed3e1aa4e74b3dbb4a825f5df483de"
+checksum = "fd5648433de89884efe3c7519081fefb854a4bd9df9b289bd55cf8d32da9f860"
 dependencies = [
  "educe",
+ "getrandom 0.2.7",
+ "rand 0.8.5",
  "tract-nnef",
 ]
 
@@ -3624,9 +3517,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.14.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64",
  "byteorder",
@@ -3635,7 +3528,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
@@ -3658,9 +3551,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uncased"
@@ -3688,15 +3581,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -3712,15 +3605,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode_categories"
@@ -3753,22 +3646,21 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]
 
 [[package]]
 name = "urlencoding"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf-8"
@@ -3839,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3855,6 +3747,7 @@ dependencies = [
  "multipart",
  "percent-encoding",
  "pin-project",
+ "rustls-pemfile 0.2.1",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -3862,7 +3755,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.10",
+ "tokio-util",
  "tower-service",
  "tracing",
 ]
@@ -3887,9 +3780,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3897,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -3912,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3924,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3934,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3947,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-api"
@@ -3963,7 +3856,7 @@ dependencies = [
  "dotenvy",
  "envconfig",
  "futures",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "ndarray",
  "reqwest",
  "serde",
@@ -3984,9 +3877,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4004,30 +3897,31 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
 ]
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+checksum = "d6631b6a2fd59b1841b622e8f1a7ad241ef0a46f2d580464ce8140ac94cbd571"
 dependencies = [
+ "bumpalo",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -4177,7 +4071,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "displaydoc",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "ndarray",
  "rayon",
  "serde",
@@ -4219,7 +4113,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "heck 0.4.0",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "ndarray",
  "num-traits",
  "tokio",
@@ -4247,7 +4141,7 @@ dependencies = [
  "displaydoc",
  "figment",
  "futures",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "kodama",
  "maplit",
  "mockall",
@@ -4312,7 +4206,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "displaydoc",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "maplit",
  "once_cell",
  "regex",
@@ -4343,7 +4237,7 @@ name = "xayn-discovery-engine-tooling"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.22",
  "csv",
  "indicatif",
  "rand 0.8.5",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -102,7 +102,7 @@ name = "async-bindgen-gen-dart"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.22",
+ "clap 4.0.10",
  "handlebars",
  "heck",
  "itertools 0.10.5",
@@ -407,20 +407,33 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.1",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -434,6 +447,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -4170,7 +4192,7 @@ name = "xayn-discovery-engine-tooling"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.22",
+ "clap 4.0.10",
  "csv",
  "indicatif",
  "rand 0.8.5",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -3299,7 +3299,7 @@ checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
 dependencies = [
  "android_log-sys",
  "tracing",
- "tracing-subscriber 0.3.15",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3346,14 +3346,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
- "chrono",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -3361,23 +3360,6 @@ dependencies = [
  "smallvec",
  "thread_local",
  "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
-dependencies = [
- "ansi_term",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3865,7 +3847,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "urlencoding",
  "uuid",
  "warp",
@@ -4119,7 +4101,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-android",
- "tracing-subscriber 0.3.15",
+ "tracing-subscriber",
  "url",
  "uuid",
  "xayn-discovery-engine-ai",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 name = "async-bindgen-derive"
 version = "0.1.0"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -102,13 +102,13 @@ name = "async-bindgen-gen-dart"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.2.22",
  "handlebars",
- "heck 0.4.0",
+ "heck",
  "itertools 0.10.5",
  "once_cell",
  "regex",
  "serde",
- "structopt",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
  "clap 3.2.22",
- "heck 0.4.0",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -394,13 +394,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -426,7 +422,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1260,15 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2910,7 +2897,7 @@ checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.0",
+ "heck",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -2950,12 +2937,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
@@ -2965,30 +2946,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -3673,12 +3630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,7 +4045,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "derive_more",
- "heck 0.4.0",
+ "heck",
  "itertools 0.10.5",
  "ndarray",
  "num-traits",

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -48,7 +48,7 @@ tokenizers = { version = "0.13.0", default-features = false, features = ["onig"]
 tokio = { version = "1.21.2", default-features = false }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
-tract-onnx = "0.17.8"
+tract-onnx = "0.18.1"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 wiremock = "0.5.14"

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.21.2", default-features = false }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 tract-onnx = "0.17.8"
-url = "2.3.1"
+url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 wiremock = "0.5.14"
 

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -9,6 +9,49 @@ members = [
     "web-api",
 ]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.64.0"
+
+[workspace.dependencies]
+anyhow = "1.0.65"
+async-trait = "0.1.57"
+bincode = "1.3.3"
+cfg-if = "1.0.0"
+chrono = { version = "0.4.22", default-features = false, features = ["std"] }
+criterion = { version = "0.3.6", features = ["html_reports"] }
+csv = "1.1.6"
+derivative = "2.2.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "display", "from"] }
+displaydoc = "0.2.3"
+float-cmp = "0.9.0"
+futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
+heck = "0.4.0"
+indicatif = "0.17.1"
+itertools = "0.10.5"
+maplit = "1.0.2"
+ndarray = "0.15.6"
+num-traits = "0.2.15"
+once_cell = "1.15.0"
+rand = "0.8.5"
+rand_distr = "0.4.3"
+rayon = "1.5.3"
+regex = "1.6.0"
+reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.85"
+sqlx = { version = "0.6.2", features = ["chrono", "runtime-tokio-rustls", "uuid"] }
+thiserror = "1.0.37"
+tokenizers = { version = "0.13.0", default-features = false, features = ["onig"] }
+tokio = { version = "1.21.2", default-features = false }
+tracing = "0.1.36"
+tracing-subscriber = "0.3.15"
+tract-onnx = "0.17.8"
+url = "2.3.1"
+uuid = { version = "1.1.2", features = ["serde", "v4"] }
+wiremock = "0.5.14"
+
 [patch.crates-io.xayn-dart-api-dl]
 git = "https://github.com/xaynetwork/xayn_dart_api_dl.git"
 branch = "main"

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.57"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.22", default-features = false, features = ["std"] }
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.10", features = ["derive"] }
 criterion = { version = "0.3.6", features = ["html_reports"] }
 csv = "1.1.6"
 derivative = "2.2.0"

--- a/discovery_engine_core/Cargo.toml
+++ b/discovery_engine_core/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.57"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.22", default-features = false, features = ["std"] }
+clap = { version = "3.2.22", features = ["derive"] }
 criterion = { version = "0.3.6", features = ["html_reports"] }
 csv = "1.1.6"
 derivative = "2.2.0"

--- a/discovery_engine_core/ai/ai/Cargo.toml
+++ b/discovery_engine_core/ai/ai/Cargo.toml
@@ -10,11 +10,11 @@ chrono = { version = "0.4.22", default-features = false }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "display", "from"] }
 displaydoc = "0.2.3"
-itertools = "0.10.3"
+itertools = "0.10.5"
 ndarray = "0.15.6"
 rayon = "1.5.3"
-serde = { version = "1.0.144", features = ["derive", "rc"] }
-thiserror = "1.0.32"
+serde = { version = "1.0.145", features = ["derive", "rc"] }
+thiserror = "1.0.37"
 tracing = "0.1.36"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 xayn-discovery-engine-bert = { path = "../bert" }

--- a/discovery_engine_core/ai/ai/Cargo.toml
+++ b/discovery_engine_core/ai/ai/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "xayn-discovery-engine-ai"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-bincode = "1.3.3"
-chrono = { version = "0.4.22", default-features = false }
-derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "display", "from"] }
-displaydoc = "0.2.3"
-itertools = "0.10.5"
-ndarray = "0.15.6"
-rayon = "1.5.3"
-serde = { version = "1.0.145", features = ["derive", "rc"] }
-thiserror = "1.0.37"
-tracing = "0.1.36"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+bincode = { workspace = true }
+chrono = { workspace = true }
+derivative = { workspace = true }
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
+itertools = { workspace = true }
+ndarray = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true, features = ["rc"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
 xayn-discovery-engine-bert = { path = "../bert" }
 xayn-discovery-engine-providers = { path = "../../providers" }
 
 [dev-dependencies]
-serde_json = "1.0.85"
+serde_json = { workspace = true }
 xayn-discovery-engine-test-utils = { path = "../test-utils" }

--- a/discovery_engine_core/ai/bert/Cargo.toml
+++ b/discovery_engine_core/ai/bert/Cargo.toml
@@ -9,10 +9,10 @@ derive_more = { version = "0.99.17", default-features = false, features = ["dere
 displaydoc = "0.2.3"
 float-cmp = "0.9.0"
 ndarray = { version = "0.15.6", features = ["serde"] }
-serde = { version = "1.0.144", features = ["derive"] }
-thiserror = "1.0.32"
+serde = { version = "1.0.145", features = ["derive"] }
+thiserror = "1.0.37"
 tokenizers = { version = "0.13.0", default-features = false, features = ["onig"] }
-tract-onnx = "0.17.3"
+tract-onnx = "0.17.8"
 
 # dev-dependencies which don't work for aarch targets
 onnxruntime = { version = "0.0.13", optional = true }
@@ -20,7 +20,7 @@ onnxruntime = { version = "0.0.13", optional = true }
 [dev-dependencies]
 criterion = { version = "0.3.6", features = ["html_reports"] }
 csv = "1.1.6"
-indicatif = "0.17.0"
+indicatif = "0.17.1"
 xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[example]]

--- a/discovery_engine_core/ai/bert/Cargo.toml
+++ b/discovery_engine_core/ai/bert/Cargo.toml
@@ -1,26 +1,27 @@
 [package]
 name = "xayn-discovery-engine-bert"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "from"] }
-displaydoc = "0.2.3"
-float-cmp = "0.9.0"
-ndarray = { version = "0.15.6", features = ["serde"] }
-serde = { version = "1.0.145", features = ["derive"] }
-thiserror = "1.0.37"
-tokenizers = { version = "0.13.0", default-features = false, features = ["onig"] }
-tract-onnx = "0.17.8"
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
+float-cmp = { workspace = true }
+ndarray = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokenizers = { workspace = true }
+tract-onnx = { workspace = true }
 
 # dev-dependencies which don't work for aarch targets
 onnxruntime = { version = "0.0.13", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.3.6", features = ["html_reports"] }
-csv = "1.1.6"
-indicatif = "0.17.1"
+criterion = { workspace = true }
+csv = { workspace = true }
+indicatif = { workspace = true }
 xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[example]]

--- a/discovery_engine_core/ai/bert/src/model.rs
+++ b/discovery_engine_core/ai/bert/src/model.rs
@@ -117,9 +117,17 @@ where
         let input_fact = InferenceFact::dt_shape(i64::datum_type(), &[1, token_size]);
         let plan = tract_onnx::onnx()
             .model_for_read(&mut model)?
-            .with_input_fact(0, input_fact.clone())?
-            .with_input_fact(1, input_fact.clone())?
-            .with_input_fact(2, input_fact)?
+            .with_input_fact(0, input_fact.clone())? // token ids
+            .with_input_fact(1, input_fact.clone())? // attention mask
+            .with_input_fact(2, input_fact)? // type ids
+            .with_output_fact(
+                0,
+                InferenceFact::dt_shape(f32::datum_type(), &[1, token_size, K::EMBEDDING_SIZE]),
+            )? // all embeddings
+            .with_output_fact(
+                1,
+                InferenceFact::dt_shape(f32::datum_type(), &[1, K::EMBEDDING_SIZE]),
+            )? // [CLS] embedding
             .into_optimized()?
             .into_runnable()?;
 

--- a/discovery_engine_core/ai/kpe/Cargo.toml
+++ b/discovery_engine_core/ai/kpe/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 derive_more = { version = "0.99.17", default-features = false, features = ["deref", "from"] }
 displaydoc = "0.2.3"
 ndarray = "0.15.6"
-thiserror = "1.0.32"
+thiserror = "1.0.37"
 tokenizers = { version = "0.13.0", default-features = false, features = ["onig"] }
-tract-onnx = "0.17.3"
+tract-onnx = "0.17.8"
 xayn-discovery-engine-layer = { path = "../layer" }
 
 [dev-dependencies]

--- a/discovery_engine_core/ai/kpe/Cargo.toml
+++ b/discovery_engine_core/ai/kpe/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "xayn-discovery-engine-kpe"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "from"] }
-displaydoc = "0.2.3"
-ndarray = "0.15.6"
-thiserror = "1.0.37"
-tokenizers = { version = "0.13.0", default-features = false, features = ["onig"] }
-tract-onnx = "0.17.8"
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
+ndarray = { workspace = true }
+thiserror = { workspace = true }
+tokenizers = { workspace = true }
+tract-onnx = { workspace = true }
 xayn-discovery-engine-layer = { path = "../layer" }
 
 [dev-dependencies]
-criterion = { version = "0.3.6", features = ["html_reports"] }
+criterion = { workspace = true }
 xayn-discovery-engine-test-utils = { path = "../test-utils" }
 
 [[example]]

--- a/discovery_engine_core/ai/kpe/examples/kpe.rs
+++ b/discovery_engine_core/ai/kpe/examples/kpe.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kpe = Config::from_files(vocab()?, bert()?, cnn()?, classifier()?)?
         .with_token_size(128)?
         .build()?;
-    let key_phrases = kpe.run("Berlin & Brandenburg")?;
+    let key_phrases = kpe.run("This sequence will be split into key phrases.")?;
     println!("{:?}", key_phrases);
     assert_eq!(key_phrases.len(), 30);
 

--- a/discovery_engine_core/ai/kpe/src/model/bert.rs
+++ b/discovery_engine_core/ai/kpe/src/model/bert.rs
@@ -76,6 +76,10 @@ impl Bert {
             .model_for_read(&mut model)?
             .with_input_fact(0, input_fact.clone())? // token ids
             .with_input_fact(1, input_fact)? // attention mask
+            .with_output_fact(
+                0,
+                InferenceFact::dt_shape(f32::datum_type(), &[1, token_size, Self::EMBEDDING_SIZE]),
+            )? // embeddings
             .into_optimized()?
             .into_runnable()?;
 

--- a/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
+++ b/discovery_engine_core/ai/kpe/src/tokenizer/encoding.rs
@@ -134,7 +134,7 @@ impl<const KEY_PHRASE_SIZE: usize> Tokenizer<KEY_PHRASE_SIZE> {
 
         encoding
             .is_valid(self.tokenizer.get_vocab_size(true), KEY_PHRASE_SIZE)
-            .then(|| (encoding, key_phrases))
+            .then_some((encoding, key_phrases))
             .ok_or_else(|| "invalid encoding".into())
     }
 }

--- a/discovery_engine_core/ai/layer/Cargo.toml
+++ b/discovery_engine_core/ai/layer/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "xayn-discovery-engine-layer"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-bincode = "1.3.3"
-displaydoc = "0.2.3"
-ndarray = "0.15.6"
-rand = "0.8.5"
-rand_distr = "0.4.3"
-serde = { version = "1.0.145", features = ["derive"] }
-thiserror = "1.0.37"
+bincode = { workspace = true }
+displaydoc = { workspace = true }
+ndarray = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 xayn-discovery-engine-test-utils = { path = "../test-utils" }

--- a/discovery_engine_core/ai/layer/Cargo.toml
+++ b/discovery_engine_core/ai/layer/Cargo.toml
@@ -10,8 +10,8 @@ displaydoc = "0.2.3"
 ndarray = "0.15.6"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-serde = { version = "1.0.144", features = ["derive"] }
-thiserror = "1.0.32"
+serde = { version = "1.0.145", features = ["derive"] }
+thiserror = "1.0.37"
 
 [dev-dependencies]
 xayn-discovery-engine-test-utils = { path = "../test-utils" }

--- a/discovery_engine_core/ai/test-utils/Cargo.toml
+++ b/discovery_engine_core/ai/test-utils/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "xayn-discovery-engine-test-utils"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 publish = false
 
 [dependencies]
-float-cmp = "0.9.0"
-ndarray = "0.15.6"
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
-uuid = "1.1.2"
+float-cmp = { workspace = true }
+ndarray = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/discovery_engine_core/ai/test-utils/Cargo.toml
+++ b/discovery_engine_core/ai/test-utils/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 float-cmp = "0.9.0"
 ndarray = "0.15.6"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 uuid = "1.1.2"

--- a/discovery_engine_core/async-bindgen/async-bindgen-derive/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-derive/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "async-bindgen-derive"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "Apache-2.0"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-heck = "0.4.0"
-once_cell = "1.15.0"
+heck = { workspace = true }
+once_cell = { workspace = true }
 proc-macro2 = "1.0.46"
 quote = "1.0.21"
-syn = { version = "1.0.101", features = ["full", "extra-traits"] }
+syn = { version = "1.0.101", features = ["extra-traits", "full"] }

--- a/discovery_engine_core/async-bindgen/async-bindgen-derive/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-derive/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 
 [dependencies]
 heck = "0.4.0"
-once_cell = "1.12.0"
-proc-macro2 = "1.0.42"
+once_cell = "1.15.0"
+proc-macro2 = "1.0.46"
 quote = "1.0.21"
-syn = { version = "1.0.99", features = ["full", "extra-traits"] }
+syn = { version = "1.0.101", features = ["full", "extra-traits"] }

--- a/discovery_engine_core/async-bindgen/async-bindgen-derive/src/parse/api.rs
+++ b/discovery_engine_core/async-bindgen/async-bindgen-derive/src/parse/api.rs
@@ -69,7 +69,7 @@ impl Api {
 fn parse_impl_block(impl_block: TokenStream) -> Result<(Ident, Vec<FunctionInfo>), Error> {
     let ast = syn::parse2::<ItemImpl>(impl_block)?;
     let name = if let Type::Path(path) = &*ast.self_ty {
-        (path.qself.is_none()).then(|| path)
+        (path.qself.is_none()).then_some(path)
     } else {
         None
     };

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.62"
-handlebars = "4.3.3"
+anyhow = "1.0.65"
+handlebars = "4.3.5"
 heck = "0.4.0"
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 regex = "1.6.0"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 structopt = "0.3.26"
 
 [dev-dependencies]
-itertools = "0.10.3"
+itertools = "0.10.5"

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "async-bindgen-gen-dart"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = { workspace = true }
 handlebars = "4.3.5"
-heck = "0.4.0"
-once_cell = "1.15.0"
-regex = "1.6.0"
-serde = { version = "1.0.145", features = ["derive"] }
+heck = { workspace = true }
+once_cell = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
 structopt = "0.3.26"
 
 [dev-dependencies]
-itertools = "0.10.5"
+itertools = { workspace = true }

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/Cargo.toml
@@ -7,12 +7,12 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
 handlebars = "4.3.5"
 heck = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
-structopt = "0.3.26"
 
 [dev-dependencies]
 itertools = { workspace = true }

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/main.rs
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/main.rs
@@ -18,27 +18,27 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use clap::Parser;
 use gen_dart::generate;
 use parse_genesis::AsyncFunctionSignature;
-use structopt::StructOpt;
 
 mod gen_dart;
 mod parse_genesis;
 #[cfg(test)]
 mod test_utils;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Generate dart code for async-bindgen")]
+/// Generate dart code for async-bindgen
+#[derive(Debug, Parser)]
 struct Cli {
-    #[structopt(long)]
+    #[clap(long)]
     genesis: PathBuf,
 
-    #[structopt(long)]
+    #[clap(long)]
     ffi_class: String,
 }
 
 fn main() {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
     let genesis_ext = path_with_all_extensions_replaced(&cli.genesis, "ext.dart");
     let rel_path = Path::new(".").join(cli.genesis.file_name().unwrap());
     let file = fs::read_to_string(&cli.genesis).expect("failed to read genesis file");

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/parse_genesis.rs
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/parse_genesis.rs
@@ -196,7 +196,7 @@ fn captures_as_trimmed_lines<'a>(
         .lines()
         .flat_map(|line| {
             let line = line.trim();
-            (!line.is_empty()).then(|| line)
+            (!line.is_empty()).then_some(line)
         })
 }
 

--- a/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/test_utils.rs
+++ b/discovery_engine_core/async-bindgen/async-bindgen-gen-dart/src/test_utils.rs
@@ -31,6 +31,6 @@ pub(crate) use assert_trimmed_line_eq;
 pub(crate) fn trimmed_non_empty_lines(s: &str) -> impl Iterator<Item = &str> {
     s.lines().flat_map(|line| {
         let line = line.trim();
-        (!line.is_empty()).then(|| line)
+        (!line.is_empty()).then_some(line)
     })
 }

--- a/discovery_engine_core/async-bindgen/async-bindgen/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen/Cargo.toml
@@ -6,8 +6,8 @@ license = "Apache-2.0"
 
 [dependencies]
 async-bindgen-derive = { path = "../async-bindgen-derive" }
-once_cell = "1.12.0"
+once_cell = "1.15.0"
 static_assertions = "1.1.0"
-thiserror = "1.0.32"
-tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread"], default-features = false }
+thiserror = "1.0.37"
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread"], default-features = false }
 xayn-dart-api-dl = "0.3.0"

--- a/discovery_engine_core/async-bindgen/async-bindgen/Cargo.toml
+++ b/discovery_engine_core/async-bindgen/async-bindgen/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "async-bindgen"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "Apache-2.0"
 
 [dependencies]
 async-bindgen-derive = { path = "../async-bindgen-derive" }
-once_cell = "1.15.0"
+once_cell = { workspace = true }
 static_assertions = "1.1.0"
-thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread"], default-features = false }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 xayn-dart-api-dl = "0.3.0"

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -9,13 +9,13 @@ async-bindgen = { path = "../async-bindgen/async-bindgen" }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.22", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
-itertools = "0.10.3"
+itertools = "0.10.5"
 ndarray = "0.15.6"
 num-traits = "0.2.15"
-tokio = { version = "1.20.1", features = ["sync"] }
+tokio = { version = "1.21.2", features = ["sync"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
-url = "2.2.2"
+url = "2.3.1"
 uuid = "1.1.2"
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-core = { path = "../core" }

--- a/discovery_engine_core/bindings/Cargo.toml
+++ b/discovery_engine_core/bindings/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "xayn-discovery-engine-bindings"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
 async-bindgen = { path = "../async-bindgen/async-bindgen" }
-cfg-if = "1.0.0"
-chrono = { version = "0.4.22", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "from"] }
-itertools = "0.10.5"
-ndarray = "0.15.6"
-num-traits = "0.2.15"
-tokio = { version = "1.21.2", features = ["sync"] }
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3.15", features = ["json"] }
-url = "2.3.1"
-uuid = "1.1.2"
+cfg-if = { workspace = true }
+chrono = { workspace = true }
+derive_more = { workspace = true }
+itertools = { workspace = true }
+ndarray = { workspace = true }
+num-traits = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
+url = { workspace = true }
+uuid = { workspace = true }
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-core = { path = "../core" }
 xayn-discovery-engine-providers = { path = "../providers" }
@@ -24,12 +25,9 @@ xayn-discovery-engine-providers = { path = "../providers" }
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = "0.2.0"
 
-[dev-dependencies]
-uuid = { version = "1.1.2", features = ["v4"] }
-
 [build-dependencies]
 cbindgen = "=0.24.3"
-heck = "0.4.0"
+heck = { workspace = true }
 
 [features]
 storage = ["xayn-discovery-engine-core/storage"]

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -1,50 +1,51 @@
 [package]
 name = "xayn-discovery-engine-core"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-async-trait = "0.1.57"
-bincode = "1.3.3"
-cfg-if = "1.0.0"
-chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
-derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
-displaydoc = "0.2.3"
+async-trait = { workspace = true }
+bincode = { workspace = true }
+cfg-if = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+derivative = { workspace = true }
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
 figment = { version = "0.10.8", default-features = false, features = ["json"] }
-futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
-itertools = "0.10.5"
+futures = { workspace = true }
+itertools = { workspace = true }
 kodama = "0.2.3"
-ndarray = "0.15.6"
+ndarray = { workspace = true }
 num-derive = "0.3.3"
-num-traits = "0.2.15"
-rand = "0.8.5"
-rand_distr = "0.4.3"
-rayon = "1.5.3"
-serde = { version = "1.0.145", features = ["derive"] }
+num-traits = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true }
 serde_repr = "0.1.9"
-thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["macros", "sync", "fs"] }
-tracing = "0.1.36"
-url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "macros", "sync"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true }
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-bert = { path = "../ai/bert" }
 xayn-discovery-engine-providers = { path = "../providers" }
 
 # feature storage
-sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono"], optional = true }
+sqlx = { workspace = true, features = ["sqlite"], optional = true }
 
 [dev-dependencies]
 async-once-cell = "0.4.2"
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = "0.11.2"
 rand_chacha = "0.3.1"
-serde_json = "1.0.85"
+serde_json = { workspace = true }
 tempfile = "3.3.0"
-tokio = { version = "1.21.2", features = ["macros", "rt", "sync"] }
-wiremock = "0.5.14"
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+wiremock = { workspace = true }
 xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 
 [features]

--- a/discovery_engine_core/core/Cargo.toml
+++ b/discovery_engine_core/core/Cargo.toml
@@ -12,9 +12,9 @@ chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from"] }
 displaydoc = "0.2.3"
-figment = { version = "0.10.6", default-features = false, features = ["json"] }
+figment = { version = "0.10.8", default-features = false, features = ["json"] }
 futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
-itertools = "0.10.3"
+itertools = "0.10.5"
 kodama = "0.2.3"
 ndarray = "0.15.6"
 num-derive = "0.3.3"
@@ -22,10 +22,10 @@ num-traits = "0.2.15"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = "1.5.3"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_repr = "0.1.9"
-thiserror = "1.0.32"
-tokio = { version = "1.20.1", features = ["macros", "sync", "fs"] }
+thiserror = "1.0.37"
+tokio = { version = "1.21.2", features = ["macros", "sync", "fs"] }
 tracing = "0.1.36"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
@@ -34,7 +34,7 @@ xayn-discovery-engine-bert = { path = "../ai/bert" }
 xayn-discovery-engine-providers = { path = "../providers" }
 
 # feature storage
-sqlx = { version = "0.6.1", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono"], optional = true }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono"], optional = true }
 
 [dev-dependencies]
 async-once-cell = "0.4.2"
@@ -43,7 +43,7 @@ mockall = "0.11.2"
 rand_chacha = "0.3.1"
 serde_json = "1.0.85"
 tempfile = "3.3.0"
-tokio = { version = "1.20.1", features = ["macros", "rt", "sync"] }
+tokio = { version = "1.21.2", features = ["macros", "rt", "sync"] }
 wiremock = "0.5.14"
 xayn-discovery-engine-test-utils = { path = "../ai/test-utils" }
 

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -312,7 +312,7 @@ pub struct HistoricDocument {
 
 /// A source domain with an associated weight.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub struct WeightedSource {
     /// Source domain.
     pub source: String,

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -1180,7 +1180,10 @@ impl Engine {
     }
 
     /// Sets a new list of excluded and trusted sources.
-    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    #[cfg_attr(
+        not(feature = "storage"),
+        allow(unused_variables, clippy::unused_async)
+    )]
     pub async fn set_sources(
         &mut self,
         excluded: Vec<String>,
@@ -1229,6 +1232,7 @@ impl Engine {
     }
 
     /// Returns the trusted sources.
+    #[cfg_attr(not(feature = "storage"), allow(clippy::unused_async))]
     pub async fn trusted_sources(&mut self) -> Result<Vec<String>, Error> {
         #[cfg(feature = "storage")]
         {
@@ -1245,6 +1249,7 @@ impl Engine {
     }
 
     /// Returns the excluded sources.
+    #[cfg_attr(not(feature = "storage"), allow(clippy::unused_async))]
     pub async fn excluded_sources(&mut self) -> Result<Vec<String>, Error> {
         #[cfg(feature = "storage")]
         {
@@ -1261,7 +1266,10 @@ impl Engine {
     }
 
     /// Adds a trusted source.
-    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    #[cfg_attr(
+        not(feature = "storage"),
+        allow(unused_variables, clippy::unused_async)
+    )]
     pub async fn add_trusted_source(&mut self, new_trusted: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
@@ -1299,7 +1307,10 @@ impl Engine {
     }
 
     /// Removes a trusted source.
-    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    #[cfg_attr(
+        not(feature = "storage"),
+        allow(unused_variables, clippy::unused_async)
+    )]
     pub async fn remove_trusted_source(&mut self, trusted: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
@@ -1327,7 +1338,10 @@ impl Engine {
     }
 
     /// Adds an excluded source.
-    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    #[cfg_attr(
+        not(feature = "storage"),
+        allow(unused_variables, clippy::unused_async)
+    )]
     pub async fn add_excluded_source(&mut self, new_excluded: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {
@@ -1364,7 +1378,10 @@ impl Engine {
     }
 
     /// Removes an excluded source.
-    #[cfg_attr(not(feature = "storage"), allow(unused_variables))]
+    #[cfg_attr(
+        not(feature = "storage"),
+        allow(unused_variables, clippy::unused_async)
+    )]
     pub async fn remove_excluded_source(&mut self, excluded: String) -> Result<(), Error> {
         #[cfg(feature = "storage")]
         {

--- a/discovery_engine_core/core/src/stack/exploration/selection.rs
+++ b/discovery_engine_core/core/src/stack/exploration/selection.rs
@@ -121,7 +121,7 @@ where
         let to_remove = doc_similarities
             .row(chosen_doc)
             .indexed_iter()
-            .filter_map(|(idx, doc_sim)| (*doc_sim >= threshold).then(|| idx))
+            .filter_map(|(idx, doc_sim)| (*doc_sim >= threshold).then_some(idx))
             .collect();
         candidates = &candidates - &to_remove;
 
@@ -170,7 +170,7 @@ fn retain_documents_by_indices(
     documents
         .into_iter()
         .enumerate()
-        .filter_map(|(idx, doc)| selected.contains(&idx).then(|| doc))
+        .filter_map(|(idx, doc)| selected.contains(&idx).then_some(doc))
         .collect()
 }
 

--- a/discovery_engine_core/core/src/stack/filters/semantic.rs
+++ b/discovery_engine_core/core/src/stack/filters/semantic.rs
@@ -31,7 +31,7 @@ fn condensed_cosine_similarity(documents: &[Document]) -> Vec<f32> {
             .map(|document| document.smbert_embedding.view()),
     )
     .indexed_iter()
-    .filter_map(|((i, j), &similarity)| (i < j).then(|| similarity))
+    .filter_map(|((i, j), &similarity)| (i < j).then_some(similarity))
     .collect()
 }
 

--- a/discovery_engine_core/core/src/stack/filters/source.rs
+++ b/discovery_engine_core/core/src/stack/filters/source.rs
@@ -38,7 +38,7 @@ pub(crate) fn source_weight(document: &Document, sources: &[WeightedSource]) -> 
     let source = &document.resource.source_domain;
     sources
         .iter()
-        .find_map(|weighted| (&weighted.source == source).then(|| weighted.weight))
+        .find_map(|weighted| (&weighted.source == source).then_some(weighted.weight))
         .unwrap_or(0)
 }
 

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -47,6 +47,7 @@ pub enum NewItemsError {
 /// or different strategies.
 #[cfg_attr(test, automock)]
 #[async_trait]
+#[allow(unreachable_pub)] // false positive, probably due to proc macro
 pub trait Ops {
     /// Get the id for this set of operations.
     ///

--- a/discovery_engine_core/core/src/state.rs
+++ b/discovery_engine_core/core/src/state.rs
@@ -57,7 +57,7 @@ impl Engine {
     pub(crate) fn deserialize(
         bytes: &[u8],
     ) -> Result<(HashMap<Id, Data>, UserInterests, KeyPhrases), Error> {
-        match bytes.get(0) {
+        match bytes.first() {
             Some(version) if *version < STATE_VERSION => Ok(Default::default()),
             Some(&STATE_VERSION) => {
                 bincode::deserialize(&bytes[1..]).map_err(Error::Deserialization)
@@ -89,7 +89,7 @@ impl Engine {
                         .map(|stacks| (stacks, state))
                 })
                 .and_then(|(stacks, state)| {
-                    match state.coi.0.get(0) {
+                    match state.coi.0.first() {
                         Some(&0) => Ok((stacks, UserInterests::default(), KeyPhrases::default())),
                         Some(&1) => {
                             #[derive(Deserialize)]

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -262,9 +262,11 @@ pub mod models {
     impl ApiDocumentView {
         /// Gets the snippet or falls back to the title if the snippet is empty.
         pub(crate) fn snippet_or_title(&self) -> &str {
-            (!self.news_resource.snippet.is_empty())
-                .then(|| &self.news_resource.snippet)
-                .unwrap_or(&self.news_resource.title)
+            if self.news_resource.snippet.is_empty() {
+                &self.news_resource.title
+            } else {
+                &self.news_resource.snippet
+            }
         }
     }
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -695,7 +695,7 @@ impl StateScope for SqliteStorage {
 
         tx.commit().await?;
 
-        Ok(state.and_then(|state| (!state.state.is_empty()).then(|| state.state)))
+        Ok(state.and_then(|state| (!state.state.is_empty()).then_some(state.state)))
     }
 
     async fn clear(&self) -> Result<bool, Error> {

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -9,18 +9,18 @@ async-trait = "0.1.57"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "deref"] }
 displaydoc = "0.2.3"
-itertools = "0.10.3"
+itertools = "0.10.5"
 maplit = "1.0.2"
-once_cell = "1.13.0"
+once_cell = "1.15.0"
 regex = { version = "1.6.0", features = ["unicode-gencat"] }
-reqwest = { version = "0.11.11", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1.0.144", features = ["derive"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 serde_path_to_error = "0.1.8"
-thiserror = "1.0.32"
+thiserror = "1.0.37"
 tracing = "0.1.36"
-url = "2.2.2"
+url = "2.3.1"
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["macros", "rt"] }
+tokio = { version = "1.21.2", features = ["macros", "rt"] }
 wiremock = "0.5.14"

--- a/discovery_engine_core/providers/Cargo.toml
+++ b/discovery_engine_core/providers/Cargo.toml
@@ -1,26 +1,27 @@
 [package]
 name = "xayn-discovery-engine-providers"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
 
 [dependencies]
-async-trait = "0.1.57"
-chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["display", "deref"] }
-displaydoc = "0.2.3"
-itertools = "0.10.5"
-maplit = "1.0.2"
-once_cell = "1.15.0"
-regex = { version = "1.6.0", features = ["unicode-gencat"] }
-reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
+async-trait = { workspace = true }
+chrono = { workspace = true, features = ["clock", "serde"] }
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
+itertools = { workspace = true }
+maplit = { workspace = true }
+once_cell = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_path_to_error = "0.1.8"
-thiserror = "1.0.37"
-tracing = "0.1.36"
-url = "2.3.1"
+thiserror = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["macros", "rt"] }
-wiremock = "0.5.14"
+tokio = { workspace = true, features = ["macros", "rt"] }
+wiremock = { workspace = true }

--- a/discovery_engine_core/providers/src/models/content.rs
+++ b/discovery_engine_core/providers/src/models/content.rs
@@ -93,9 +93,11 @@ impl GenericArticle {
 
     /// Gets the snippet or falls back to the title if the snippet is empty.
     pub fn snippet_or_title(&self) -> &str {
-        (!self.snippet.is_empty())
-            .then(|| &self.snippet)
-            .unwrap_or(&self.title)
+        if self.snippet.is_empty() {
+            &self.title
+        } else {
+            &self.snippet
+        }
     }
 }
 

--- a/discovery_engine_core/rust-toolchain.toml
+++ b/discovery_engine_core/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62.1"
+channel = "1.64.0"
 profile = "default"

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -14,15 +14,15 @@ name = "discovery_engine"
 name = "newscatcher"
 
 [dependencies]
-anyhow = "1.0.62"
-clap = { version = "3.2.17", features = ["derive"] }
+anyhow = "1.0.65"
+clap = { version = "3.2.12", features = ["derive"] }
 csv = "1.1.6"
-indicatif = "0.17.0"
+indicatif = "0.17.1"
 rand = "0.8.5"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-tokio = { version = "1.20.1", features = ["fs"] }
-url = "2.2.2"
+tokio = { version = "1.21.2", features = ["fs"] }
+url = "2.3.1"
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-core = { path = "../core" }
 xayn-discovery-engine-providers = { path = "../providers" }

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "3.2.12", features = ["derive"] }
+clap = { workspace = true }
 csv = { workspace = true }
 indicatif = { workspace = true }
 rand = { workspace = true }

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -14,7 +14,7 @@ indicatif = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-core = { path = "../core" }

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -1,8 +1,24 @@
 [package]
 name = "xayn-discovery-engine-tooling"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "3.2.12", features = ["derive"] }
+csv = { workspace = true }
+indicatif = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+url = { workspace = true }
+xayn-discovery-engine-ai = { path = "../ai/ai" }
+xayn-discovery-engine-core = { path = "../core" }
+xayn-discovery-engine-providers = { path = "../providers" }
 
 [[bin]]
 name = "clean_sources"
@@ -12,17 +28,3 @@ name = "discovery_engine"
 
 [[bin]]
 name = "newscatcher"
-
-[dependencies]
-anyhow = "1.0.65"
-clap = { version = "3.2.12", features = ["derive"] }
-csv = "1.1.6"
-indicatif = "0.17.1"
-rand = "0.8.5"
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
-tokio = { version = "1.21.2", features = ["fs"] }
-url = "2.3.1"
-xayn-discovery-engine-ai = { path = "../ai/ai" }
-xayn-discovery-engine-core = { path = "../core" }
-xayn-discovery-engine-providers = { path = "../providers" }

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -13,22 +13,22 @@ bytes = { version = "1.2.1", features = ["serde"] }
 chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "as_ref"] }
 displaydoc = "0.2.3"
-dotenvy = "0.15.1"
+dotenvy = "0.15.5"
 envconfig = "0.10.0"
 futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
-itertools = "0.10.3"
+itertools = "0.10.5"
 ndarray = "0.15.6"
-reqwest = { version = "0.11.11", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1.0.144", features = ["derive"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-sqlx = { version = "0.6.1", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono"] }
-thiserror = "1.0.32"
-tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono"] }
+thiserror = "1.0.37"
+tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.2.7"
-urlencoding = "2.1.0"
+urlencoding = "2.1.2"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
-warp = "0.3.2"
+warp = "0.3.3"
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-bert = { path = "../ai/bert" }
 xayn-discovery-engine-core = { path = "../core" }

--- a/discovery_engine_core/web-api/Cargo.toml
+++ b/discovery_engine_core/web-api/Cargo.toml
@@ -1,35 +1,36 @@
 [package]
 name = "web-api"
-version = "0.1.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "AGPL-3.0-only"
-edition = "2021"
-
-[[bin]]
-name = "ingestion"
 
 [dependencies]
-bincode = "1.3.3"
+bincode = { workspace = true }
 bytes = { version = "1.2.1", features = ["serde"] }
-chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "as_ref"] }
-displaydoc = "0.2.3"
+chrono = { workspace = true, features = ["serde"] }
+derive_more = { workspace = true }
+displaydoc = { workspace = true }
 dotenvy = "0.15.5"
 envconfig = "0.10.0"
-futures = { version = "0.3.24", default-features = false, features = ["alloc"] }
-itertools = "0.10.5"
-ndarray = "0.15.6"
-reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
-sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono"] }
-thiserror = "1.0.37"
-tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
-tracing = "0.1.36"
-tracing-subscriber = "0.2.7"
+futures = { workspace = true }
+itertools = { workspace = true }
+ndarray = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["postgres"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 urlencoding = "2.1.2"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { workspace = true }
 warp = "0.3.3"
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-bert = { path = "../ai/bert" }
 xayn-discovery-engine-core = { path = "../core" }
 xayn-discovery-engine-providers = { path = "../providers" }
+
+[[bin]]
+name = "ingestion"

--- a/discovery_engine_core/web-api/src/state.rs
+++ b/discovery_engine_core/web-api/src/state.rs
@@ -56,7 +56,7 @@ impl AppState {
         let elastic = ElasticState::new(config.elastic);
         let default_documents_count = COUNT_PARAM_RANGE
             .contains(&config.default_documents_count)
-            .then(|| config.default_documents_count)
+            .then_some(config.default_documents_count)
             .ok_or(Error::InvalidCountParam(config.default_documents_count))?;
         let app_state = AppState {
             coi,


### PR DESCRIPTION
**Summary**

- requires https://github.com/xaynetwork/xayn_dart_api_dl/pull/18
- update rust
- update deps & fix breaking changes:
  - migrate deprecated `structopt` to `clap` ([c.f. here](https://github.com/TeXitoi/structopt#maintenance))
  - update `clap` following its migration guide ([c.f. here](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating))
  - update `tract-onnx` & fix model output declarations ([c.f. here](https://github.com/sonos/tract/blob/main/CHANGELOG.md#0180---2022-09-21))
- fix new lints
- use cargo workspace & fix missing features
