### PR TITLE
[Merged by Bors] - ET-3348 fixes possible coi duplication

### DIFF
--- a/discovery_engine_core/web-api/src/migrations/20221012132833_coi_update_lock.sql
+++ b/discovery_engine_core/web-api/src/migrations/20221012132833_coi_update_lock.sql
@@ -1,0 +1,17 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS coi_update_lock (
+    user_id TEXT NOT NULL PRIMARY KEY
+);

--- a/discovery_engine_core/web-api/src/storage.rs
+++ b/discovery_engine_core/web-api/src/storage.rs
@@ -121,8 +121,7 @@ impl UserState {
         let mut positive_cois: Vec<_> = sqlx::query_as::<_, QueriedCoi>(
             "SELECT coi_id, is_positive, embedding, view_count, view_time_ms, last_view 
             FROM center_of_interest 
-            WHERE user_id = $1 AND is_positive 
-            FOR UPDATE;",
+            WHERE user_id = $1 AND is_positive;",
         )
         .bind(user_id.as_ref())
         .fetch_all(&mut tx)


### PR DESCRIPTION
**References**:
- [ET-3348]

**Summary**:
- added a dedicated table for setting up a lock needed for updating CoIs for every user in a sequential manner


**Before the change**:
- **doc_A** - transaction started
- **doc_A** - CoIs selected for update [CoiId(1)]
- **doc_B** - transaction started
- **doc_A** - now or updated CoI returned from coi calculation CoiId(2) inserted into coi table
- **doc_A** - transaction done
- **doc_B** - CoIs selected for update [CoiId(1)] - **CoI 2 is MISSING**
- **doc_B** - now or updated CoI returned from coi calculation CoiId(3) inserted into coi table
- **doc_B** - transaction done

**After the change**:
- **doc_A** - transaction started
- **doc_A** - CoIs selected for update [CoiId(1)]
- **doc_B** - transaction started
- **doc_A** - now or updated CoI returned from coi calculation CoiId(2) inserted into coi table
- **doc_A** - transaction done
- **doc_B** - CoIs selected for update [CoiId(1), CoiId(2)] - **CoI 2 is included**
- **doc_B** - now or updated CoI returned from coi calculation CoiId(3) inserted into coi table
- **doc_B** - transaction done


[ET-3348]: https://xainag.atlassian.net/browse/ET-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ