### PR TITLE
[Merged by Bors] - ET-3462 Adjust error when zero user interests

### DIFF
--- a/discovery_engine_core/web-api/src/handlers.rs
+++ b/discovery_engine_core/web-api/src/handlers.rs
@@ -68,7 +68,10 @@ pub(crate) async fn handle_personalized_documents(
 
     if user_interests.is_empty() {
         error!("No user interests");
-        return Ok(Box::new(StatusCode::NOT_FOUND));
+        return Ok(Box::new(
+            PersonalizedDocumentsError::new(PersonalizedDocumentsErrorKind::NotEnoughInteractions)
+                .to_reply(StatusCode::UNPROCESSABLE_ENTITY),
+        ));
     }
 
     let cois = &user_interests.positive;


### PR DESCRIPTION
**References**:
- [ET-3462]

**Summary**:
- return `PersonalizedDocumentsError` with `NotEnoughInteractions` when zero Center of Interest present instead of `NOT_FOUND`

[ET-3462]: https://xainag.atlassian.net/browse/ET-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ