### PR TITLE
ET-3498 port config to actix

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -2901,6 +2901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4112,12 +4122,15 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project",
+ "secrecy",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -4472,6 +4485,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zip"

--- a/discovery_engine_core/web-api2/Cargo.toml
+++ b/discovery_engine_core/web-api2/Cargo.toml
@@ -17,10 +17,13 @@ futures-util = { workspace = true }
 mime = "0.3.16"
 once_cell = { workspace = true }
 pin-project = { workspace = true }
+secrecy = { version = "0.8.0", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["postgres"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+url = { workspace = true }
 uuid = { workspace = true }

--- a/discovery_engine_core/web-api2/src/db.rs
+++ b/discovery_engine_core/web-api2/src/db.rs
@@ -1,0 +1,105 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use secrecy::{ExposeSecret, Secret};
+use serde::Deserialize;
+use sqlx::{pool::PoolOptions, postgres::PgConnectOptions, Pool, Postgres};
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    /// The default base url.
+    #[serde(default = "default_base_url")]
+    base_url: String,
+
+    /// Override port from base url.
+    #[serde(default)]
+    port: Option<u16>,
+
+    /// Override user from base url.
+    #[serde(default)]
+    user: Option<String>,
+
+    /// Override password from base url.
+    #[serde(default)]
+    password: Option<Secret<String>>,
+
+    /// Override db from base url.
+    #[serde(default)]
+    db: Option<String>,
+
+    /// Override default application name from base url.
+    ///
+    /// Defaults to `xayn-web-{CARGO_BIN_NAME}`.
+    #[serde(default = "default_application_name")]
+    application_name: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            base_url: default_base_url(),
+            user: None,
+            password: None,
+            db: None,
+            port: None,
+            application_name: default_application_name(),
+        }
+    }
+}
+
+fn default_base_url() -> String {
+    "postgres://user:pw@localhost:5432/xayn".into()
+}
+
+fn default_application_name() -> Option<String> {
+    option_env!("CARGO_BIN_NAME").map(|name| format!("xayn-web-{name}"))
+}
+
+impl Config {
+    pub(crate) async fn create_connection_pool(&self) -> Result<Pool<Postgres>, sqlx::Error> {
+        let options = self.create_connection_options()?;
+        PoolOptions::new().connect_with(options).await
+    }
+
+    fn create_connection_options(&self) -> Result<PgConnectOptions, sqlx::Error> {
+        let Self {
+            base_url,
+            port,
+            user,
+            password,
+            db,
+            application_name,
+        } = &self;
+
+        let mut options: PgConnectOptions = base_url.parse()?;
+
+        if let Some(user) = user {
+            options = options.username(user);
+        }
+        if let Some(port) = port {
+            options = options.port(*port);
+        }
+        if let Some(password) = password {
+            options = options.password(password.expose_secret())
+        }
+        if let Some(db) = db {
+            options = options.database(db);
+        }
+        if let Some(application_name) = application_name {
+            options = options.application_name(application_name);
+        }
+
+        Ok(options)
+    }
+}

--- a/discovery_engine_core/web-api2/src/elastic.rs
+++ b/discovery_engine_core/web-api2/src/elastic.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use secrecy::Secret;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    #[allow(dead_code)]
+    #[serde(default = "default_url")]
+    url: String,
+    #[allow(dead_code)]
+    #[serde(default = "default_user")]
+    user: String,
+    #[allow(dead_code)]
+    #[serde(default = "default_password")]
+    password: Secret<String>,
+    #[allow(dead_code)]
+    #[serde(default = "default_index_name")]
+    index_name: String,
+}
+
+fn default_url() -> String {
+    "http://localhost:9200".into()
+}
+
+fn default_user() -> String {
+    "elastic".into()
+}
+
+fn default_password() -> Secret<String> {
+    String::from("changeme").into()
+}
+
+fn default_index_name() -> String {
+    "test_index".into()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            url: default_url(),
+            user: default_user(),
+            password: default_password(),
+            index_name: default_index_name(),
+        }
+    }
+}

--- a/discovery_engine_core/web-api2/src/embedding.rs
+++ b/discovery_engine_core/web-api2/src/embedding.rs
@@ -12,18 +12,33 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod db;
-mod elastic;
-mod embedding;
-mod error;
-mod ingestion;
-mod load_config;
-mod logging;
-mod middleware;
-mod personalization;
-mod server;
+use std::path::PathBuf;
 
-pub use error::application::Error;
-pub use ingestion::Ingestion;
-pub use personalization::Personalization;
-pub use server::run;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Embedding {
+    #[allow(dead_code)]
+    #[serde(default = "default_vocabulary")]
+    vocabulary: PathBuf,
+    #[allow(dead_code)]
+    #[serde(default = "default_model")]
+    model: PathBuf,
+}
+
+fn default_vocabulary() -> PathBuf {
+    "assets/vocab.txt".into()
+}
+
+fn default_model() -> PathBuf {
+    "assets/model.onnx".into()
+}
+
+impl Default for Embedding {
+    fn default() -> Self {
+        Self {
+            vocabulary: default_vocabulary(),
+            model: default_model(),
+        }
+    }
+}

--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct Ingestion;
 
 impl Application for Ingestion {
-    type ConfigExtension = ();
+    type ConfigExtension = ConfigExtension;
 
     fn configure(config: &mut ServiceConfig) {
         let resource = web::resource("/documents")
@@ -37,6 +37,31 @@ impl Application for Ingestion {
 }
 
 type Config = server::Config<<Ingestion as Application>::ConfigExtension>;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ConfigExtension {
+    #[allow(dead_code)]
+    pub(crate) ingestion: IngestionConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IngestionConfig {
+    #[allow(dead_code)]
+    #[serde(default = "default_max_document_batch_size")]
+    pub(crate) max_document_batch_size: u64,
+}
+
+impl Default for IngestionConfig {
+    fn default() -> Self {
+        Self {
+            max_document_batch_size: default_max_document_batch_size(),
+        }
+    }
+}
+
+fn default_max_document_batch_size() -> u64 {
+    100
+}
 
 //FIXME use actual body
 #[derive(Deserialize)]

--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -19,17 +19,15 @@ use actix_web::{
 use serde::Deserialize;
 
 use crate::{
-    config::{CommonConfig, Config},
     error::application::{Unimplemented, WithRequestIdExt},
-    server::Application,
+    server::{self, Application},
     Error,
 };
 
 pub struct Ingestion;
 
 impl Application for Ingestion {
-    type Config = IngestionConfig;
-    type AppState = IngestionConfig;
+    type ConfigExtension = ();
 
     fn configure(config: &mut ServiceConfig) {
         let resource = web::resource("/documents")
@@ -38,28 +36,14 @@ impl Application for Ingestion {
     }
 }
 
-#[derive(Deserialize)]
-pub struct IngestionConfig {
-    #[serde(flatten)]
-    common_config: CommonConfig,
-}
-
-impl Config for IngestionConfig {
-    fn bind_address(&self) -> std::net::SocketAddr {
-        self.common_config.bind_address()
-    }
-
-    fn log_file(&self) -> Option<&std::path::Path> {
-        self.common_config.log_file()
-    }
-}
+type Config = server::Config<<Ingestion as Application>::ConfigExtension>;
 
 //FIXME use actual body
 #[derive(Deserialize)]
 struct NewDocuments {}
 
 async fn new_documents(
-    _config: Data<IngestionConfig>,
+    _config: Data<Config>,
     _new_documents: Json<NewDocuments>,
 ) -> Result<impl Responder, Error> {
     if true {

--- a/discovery_engine_core/web-api2/src/load_config.rs
+++ b/discovery_engine_core/web-api2/src/load_config.rs
@@ -12,45 +12,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 
 use figment::{
     providers::{Env, Format, Serialized, Toml},
     Figment,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
-pub trait Config: DeserializeOwned + Send + Sync + 'static {
-    fn bind_address(&self) -> SocketAddr;
-    fn log_file(&self) -> Option<&Path> {
-        None
-    }
-}
-
-#[derive(Deserialize, Debug)]
-pub struct CommonConfig {
-    #[serde(default = "default_bind_address")]
-    bind_to: SocketAddr,
-
-    #[serde(default)]
-    log_file: Option<PathBuf>,
-}
-
-fn default_bind_address() -> SocketAddr {
-    SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080).into()
-}
-
-impl Config for CommonConfig {
-    fn bind_address(&self) -> SocketAddr {
-        self.bind_to
-    }
-    fn log_file(&self) -> Option<&Path> {
-        self.log_file.as_deref()
-    }
-}
+use serde::{de::DeserializeOwned, Serialize};
 
 /// Load the configuration into given type.
 ///

--- a/discovery_engine_core/web-api2/src/personalization.rs
+++ b/discovery_engine_core/web-api2/src/personalization.rs
@@ -18,17 +18,15 @@ use actix_web::{
 use serde::Deserialize;
 
 use crate::{
-    config::{CommonConfig, Config},
     error::application::{Unimplemented, WithRequestIdExt},
-    server::Application,
+    server::{self, Application},
     Error,
 };
 
 pub struct Personalization;
 
 impl Application for Personalization {
-    type Config = PersonalizationConfig;
-    type AppState = PersonalizationConfig;
+    type ConfigExtension = ();
 
     fn configure(config: &mut ServiceConfig) {
         let scope = web::scope("/users/{user_id}")
@@ -45,21 +43,7 @@ impl Application for Personalization {
     }
 }
 
-#[derive(Deserialize, Debug)]
-pub struct PersonalizationConfig {
-    #[serde(flatten)]
-    common_config: CommonConfig,
-}
-
-impl Config for PersonalizationConfig {
-    fn bind_address(&self) -> std::net::SocketAddr {
-        self.common_config.bind_address()
-    }
-
-    fn log_file(&self) -> Option<&std::path::Path> {
-        self.common_config.log_file()
-    }
-}
+type Config = server::Config<<Personalization as Application>::ConfigExtension>;
 
 //FIXME use actual UserId
 type UserId = String;
@@ -69,7 +53,7 @@ type UserId = String;
 struct UpdateInteractions {}
 
 async fn update_interactions(
-    config: Data<PersonalizationConfig>,
+    config: Data<Config>,
     user_id: Path<UserId>,
     interactions: Json<UpdateInteractions>,
 ) -> Result<impl Responder, Error> {
@@ -83,7 +67,7 @@ async fn update_interactions(
 }
 
 async fn personalized_documents(
-    config: Data<PersonalizationConfig>,
+    config: Data<Config>,
     user_id: Path<UserId>,
 ) -> Result<impl Responder, Error> {
     dbg!((config, user_id));

--- a/discovery_engine_core/web-api2/src/server.rs
+++ b/discovery_engine_core/web-api2/src/server.rs
@@ -56,7 +56,7 @@ where
         let config_file = cli_args.config.take();
         let config =
             load_config::<Config<A::ConfigExtension>, _>(config_file.as_deref(), cli_args)?;
-        let addr = config.net.bind_to.clone();
+        let addr = config.net.bind_to;
         init_tracing(config.as_ref());
 
         let app_state = AppState::create(config).await?;

--- a/discovery_engine_core/web-api2/src/server/app_state.rs
+++ b/discovery_engine_core/web-api2/src/server/app_state.rs
@@ -12,18 +12,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod db;
-mod elastic;
-mod embedding;
-mod error;
-mod ingestion;
-mod load_config;
-mod logging;
-mod middleware;
-mod personalization;
-mod server;
+use sqlx::{Pool, Postgres};
 
-pub use error::application::Error;
-pub use ingestion::Ingestion;
-pub use personalization::Personalization;
-pub use server::run;
+use super::{Config, SetupError};
+
+pub struct AppState<E> {
+    pub(crate) config: Config<E>,
+    pub(crate) db: Pool<Postgres>,
+}
+
+impl<E> AppState<E> {
+    pub(super) async fn create(config: Config<E>) -> Result<Self, SetupError> {
+        let db = config.db.create_connection_pool().await?;
+        Ok(Self { config, db })
+    }
+}

--- a/discovery_engine_core/web-api2/src/server/app_state.rs
+++ b/discovery_engine_core/web-api2/src/server/app_state.rs
@@ -17,7 +17,9 @@ use sqlx::{Pool, Postgres};
 use super::{Config, SetupError};
 
 pub struct AppState<E> {
+    #[allow(dead_code)]
     pub(crate) config: Config<E>,
+    #[allow(dead_code)]
     pub(crate) db: Pool<Postgres>,
 }
 

--- a/discovery_engine_core/web-api2/src/server/cli.rs
+++ b/discovery_engine_core/web-api2/src/server/cli.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{net::SocketAddr, path::PathBuf};
+
+use clap::Parser;
+use serde::Serialize;
+
+/// Cli arguments for the web-api server.
+#[derive(Parser, Debug, Serialize)]
+#[command(author, version, about)]
+pub(super) struct Args {
+    /// Host and port to which the server should bind.
+    ///
+    /// This setting is prioritized over settings through
+    /// the config and environment.
+    #[arg(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) bind_to: Option<SocketAddr>,
+
+    /// File to log to additionally to logging to stdout.
+    #[arg(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) log_file: Option<PathBuf>,
+
+    /// Use given configuration file.
+    #[arg(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) config: Option<PathBuf>,
+}

--- a/discovery_engine_core/web-api2/src/server/config.rs
+++ b/discovery_engine_core/web-api2/src/server/config.rs
@@ -14,7 +14,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-use derive_more::AsRef;
+use derive_more::{AsRef, Deref};
 use serde::Deserialize;
 
 use crate::{db, elastic, logging};
@@ -50,7 +50,7 @@ impl Default for NetConfig {
 }
 
 /// Configuration combining all other configurations.
-#[derive(Deserialize, Debug, AsRef)]
+#[derive(Deserialize, Debug, Deref, AsRef)]
 pub struct Config<E> {
     #[as_ref]
     #[serde(default)]
@@ -68,6 +68,7 @@ pub struct Config<E> {
     #[serde(default)]
     pub(crate) db: db::Config,
 
+    #[deref]
     #[serde(flatten)]
     pub(crate) extension: E,
 }

--- a/discovery_engine_core/web-api2/src/server/config.rs
+++ b/discovery_engine_core/web-api2/src/server/config.rs
@@ -1,0 +1,73 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use derive_more::AsRef;
+use serde::Deserialize;
+
+use crate::{db, elastic, logging};
+
+/// Configuration for roughly network/connection layer specific configurations.
+#[derive(Debug, Deserialize)]
+pub struct NetConfig {
+    /// Address to which the server should bind.
+    #[serde(default = "default_bind_address")]
+    pub(crate) bind_to: SocketAddr,
+
+    /// Max body size limit which should be applied to all endpoints
+    #[allow(dead_code)]
+    #[serde(default = "default_max_body_size")]
+    pub(crate) max_body_size: u64,
+}
+
+fn default_bind_address() -> SocketAddr {
+    SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080).into()
+}
+
+fn default_max_body_size() -> u64 {
+    524288
+}
+
+impl Default for NetConfig {
+    fn default() -> Self {
+        Self {
+            bind_to: default_bind_address(),
+            max_body_size: default_max_body_size(),
+        }
+    }
+}
+
+/// Configuration combining all other configurations.
+#[derive(Deserialize, Debug, AsRef)]
+pub struct Config<E> {
+    #[as_ref]
+    #[serde(default)]
+    pub(crate) logging: logging::Config,
+
+    #[as_ref]
+    #[serde(default)]
+    pub(crate) net: NetConfig,
+
+    #[as_ref]
+    #[serde(default)]
+    pub(crate) elastic: elastic::Config,
+
+    #[as_ref]
+    #[serde(default)]
+    pub(crate) db: db::Config,
+
+    #[serde(flatten)]
+    pub(crate) extension: E,
+}


### PR DESCRIPTION
 - renamed `tracing` to `logging` to avoid naming collisions
   - that we use the tracing library is an implementation detail
   - similary named file for db glue code `db` and not `postrges` and `embedding` instead of `smbert`
- added (sub-)configs for `db`, `elastic` and `embedding` in  modules as well as `net` and `logging` config in existing modules
- removed `Config` trait, instead we can use bounds like `AsRef<server::Config>` or `AsRef<logging::Config>` if we need to be generic
- moved `load_config` into `load_config.rs` to avoid cyclic dependency between modules
- instead of being trait-generic over the config type and app state we now have a fixed config and app state type but with a generic extension field
  - much simpler
  - easier to add async app state creation (for `Pool<Postgres>`)
  - both have anyway mostly the same config
  - having some e.g. smbert ingestion specific options ignored is not an problem 

**References:**

- [ET-3498]