### PR TITLE
[Merged by Bors] - ET-3443 fix for embedding type in ElasticDocumentData

### DIFF
--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -185,11 +185,11 @@ fn post_documents(
         .and(with_model(model))
         .and(with_config(config))
         .and(with_client(client))
-        .and_then(handle_add_data)
+        .and_then(handle_post_documents)
 }
 
 #[instrument(skip(model, config, client))]
-async fn handle_add_data(
+async fn handle_post_documents(
     body: IngestionRequest,
     model: Model,
     config: Config,

--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -185,11 +185,11 @@ fn post_documents(
         .and(with_model(model))
         .and(with_config(config))
         .and(with_client(client))
-        .and_then(handle_post_documents)
+        .and_then(handle_add_data)
 }
 
 #[instrument(skip(model, config, client))]
-async fn handle_post_documents(
+async fn handle_add_data(
     body: IngestionRequest,
     model: Model,
     config: Config,

--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -13,7 +13,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use itertools::Itertools;
-
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};

--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -169,14 +169,18 @@ struct Total {
 
 pub(crate) mod serde_embedding_as_vec {
     use ndarray::Array;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
     use xayn_discovery_engine_ai::Embedding;
 
     pub(crate) fn serialize<S>(embedding: &Embedding, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        embedding.iter().collect::<Vec<_>>().serialize(serializer)
+        let mut seq = serializer.serialize_seq(Some(embedding.len()))?;
+        for element in embedding.iter() {
+            seq.serialize_element(element)?;
+        }
+        seq.end()
     }
 
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Embedding, D::Error>


### PR DESCRIPTION
**Reference**:
- [ET-3443]

**Summary**:
- changed type for embedding in `ElasticDocumentData` from `Embedding` to `Vec<f32>` to fix (de)serialization structure that we store in Elastic Search and use for kNN search.

Before change `Embedding` was serialized into:
```
"embedding": {
  "v": 1,
  "dim":[128],
  "data": [/* embeddings vector */]
}
```
After the change:
```
"embedding": [/* embeddings vector */]
```

[ET-3443]: https://xainag.atlassian.net/browse/ET-3443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ