### PR TITLE
[Merged by Bors] - ET-3376 use futures unordered

### DIFF
--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
+use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use tracing::{debug, error, instrument};
 use warp::{hyper::StatusCode, reject::Reject, Rejection};

--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use futures::future::join_all;
+use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use tracing::{debug, error, instrument};
 use warp::{hyper::StatusCode, reject::Reject, Rejection};
@@ -80,7 +80,7 @@ pub(crate) async fn handle_personalized_documents(
             handle_user_state_op_error(err)
         })?;
     let documents_count = query.count.unwrap_or(state.default_documents_count);
-    let document_futures = cois
+    let mut document_futures = cois
         .iter()
         .map(|(coi, weight)| async {
             // weights_sum can't be zero, because coi weights will always return some weights that are > 0
@@ -106,13 +106,13 @@ pub(crate) async fn handle_personalized_documents(
                 })
                 .await
         })
-        .collect_vec();
+        .collect::<FuturesUnordered<_>>();
 
     let mut all_documents = Vec::new();
     let mut errors = Vec::new();
 
-    for results in join_all(document_futures).await {
-        match results {
+    while let Some(result) = document_futures.next().await {
+        match result {
             Ok(documents) => all_documents.extend(documents),
             Err(err) => {
                 error!("Error fetching document: {err}");


### PR DESCRIPTION
Use `FuturesUnordered` instead of `join_all`.

I'm still not sure it makes any sense as it could easily be a neglible small performance reduction instead of a similar small increase and it either way is IMHO a pre-mature optimization. Just to put it into context `join_all` will internally use `FuturesUnordered` (through `FuturesOrdered`) iff and only iff there are "many" futures (> 30), else it will not use it as it's slower.

There is also the thing that tokio promotes using `spawn` when you join over multiple futures. E.g. tokio has some mechanism to auto-brake live locks but that same mechanism can cripple larger nested futures, `FuturesUnordered` somewhat works around it but there are limits in how much it can do so. I might be better to spawn the requests and then just use `join_all` for simplicity (simpler as in simpler for us).  One thing which speaks against doing this is that spawing futures requires them to be static, so we would need to sprinkle in some `Arc`s.

**References:**

- [ET-3376]

[ET-3376]: https://xainag.atlassian.net/browse/ET-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ