### PR TITLE
[Merged by Bors] - ET-3312 newscatcher api for mind dataset

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -32,10 +32,12 @@ dependencies = [
  "ahash",
  "base64",
  "bitflags",
+ "brotli",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
+ "flate2",
  "futures-core",
  "h2",
  "http",
@@ -51,6 +53,17 @@ dependencies = [
  "sha1",
  "smallvec",
  "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -123,15 +136,18 @@ checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
 dependencies = [
  "actix-codec",
  "actix-http",
+ "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
  "actix-utils",
+ "actix-web-codegen",
  "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
+ "cookie",
  "derive_more",
  "encoding_rs",
  "futures-core",
@@ -151,6 +167,18 @@ dependencies = [
  "socket2",
  "time 0.3.15",
  "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -177,6 +205,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -394,6 +437,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +572,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -654,6 +721,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.15",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1793,6 +1871,15 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -4706,13 +4793,21 @@ dependencies = [
 name = "xayn-discovery-engine-tooling"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "clap 4.0.10",
  "csv",
+ "displaydoc",
+ "env_logger",
+ "envconfig",
+ "envconfig_derive",
  "indicatif",
+ "log",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "url",
  "xayn-discovery-engine-ai",
@@ -4744,4 +4839,33 @@ dependencies = [
  "flate2",
  "thiserror",
  "time 0.1.44",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -15,8 +15,8 @@ displaydoc = { workspace = true }
 env_logger = "0.9.1"
 envconfig = "0.10.0"
 envconfig_derive = "0.10.0"
-log = "0.4.17"
 indicatif = { workspace = true }
+log = "0.4.17"
 rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/discovery_engine_core/tooling/Cargo.toml
+++ b/discovery_engine_core/tooling/Cargo.toml
@@ -7,13 +7,21 @@ license = "AGPL-3.0-only"
 publish = false
 
 [dependencies]
+actix-web = "4.2.1"
 anyhow = { workspace = true }
 clap = { workspace = true }
 csv = { workspace = true }
+displaydoc = { workspace = true }
+env_logger = "0.9.1"
+envconfig = "0.10.0"
+envconfig_derive = "0.10.0"
+log = "0.4.17"
 indicatif = { workspace = true }
 rand = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 xayn-discovery-engine-ai = { path = "../ai/ai" }
@@ -28,3 +36,6 @@ name = "discovery_engine"
 
 [[bin]]
 name = "newscatcher"
+
+[[bin]]
+name = "backend"

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 use serde::Deserialize;
 
 #[derive(Clone, Deserialize, Debug)]

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -27,7 +27,6 @@ pub struct Response<T> {
 #[derive(Clone, Deserialize, Debug)]
 pub struct Hits<T> {
     pub hits: Vec<Hit<T>>,
-    // pub total: Total,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -51,10 +50,4 @@ pub struct MindArticle {
     #[serde(rename(deserialize = "Category"))]
     pub category: String,
     pub date_published: String,
-}
-
-#[allow(dead_code)]
-#[derive(Clone, Deserialize, Debug)]
-pub struct Total {
-    pub value: usize,
 }

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -20,7 +20,7 @@ pub struct CountResponse {
 }
 
 #[derive(Clone, Deserialize, Debug)]
-pub struct SearchResponse<T> {
+pub struct Response<T> {
     pub hits: Hits<T>,
 }
 
@@ -39,8 +39,9 @@ pub struct Hit<T> {
     pub sort: String,
 }
 
+/// An article in the MIND dataset.
 #[derive(Clone, Deserialize, Debug)]
-pub struct Article {
+pub struct MindArticle {
     #[serde(rename(deserialize = "Title"))]
     pub title: String,
     #[serde(rename(deserialize = "Abstract"))]

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -1,14 +1,19 @@
 use serde::Deserialize;
 
 #[derive(Clone, Deserialize, Debug)]
-pub struct Response<T> {
+pub struct CountResponse {
+    pub count: usize,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct SearchResponse<T> {
     pub hits: Hits<T>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct Hits<T> {
     pub hits: Vec<Hit<T>>,
-    pub total: Total,
+    // pub total: Total,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -17,21 +22,23 @@ pub struct Hit<T> {
     pub id: String,
     #[serde(rename(deserialize = "_source"))]
     pub source: T,
+    pub sort: String,
 }
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct Article {
+    #[serde(rename(deserialize = "Title"))]
     pub title: String,
-    pub excerpt: String,
-    pub clean_url: String,
-    pub link: String,
-    pub topic: String,
-    pub country: String,
-    pub language: String,
-    pub published_date: String,
-    pub embedding: Vec<f32>,
+    #[serde(rename(deserialize = "Abstract"))]
+    pub snippet: String,
+    #[serde(rename(deserialize = "URL"))]
+    pub url: String,
+    #[serde(rename(deserialize = "Category"))]
+    pub category: String,
+    pub date_published: String,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Deserialize, Debug)]
 pub struct Total {
     pub value: usize,

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Response<T> {
+    pub hits: Hits<T>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Hits<T> {
+    pub hits: Vec<Hit<T>>,
+    pub total: Total,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Hit<T> {
+    #[serde(rename(deserialize = "_id"))]
+    pub id: String,
+    #[serde(rename(deserialize = "_source"))]
+    pub source: T,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Article {
+    pub title: String,
+    pub excerpt: String,
+    pub clean_url: String,
+    pub link: String,
+    pub topic: String,
+    pub country: String,
+    pub language: String,
+    pub published_date: String,
+    pub embedding: Vec<f32>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Total {
+    pub value: usize,
+}

--- a/discovery_engine_core/tooling/src/bin/backend/errors.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/errors.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 use displaydoc::Display as DisplayDoc;
 use thiserror::Error;
 

--- a/discovery_engine_core/tooling/src/bin/backend/errors.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/errors.rs
@@ -1,0 +1,13 @@
+use displaydoc::Display as DisplayDoc;
+use thiserror::Error;
+
+#[derive(Error, Debug, DisplayDoc)]
+pub(crate) enum BackendError {
+    /// Elastic search error: {0}
+    Elastic(#[source] reqwest::Error),
+
+    /// Error receiving response: {0}
+    Receiving(#[source] reqwest::Error),
+}
+
+impl actix_web::error::ResponseError for BackendError {}

--- a/discovery_engine_core/tooling/src/bin/backend/errors.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/errors.rs
@@ -5,9 +5,10 @@ use thiserror::Error;
 pub(crate) enum BackendError {
     /// Elastic search error: {0}
     Elastic(#[source] reqwest::Error),
-
     /// Error receiving response: {0}
     Receiving(#[source] reqwest::Error),
+    /// Error searching news with no history
+    NoHistory,
 }
 
 impl actix_web::error::ResponseError for BackendError {}

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -83,6 +83,9 @@ async fn main() -> std::io::Result<()> {
         total: response.count,
     });
 
+    let app_config = web::Data::new(config);
+    let app_client = web::Data::new(client);
+
     let addr = "0.0.0.0";
     let port = 8080;
     info!("Starting server on {addr}:{port}");
@@ -90,9 +93,9 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .app_data(web::Data::new(config.clone()))
+            .app_data(app_config.clone())
             .app_data(app_state.clone())
-            .app_data(web::Data::new(client.clone()))
+            .app_data(app_client.clone())
             .service(search_get)
             .service(search_post)
             .service(popular_get)

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -34,9 +34,7 @@ pub struct Config {
 }
 
 struct AppState {
-    #[allow(dead_code)]
     index: RwLock<usize>,
-    #[allow(dead_code)]
     from_index: RwLock<String>,
     history: RwLock<Vec<String>>,
     page_size: usize,

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -1,0 +1,100 @@
+mod elastic;
+mod errors;
+mod newscatcher;
+mod routes;
+
+use actix_web::{middleware::Logger, web, App, HttpServer};
+use envconfig::Envconfig;
+use log::info;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::routes::{latest_headlines_get, latest_headlines_post, search_get, search_post};
+
+#[derive(Envconfig, Clone, Debug)]
+pub struct Config {
+    #[envconfig(from = "ELASTIC_URL")]
+    pub elastic_url: String,
+
+    #[envconfig(from = "ELASTIC_USER")]
+    pub elastic_user: String,
+
+    #[envconfig(from = "ELASTIC_PASSWORD")]
+    pub elastic_password: String,
+
+    #[envconfig(from = "ELASTIC_INDEX_NAME")]
+    pub elastic_index_name: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct SearchParams {
+    #[serde(rename(deserialize = "q"))]
+    query: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Search {
+    #[serde(flatten)]
+    query: SearchParams,
+
+    #[serde(flatten)]
+    pagination: PaginationParams,
+    // These parameters may be sent by our client, but we will currently
+    // ignore these for these, for the POC at least.
+    // sort_by: String,
+    // lang: String,
+    // countries: String,
+    // not_sources: String,
+    // to_rank: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct PaginationParams {
+    #[serde(default = "default_page")]
+    page: usize,
+    #[serde(default = "default_page_size")]
+    page_size: usize,
+}
+
+impl PaginationParams {
+    pub fn page_size(&self) -> usize {
+        self.page_size.clamp(1, 100)
+    }
+
+    pub fn page(&self) -> usize {
+        self.page.clamp(1, 100)
+    }
+}
+
+fn default_page() -> usize {
+    1
+}
+
+fn default_page_size() -> usize {
+    100
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let config = Config::init_from_env().expect("Could not read config from environment");
+
+    let addr = "0.0.0.0";
+    let port = 8080;
+    info!("Starting server on {}:{}", addr, port);
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .app_data(web::Data::new(config.clone()))
+            .app_data(web::Data::new(Client::new()))
+            .service(search_get)
+            .service(search_post)
+            .service(latest_headlines_get)
+            .service(latest_headlines_post)
+    })
+    .bind((addr, port))?
+    .run()
+    .await
+}

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -47,53 +47,6 @@ struct SearchParams {
     query: String,
 }
 
-#[allow(dead_code)]
-#[derive(Deserialize, Debug)]
-struct Search {
-    #[serde(flatten)]
-    query: SearchParams,
-
-    #[serde(flatten)]
-    pagination: PaginationParams,
-    // These parameters may be sent by our client, but we will currently
-    // ignore these for these, for the POC at least.
-    // sort_by: String,
-    // lang: String,
-    // countries: String,
-    // not_sources: String,
-    // to_rank: usize,
-}
-
-#[allow(dead_code)]
-#[derive(Deserialize, Debug)]
-struct PaginationParams {
-    #[serde(default = "default_page")]
-    page: usize,
-    #[serde(default = "default_page_size")]
-    page_size: usize,
-}
-
-#[allow(dead_code)]
-impl PaginationParams {
-    pub fn page_size(&self) -> usize {
-        self.page_size.clamp(1, 200)
-    }
-
-    pub fn page(&self) -> usize {
-        self.page.clamp(1, 200)
-    }
-}
-
-#[allow(dead_code)]
-fn default_page() -> usize {
-    1
-}
-
-#[allow(dead_code)]
-fn default_page_size() -> usize {
-    200
-}
-
 async fn query_count(
     config: &Config,
     client: &Client,
@@ -132,7 +85,7 @@ async fn main() -> std::io::Result<()> {
 
     let addr = "0.0.0.0";
     let port = 8080;
-    info!("Starting server on {}:{}", addr, port);
+    info!("Starting server on {addr}:{port}");
 
     HttpServer::new(move || {
         App::new()

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -9,21 +9,12 @@ use log::info;
 use reqwest::Client;
 use serde::Deserialize;
 
-use crate::routes::{latest_headlines_get, latest_headlines_post, search_get, search_post};
+use crate::routes::{popular_get, popular_post, search_get, search_post};
 
 #[derive(Envconfig, Clone, Debug)]
 pub struct Config {
-    #[envconfig(from = "ELASTIC_URL")]
-    pub elastic_url: String,
-
-    #[envconfig(from = "ELASTIC_USER")]
-    pub elastic_user: String,
-
-    #[envconfig(from = "ELASTIC_PASSWORD")]
-    pub elastic_password: String,
-
-    #[envconfig(from = "ELASTIC_INDEX_NAME")]
-    pub elastic_index_name: String,
+    #[envconfig(from = "MIND_ENDPOINT")]
+    pub mind_endpoint: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -91,8 +82,8 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(Client::new()))
             .service(search_get)
             .service(search_post)
-            .service(latest_headlines_get)
-            .service(latest_headlines_post)
+            .service(popular_get)
+            .service(popular_post)
     })
     .bind((addr, port))?
     .run()

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 mod elastic;
 mod errors;
 mod newscatcher;

--- a/discovery_engine_core/tooling/src/bin/backend/newscatcher.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/newscatcher.rs
@@ -1,0 +1,40 @@
+// Here we emulate the format of the Newscatcher API, so that it's compatible with
+// our current client in the discovery engine.
+
+use serde::Serialize;
+
+#[derive(Clone, Serialize, Debug)]
+pub struct Article {
+    pub title: String,
+    #[serde(rename(serialize = "_score"), skip_serializing_if = "Option::is_none")]
+    pub score: Option<f32>,
+    pub rank: u64,
+    pub clean_url: String,
+    pub excerpt: String,
+    pub link: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub media: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub topic: String,
+    pub country: String,
+    pub language: String,
+    pub published_date: String,
+    pub embedding: Vec<f32>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Response {
+    pub status: String,
+    pub articles: Vec<Article>,
+    pub total_pages: usize,
+}
+
+impl Response {
+    pub fn new(articles: Vec<Article>, total_pages: usize) -> Self {
+        Self {
+            status: "ok".to_string(),
+            articles,
+            total_pages,
+        }
+    }
+}

--- a/discovery_engine_core/tooling/src/bin/backend/newscatcher.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/newscatcher.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 // Here we emulate the format of the Newscatcher API, so that it's compatible with
 // our current client in the discovery engine.
 

--- a/discovery_engine_core/tooling/src/bin/backend/routes.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/routes.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 use actix_web::{
     get,
     post,

--- a/discovery_engine_core/tooling/src/bin/backend/routes.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/routes.rs
@@ -1,0 +1,191 @@
+use actix_web::{
+    get,
+    post,
+    web::{Data, Json, Query},
+    Responder,
+};
+use log::debug;
+use reqwest::Client;
+use serde_json::{json, Value};
+
+use crate::{
+    elastic::{self, Hit},
+    errors::BackendError,
+    newscatcher,
+    Config,
+    PaginationParams,
+    Search,
+    SearchParams,
+};
+
+#[get("/search")]
+pub(crate) async fn search_get(
+    config: Data<Config>,
+    client: Data<Client>,
+    search_params: Query<SearchParams>,
+    page_params: Query<PaginationParams>,
+) -> Result<impl Responder, BackendError> {
+    handle_search(&config, &client, &search_params, &page_params).await
+}
+
+#[post("/search")]
+pub(crate) async fn search_post(
+    config: Data<Config>,
+    client: Data<Client>,
+    search: Json<Search>,
+) -> Result<impl Responder, BackendError> {
+    handle_search(&config, &client, &search.query, &search.pagination).await
+}
+
+#[get("/latest-headlines")]
+pub(crate) async fn latest_headlines_get(
+    config: Data<Config>,
+    client: Data<Client>,
+    page_params: Query<PaginationParams>,
+) -> Result<impl Responder, BackendError> {
+    handle_latest_headlines(&config, &client, &page_params).await
+}
+
+#[post("/latest-headlines")]
+pub(crate) async fn latest_headlines_post(
+    config: Data<Config>,
+    client: Data<Client>,
+    page_params: Json<PaginationParams>,
+) -> Result<impl Responder, BackendError> {
+    handle_latest_headlines(&config, &client, &page_params).await
+}
+
+async fn handle_search(
+    config: &Config,
+    client: &Client,
+    search_params: &SearchParams,
+    page_params: &PaginationParams,
+) -> Result<impl Responder, BackendError> {
+    let response = fetch_search_results(config, client, search_params, page_params).await?;
+    Ok(Json(newscatcher::Response::from((response, page_params))))
+}
+
+async fn handle_latest_headlines(
+    config: &Config,
+    client: &Client,
+    params: &PaginationParams,
+) -> Result<impl Responder, BackendError> {
+    let response = fetch_latest_headlines(config, client, params).await?;
+    Ok(Json(newscatcher::Response::from((response, params))))
+}
+
+async fn fetch_search_results(
+    config: &Config,
+    client: &Client,
+    search_params: &SearchParams,
+    page_params: &PaginationParams,
+) -> Result<elastic::Response<elastic::Article>, BackendError> {
+    let from = (page_params.page() - 1) * page_params.page_size();
+    let body = json!({
+        "from": from,
+        "size": page_params.page_size(),
+        "query": {
+            "query_string": {
+                "query": search_params.query,
+                "fields": ["excerpt", "title"]
+            }
+        }
+    });
+    query_elastic_search(config, client, body).await
+}
+
+async fn fetch_latest_headlines(
+    config: &Config,
+    client: &Client,
+    params: &PaginationParams,
+) -> Result<elastic::Response<elastic::Article>, BackendError> {
+    let from = (params.page() - 1) * params.page_size();
+    let body = json!({
+        "from": from,
+        "size": params.page_size(),
+        "query": {
+            "match_all":{}
+        },
+        "sort": [
+            {
+                "published_date": {
+                    "order": "desc"
+                }
+            }
+        ]
+    });
+    query_elastic_search(config, client, body).await
+}
+
+async fn query_elastic_search(
+    config: &Config,
+    client: &Client,
+    body: Value,
+) -> Result<elastic::Response<elastic::Article>, BackendError> {
+    debug!("Query: {:#?}", body);
+
+    let url = format!(
+        "{}/{}/_search",
+        config.elastic_url, config.elastic_index_name
+    );
+
+    debug!("Querying '{}'", url);
+
+    let res = client
+        .post(url)
+        .basic_auth(&config.elastic_user, Some(&config.elastic_password))
+        .json(&body)
+        .send()
+        .await
+        .map_err(BackendError::Elastic)?
+        .error_for_status()
+        .map_err(BackendError::Elastic)?;
+
+    res.json().await.map_err(BackendError::Receiving)
+}
+
+fn convert(input: Vec<Hit<elastic::Article>>) -> Vec<newscatcher::Article> {
+    input.into_iter().map(Hit::into).collect()
+}
+
+impl From<Hit<elastic::Article>> for newscatcher::Article {
+    fn from(hit: Hit<elastic::Article>) -> Self {
+        Self {
+            title: hit.source.title,
+            score: None,
+            rank: 0,
+            clean_url: hit.source.clean_url,
+            excerpt: hit.source.excerpt,
+            link: hit.source.link,
+            media: "".to_string(),
+            topic: hit.source.topic,
+            country: hit.source.country,
+            language: hit.source.language,
+            published_date: hit.source.published_date,
+            embedding: hit.source.embedding,
+        }
+    }
+}
+
+impl From<(elastic::Response<elastic::Article>, &PaginationParams)> for newscatcher::Response {
+    fn from((response, params): (elastic::Response<elastic::Article>, &PaginationParams)) -> Self {
+        let total_pages = if response.hits.hits.is_empty() {
+            0
+        } else {
+            // let mut total_pages = response.hits.total.value / params.page_size();
+            // if response.hits.total.value % params.page_size() > 0 {
+            //     total_pages += 1
+            // }
+            // total_pages
+            let total = response.hits.total.value;
+            let pg_size = params.page_size;
+            match (total / pg_size, total % pg_size) {
+                (pages, 0) => pages,
+                (pages, _) => pages + 1,
+            }
+        };
+
+        let articles = convert(response.hits.hits);
+        Self::new(articles, total_pages)
+    }
+}

--- a/discovery_engine_core/tooling/src/bin/backend/routes.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/routes.rs
@@ -159,7 +159,7 @@ async fn fetch_popular_results(
     let mut body = json!({
         "size": app_state.page_size,
         "query": {
-            "match_all":{}
+            "match_all": {}
         },
         "sort": [
             {


### PR DESCRIPTION
**Summary**

an api for searching news and fetching popular news from the MIND dataset, returned as newscatcher-like articles.

- similar idea to the [tv poc backend](https://github.com/xaynetwork/xayn_tvpoc_backend)
- logic based on [python implementation](https://github.com/xaynetwork/xayn_ai_research/blob/f294ac7b689e2552534355eae174b3bdaa889517/xayn_ai/discovery_app/api_handlers.py#L560)