### PR TITLE
[Merged by Bors] - ET-3472 Healthcheck routes for web APIs

### DIFF
--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -33,8 +33,7 @@ impl Application for Ingestion {
     type AppState = IngestionConfig;
 
     fn configure(config: &mut ServiceConfig) {
-        let healthcheck =
-            web::resource("/health").route(web::get().to(get_healthcheck.error_with_request_id()));
+        let healthcheck = web::resource("/health").route(web::get().to(HttpResponse::Ok));
         let resource = web::resource("/documents")
             .route(web::post().to(new_documents.error_with_request_id()));
 
@@ -61,10 +60,6 @@ impl Config for IngestionConfig {
 //FIXME use actual body
 #[derive(Deserialize)]
 struct NewDocuments {}
-
-async fn get_healthcheck() -> Result<impl Responder, Error> {
-    Ok(HttpResponse::Ok().finish())
-}
 
 async fn new_documents(
     _config: Data<IngestionConfig>,

--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -14,7 +14,6 @@
 
 use actix_web::{
     web::{self, Data, Json, ServiceConfig},
-    HttpResponse,
     Responder,
 };
 use serde::Deserialize;
@@ -33,11 +32,10 @@ impl Application for Ingestion {
     type AppState = IngestionConfig;
 
     fn configure(config: &mut ServiceConfig) {
-        let healthcheck = web::resource("/health").route(web::get().to(HttpResponse::Ok));
         let resource = web::resource("/documents")
             .route(web::post().to(new_documents.error_with_request_id()));
 
-        config.service(healthcheck).service(resource);
+        config.service(resource);
     }
 }
 

--- a/discovery_engine_core/web-api2/src/personalization.rs
+++ b/discovery_engine_core/web-api2/src/personalization.rs
@@ -13,7 +13,6 @@
 
 use actix_web::{
     web::{self, Data, Json, Path, ServiceConfig},
-    HttpResponse,
     Responder,
 };
 use serde::Deserialize;
@@ -32,7 +31,6 @@ impl Application for Personalization {
     type AppState = PersonalizationConfig;
 
     fn configure(config: &mut ServiceConfig) {
-        let healthcheck = web::resource("/health").route(web::get().to(HttpResponse::Ok));
         let scope = web::scope("/users/{user_id}")
             .service(
                 web::resource("interactions")
@@ -43,7 +41,7 @@ impl Application for Personalization {
                     .route(web::get().to(personalized_documents.error_with_request_id())),
             );
 
-        config.service(healthcheck).service(scope);
+        config.service(scope);
     }
 }
 

--- a/discovery_engine_core/web-api2/src/personalization.rs
+++ b/discovery_engine_core/web-api2/src/personalization.rs
@@ -32,8 +32,7 @@ impl Application for Personalization {
     type AppState = PersonalizationConfig;
 
     fn configure(config: &mut ServiceConfig) {
-        let healthcheck =
-            web::resource("/health").route(web::get().to(get_healthcheck.error_with_request_id()));
+        let healthcheck = web::resource("/health").route(web::get().to(HttpResponse::Ok));
         let scope = web::scope("/users/{user_id}")
             .service(
                 web::resource("interactions")
@@ -70,10 +69,6 @@ type UserId = String;
 //FIXME use actual body
 #[derive(Deserialize, Debug)]
 struct UpdateInteractions {}
-
-async fn get_healthcheck() -> Result<impl Responder, Error> {
-    Ok(HttpResponse::Ok().finish())
-}
 
 async fn update_interactions(
     config: Data<PersonalizationConfig>,

--- a/discovery_engine_core/web-api2/src/server.rs
+++ b/discovery_engine_core/web-api2/src/server.rs
@@ -21,6 +21,7 @@ use tracing::error;
 use actix_web::{
     web::{self, ServiceConfig},
     App,
+    HttpResponse,
     HttpServer,
 };
 
@@ -80,6 +81,7 @@ where
         HttpServer::new(move || {
             App::new()
                 .app_data(app_state.clone())
+                .service(web::resource("/health").route(web::get().to(HttpResponse::Ok)))
                 .configure(A::configure)
                 .wrap_fn(wrap_non_json_errors)
                 .wrap_fn(tracing_log_request)


### PR DESCRIPTION
**References**:
- [ET-3472]

**Summary**:
- added healtheck routes to both services

[ET-3472]: https://xainag.atlassian.net/browse/ET-3472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ