### PR TITLE
[Merged by Bors] - ET-3461: url encode id path

### DIFF
--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -126,7 +126,7 @@ impl ElasticState {
     ) -> Result<Option<DocumentProperties>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/docs-get.html
         self.query_elastic_search::<Value, DocumentPropertiesResponse>(
-            &format!("_source/{id}?_source_includes=properties"),
+            &format!("_source/{}?_source_includes=properties", id.encode()),
             None,
         )
         .await
@@ -150,7 +150,7 @@ impl ElasticState {
             "_source": false
         }));
 
-        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{id}"), body)
+        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{}", id.encode()), body)
             .await
             .and(Ok(true))
             .or_not_found(Ok(false))
@@ -169,7 +169,7 @@ impl ElasticState {
             "_source": false
         }));
 
-        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{id}"), body)
+        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{}", id.encode()), body)
             .await
             .and(Ok(true))
             .or_not_found(Ok(false))
@@ -182,7 +182,11 @@ impl ElasticState {
     ) -> Result<Option<DocumentProperty>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/docs-get.html
         self.query_elastic_search::<Value, DocumentPropertyResponse>(
-            &format!("_source/{doc_id}?_source_includes=properties.{prop_id}"),
+            &format!(
+                "_source/{}?_source_includes=properties.{}",
+                doc_id.encode(),
+                prop_id.encode()
+            ),
             None,
         )
         .await
@@ -208,10 +212,13 @@ impl ElasticState {
             "_source": false
         }));
 
-        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{doc_id}"), body)
-            .await
-            .and(Ok(true))
-            .or_not_found(Ok(false))
+        self.query_elastic_search::<_, GenericResponse>(
+            &format!("_update/{}", doc_id.encode()),
+            body,
+        )
+        .await
+        .and(Ok(true))
+        .or_not_found(Ok(false))
     }
 
     pub async fn delete_document_property(
@@ -230,10 +237,13 @@ impl ElasticState {
             "_source": false
         }));
 
-        self.query_elastic_search::<_, GenericResponse>(&format!("_update/{doc_id}"), body)
-            .await
-            .and(Ok(true))
-            .or_not_found(Ok(false))
+        self.query_elastic_search::<_, GenericResponse>(
+            &format!("_update/{}", doc_id.encode()),
+            body,
+        )
+        .await
+        .and(Ok(true))
+        .or_not_found(Ok(false))
     }
 
     pub async fn query_elastic_search<B, T>(&self, route: &str, body: Option<B>) -> Result<T, Error>

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, ops::RangeInclusive, string::FromUtf8Error};
+use std::{borrow::Cow, collections::HashMap, ops::RangeInclusive, string::FromUtf8Error};
 
 use derive_more::{AsRef, Display};
 use displaydoc::Display as DisplayDoc;
@@ -106,9 +106,13 @@ impl DocumentId {
             Ok(Self(id))
         }
     }
+
+    pub fn encode(&self) -> Cow<str> {
+        urlencoding::encode(self.as_ref())
+    }
 }
 
-#[derive(Clone, Debug, Display, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Display, Serialize, Deserialize, PartialEq, Eq, Hash, AsRef)]
 pub struct DocumentPropertyId(String);
 
 impl DocumentPropertyId {
@@ -122,6 +126,10 @@ impl DocumentPropertyId {
         } else {
             Ok(Self(id))
         }
+    }
+
+    pub fn encode(&self) -> Cow<str> {
+        urlencoding::encode(self.as_ref())
     }
 }
 


### PR DESCRIPTION
**References**

- [ET-3461]

**Summary**

All the `DocumentId` and `DocumentPropertyId` inputs in the URL of a request to ElasticSearch is now urlencoded.

[ET-3461]: https://xainag.atlassian.net/browse/ET-3461