### PR TITLE
[Merged by Bors] - rustfmt groups imports

### DIFF
--- a/discovery_engine_core/ai/ai/src/coi/context.rs
+++ b/discovery_engine_core/ai/ai/src/coi/context.rs
@@ -211,12 +211,11 @@ mod tests {
     use ndarray::arr1;
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
+    use super::*;
     use crate::{
         coi::point::tests::{create_neg_cois, create_pos_cois},
         utils::SECONDS_PER_DAY_F32,
     };
-
-    use super::*;
 
     #[test]
     fn test_has_enough_cois() {

--- a/discovery_engine_core/ai/ai/src/coi/point.rs
+++ b/discovery_engine_core/ai/ai/src/coi/point.rs
@@ -164,7 +164,6 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use ndarray::{arr1, FixedInitializer};
-
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;

--- a/discovery_engine_core/ai/ai/src/coi/stats.rs
+++ b/discovery_engine_core/ai/ai/src/coi/stats.rs
@@ -128,10 +128,10 @@ pub(super) fn compute_coi_decay_factor(
 
 #[cfg(test)]
 mod tests {
-    use crate::coi::{config::Config, point::tests::create_pos_cois};
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
+    use crate::coi::{config::Config, point::tests::create_pos_cois};
 
     #[test]
     fn test_compute_relevances_empty_cois() {

--- a/discovery_engine_core/ai/ai/src/embedding.rs
+++ b/discovery_engine_core/ai/ai/src/embedding.rs
@@ -17,7 +17,6 @@ use std::ops::RangeInclusive;
 use itertools::Itertools;
 use ndarray::{Array2, ArrayBase, ArrayView1, Data, Ix1};
 use xayn_discovery_engine_bert::Embedding1;
-
 // Re-export `Embedding` specific errors.
 pub use xayn_discovery_engine_bert::MalformedBytesEmbedding;
 
@@ -109,9 +108,9 @@ pub fn cosine_similarity(a: ArrayView1<'_, f32>, b: ArrayView1<'_, f32>) -> f32 
 #[cfg(test)]
 mod tests {
     use ndarray::{arr1, arr2};
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
-    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_l2_norm() {

--- a/discovery_engine_core/ai/ai/src/kps/key_phrase.rs
+++ b/discovery_engine_core/ai/ai/src/kps/key_phrase.rs
@@ -467,12 +467,11 @@ mod tests {
     use ndarray::arr2;
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
+    use super::*;
     use crate::{
         coi::{config::Config as CoiConfig, point::tests::create_pos_cois},
         kps::config::Config as KpsConfig,
     };
-
-    use super::*;
 
     impl KeyPhrases {
         pub(crate) fn new<'a, const N: usize>(

--- a/discovery_engine_core/ai/ai/src/lib.rs
+++ b/discovery_engine_core/ai/ai/src/lib.rs
@@ -38,6 +38,8 @@ mod error;
 mod kps;
 pub mod utils;
 
+#[cfg(doc)]
+pub use crate::embedding::COSINE_SIMILARITY_RANGE;
 pub use crate::{
     coi::{
         config::{Config as CoiConfig, Error as CoiConfigError},
@@ -62,6 +64,3 @@ pub use crate::{
     },
     utils::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc, system_time_now},
 };
-
-#[cfg(doc)]
-pub use crate::embedding::COSINE_SIMILARITY_RANGE;

--- a/discovery_engine_core/ai/ai/src/utils.rs
+++ b/discovery_engine_core/ai/ai/src/utils.rs
@@ -117,9 +117,9 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
     use serde_json::{from_str, to_string};
+    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     use super::*;
-    use xayn_discovery_engine_test_utils::assert_approx_eq;
 
     #[test]
     fn test_nan_safe_f32_cmp_sorts_in_the_right_order() {

--- a/discovery_engine_core/ai/bert/benches/bert.rs
+++ b/discovery_engine_core/ai/bert/benches/bert.rs
@@ -19,7 +19,6 @@ use std::path::Path;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ndarray::s;
 use onnxruntime::{environment::Environment, GraphOptimizationLevel};
-
 use xayn_discovery_engine_bert::{tokenizer::Tokenizer, Config, Embedding2, NonePooler};
 use xayn_discovery_engine_test_utils::asset::smbert;
 

--- a/discovery_engine_core/ai/bert/examples/validate.rs
+++ b/discovery_engine_core/ai/bert/examples/validate.rs
@@ -27,7 +27,6 @@ use csv::Reader;
 use indicatif::ProgressBar;
 use ndarray::{s, Array1, Array2, ArrayView1, Axis};
 use onnxruntime::{environment::Environment, session::Session, GraphOptimizationLevel};
-
 use xayn_discovery_engine_bert::{
     tokenizer::Tokenizer,
     Config,

--- a/discovery_engine_core/ai/test-utils/src/lib.rs
+++ b/discovery_engine_core/ai/test-utils/src/lib.rs
@@ -34,6 +34,7 @@ mod approx_eq;
 pub mod asset;
 pub mod uuid;
 
-pub use crate::approx_eq::ApproxEqIter;
 #[doc(hidden)] // required for standalone export of assert_approx_eq!
 pub use float_cmp::approx_eq;
+
+pub use crate::approx_eq::ApproxEqIter;

--- a/discovery_engine_core/core/src/config.rs
+++ b/discovery_engine_core/core/src/config.rs
@@ -20,7 +20,6 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-
 use xayn_discovery_engine_ai::{CoiConfig, KpsConfig};
 use xayn_discovery_engine_providers::Market;
 

--- a/discovery_engine_core/core/src/document.rs
+++ b/discovery_engine_core/core/src/document.rs
@@ -25,13 +25,11 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
-
+pub use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_ai::{Document as AiDocument, DocumentId};
 use xayn_discovery_engine_providers::GenericArticle;
 
 use crate::stack::Id as StackId;
-
-pub use xayn_discovery_engine_ai::Embedding;
 
 /// Errors that could happen when constructing a [`Document`].
 #[derive(Error, Debug, DisplayDoc)]
@@ -307,7 +305,6 @@ pub struct WeightedSource {
 #[cfg(test)]
 pub(crate) mod tests {
     use chrono::TimeZone;
-
     use xayn_discovery_engine_providers::{Rank, UrlWithDomain};
 
     use super::*;

--- a/discovery_engine_core/core/src/engine.rs
+++ b/discovery_engine_core/core/src/engine.rs
@@ -29,7 +29,6 @@ use rayon::iter::{Either, IntoParallelIterator, ParallelIterator};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument, Level};
-
 use xayn_discovery_engine_ai::{
     self,
     cosine_similarity,
@@ -1408,12 +1407,11 @@ pub(crate) mod tests {
         MockServer,
         ResponseTemplate,
     };
-
-    use crate::{document::tests::mock_generic_article, stack::ops::MockOps};
     use xayn_discovery_engine_providers::{Rank, UrlWithDomain};
     use xayn_discovery_engine_test_utils::asset::{smbert_mocked, smbert_quantized};
 
     use super::*;
+    use crate::{document::tests::mock_generic_article, stack::ops::MockOps};
 
     #[test]
     fn test_usize_not_to_small() {

--- a/discovery_engine_core/core/src/stack.rs
+++ b/discovery_engine_core/core/src/stack.rs
@@ -299,9 +299,8 @@ mod tests {
     use uuid::Uuid;
     use xayn_discovery_engine_test_utils::assert_approx_eq;
 
-    use crate::stack::ops::MockOps;
-
     use super::*;
+    use crate::stack::ops::MockOps;
 
     // assert that `f` returns ok if the argument contains only documents valid `stack_id`
     fn assert_valid_document<T, F>(f: F, stack_id: Id)

--- a/discovery_engine_core/core/src/stack/exploration.rs
+++ b/discovery_engine_core/core/src/stack/exploration.rs
@@ -15,6 +15,7 @@
 //! Exploration stack.
 
 use std::collections::HashSet;
+
 use uuid::uuid;
 use xayn_discovery_engine_ai::UserInterests;
 

--- a/discovery_engine_core/core/src/stack/exploration/selection.rs
+++ b/discovery_engine_core/core/src/stack/exploration/selection.rs
@@ -184,9 +184,8 @@ mod tests {
     use xayn_discovery_engine_ai::CoiId;
     use xayn_discovery_engine_test_utils::{assert_approx_eq, uuid::mock_uuid};
 
-    use crate::document::Id;
-
     use super::*;
+    use crate::document::Id;
 
     fn new_doc() -> Document {
         Document {

--- a/discovery_engine_core/core/src/stack/filters/article.rs
+++ b/discovery_engine_core/core/src/stack/filters/article.rs
@@ -12,12 +12,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use xayn_discovery_engine_ai::GenericError;
+use xayn_discovery_engine_providers::GenericArticle;
+
 use crate::{
     document::{Document, HistoricDocument},
     stack::filters::DuplicateFilter,
 };
-use xayn_discovery_engine_ai::GenericError;
-use xayn_discovery_engine_providers::GenericArticle;
 
 pub(crate) trait ArticleFilter {
     fn apply(
@@ -76,12 +77,11 @@ impl SourcesFilter {
 mod tests {
     use std::{collections::HashMap, iter::FromIterator};
 
-    use crate::document::Document;
     use itertools::Itertools;
-
     use xayn_discovery_engine_providers::{NewscatcherArticle, Rank};
 
     use super::*;
+    use crate::document::Document;
 
     pub(crate) fn to_generic_article(articles: Vec<NewscatcherArticle>) -> Vec<GenericArticle> {
         articles

--- a/discovery_engine_core/core/src/stack/filters/deduplication.rs
+++ b/discovery_engine_core/core/src/stack/filters/deduplication.rs
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::collections::{HashMap, HashSet};
+
 use xayn_discovery_engine_providers::GenericArticle;
 
 use crate::document::{Document, HistoricDocument, NewsResource};

--- a/discovery_engine_core/core/src/stack/filters/semantic.rs
+++ b/discovery_engine_core/core/src/stack/filters/semantic.rs
@@ -20,9 +20,8 @@ use kodama::{linkage, Dendrogram, Method};
 use ndarray::ArrayView1;
 use xayn_discovery_engine_ai::{cosine_similarity, nan_safe_f32_cmp, pairwise_cosine_similarity};
 
-use crate::document::{Document, WeightedSource};
-
 use super::source_weight;
+use crate::document::{Document, WeightedSource};
 
 /// Computes the condensed cosine similarity matrix of the documents' embeddings.
 fn condensed_cosine_similarity<'a, I>(embeddings: I) -> Vec<f32>
@@ -304,9 +303,8 @@ mod tests {
     use xayn_discovery_engine_bert::{AveragePooler, AvgBert, Config as BertConfig};
     use xayn_discovery_engine_test_utils::{assert_approx_eq, asset::smbert_quantized};
 
-    use crate::document::NewsResource;
-
     use super::*;
+    use crate::document::NewsResource;
 
     #[test]
     fn test_condensed_cosine_similarity() {

--- a/discovery_engine_core/core/src/stack/filters/source.rs
+++ b/discovery_engine_core/core/src/stack/filters/source.rs
@@ -44,9 +44,10 @@ pub(crate) fn source_weight(document: &Document, sources: &[WeightedSource]) -> 
 
 #[cfg(test)]
 mod tests {
+    use xayn_discovery_engine_providers::{GenericArticle, NewscatcherArticle};
+
     use super::*;
     use crate::document::{Document, WeightedSource};
-    use xayn_discovery_engine_providers::{GenericArticle, NewscatcherArticle};
 
     impl WeightedSource {
         fn new(source_domain: &str, weight: i32) -> Self {

--- a/discovery_engine_core/core/src/stack/ops.rs
+++ b/discovery_engine_core/core/src/stack/ops.rs
@@ -17,7 +17,6 @@ use displaydoc::Display;
 #[cfg(test)]
 use mockall::automock;
 use thiserror::Error;
-
 use xayn_discovery_engine_ai::{GenericError, KeyPhrase};
 use xayn_discovery_engine_providers::{GenericArticle, Market};
 

--- a/discovery_engine_core/core/src/stack/ops/breaking.rs
+++ b/discovery_engine_core/core/src/stack/ops/breaking.rs
@@ -27,6 +27,7 @@ use xayn_discovery_engine_providers::{
     RankLimit,
 };
 
+use super::{common::request_min_new_items, NewItemsError, Ops};
 use crate::{
     config::EndpointConfig,
     document::{Document, HistoricDocument},
@@ -35,8 +36,6 @@ use crate::{
         Id,
     },
 };
-
-use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for breaking news items.
 pub struct BreakingNews {

--- a/discovery_engine_core/core/src/stack/ops/personalized.rs
+++ b/discovery_engine_core/core/src/stack/ops/personalized.rs
@@ -27,6 +27,7 @@ use xayn_discovery_engine_providers::{
     SimilarSearchQuery,
 };
 
+use super::{common::request_min_new_items, NewItemsError, Ops};
 use crate::{
     config::EndpointConfig,
     document::{Document, HistoricDocument},
@@ -35,8 +36,6 @@ use crate::{
         Id,
     },
 };
-
-use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for personalized news items.
 pub struct PersonalizedNews {

--- a/discovery_engine_core/core/src/stack/ops/trusted.rs
+++ b/discovery_engine_core/core/src/stack/ops/trusted.rs
@@ -27,6 +27,7 @@ use xayn_discovery_engine_providers::{
     TrustedHeadlinesQuery,
 };
 
+use super::{common::request_min_new_items, NewItemsError, Ops};
 use crate::{
     config::EndpointConfig,
     document::{Document, HistoricDocument},
@@ -35,8 +36,6 @@ use crate::{
         Id,
     },
 };
-
-use super::{common::request_min_new_items, NewItemsError, Ops};
 
 /// Stack operations customized for trusted news.
 pub struct TrustedNews {

--- a/discovery_engine_core/core/src/state.rs
+++ b/discovery_engine_core/core/src/state.rs
@@ -105,15 +105,17 @@ impl Engine {
 }
 
 mod naive_date_time_migration {
+    use std::collections::HashMap;
+
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{Deserialize, Serialize};
+    use url::Url;
+    use xayn_discovery_engine_ai::Embedding;
+
     use crate::{
         document::{Document, Id, NewsResource, UserReaction},
         stack::{Data, Id as StackId},
     };
-    use chrono::{DateTime, NaiveDateTime, Utc};
-    use serde::{Deserialize, Serialize};
-    use std::collections::HashMap;
-    use url::Url;
-    use xayn_discovery_engine_ai::Embedding;
 
     #[derive(Serialize, Deserialize)]
     pub(super) struct DataWithNaiveDateTime {

--- a/discovery_engine_core/core/src/storage.rs
+++ b/discovery_engine_core/core/src/storage.rs
@@ -25,14 +25,13 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use displaydoc::Display;
 use thiserror::Error;
-use xayn_discovery_engine_ai::{GenericError, MalformedBytesEmbedding};
+use xayn_discovery_engine_ai::{Embedding, GenericError, MalformedBytesEmbedding};
 
 use crate::{
     document::{self, HistoricDocument, NewsResource, UserReaction, ViewMode, WeightedSource},
     stack,
     storage::models::{ApiDocumentView, NewDocument, Search, TimeSpentDocumentView},
 };
-use xayn_discovery_engine_ai::Embedding;
 
 pub(crate) type BoxedStorage = Box<dyn Storage + Send + Sync>;
 

--- a/discovery_engine_core/core/src/storage/sqlite.rs
+++ b/discovery_engine_core/core/src/storage/sqlite.rs
@@ -25,6 +25,7 @@ use url::Url;
 use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_providers::Market;
 
+use self::utils::SqlxSqliteResultExt;
 use crate::{
     document::{self, HistoricDocument, UserReaction, ViewMode, WeightedSource},
     stack,
@@ -53,8 +54,6 @@ use crate::{
         Storage,
     },
 };
-
-use self::utils::SqlxSqliteResultExt;
 
 mod dart_migrations;
 mod setup;
@@ -1036,14 +1035,13 @@ impl SourceReactionScope for SqliteStorage {
 
 #[cfg(test)]
 mod tests {
-    use maplit::hashset;
     use std::{collections::HashSet, time::Duration};
 
+    use maplit::hashset;
     use xayn_discovery_engine_ai::Embedding;
 
-    use crate::{document::NewsResource, stack, storage::models::NewDocument};
-
     use super::*;
+    use crate::{document::NewsResource, stack, storage::models::NewDocument};
 
     fn create_documents(n: u8) -> Vec<NewDocument> {
         (0..n)

--- a/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/dart_migrations.rs
@@ -19,6 +19,7 @@ use sqlx::QueryBuilder;
 use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_providers::Market;
 
+use super::SqliteStorage;
 use crate::{
     document::ViewMode,
     stack,
@@ -30,8 +31,6 @@ use crate::{
         Storage,
     },
 };
-
-use super::SqliteStorage;
 
 /// Add the data from the  dart -> rust/sqlite migration to the prepared database.
 pub(super) async fn store_migration_data(
@@ -233,12 +232,11 @@ mod tests {
     use num_traits::FromPrimitive;
     use tracing::warn;
 
+    use super::{super::setup::init_storage_system_once, *};
     use crate::{
         document::{self, UserReaction, WeightedSource},
         storage::models::{Paging, Search, SearchBy},
     };
-
-    use super::{super::setup::init_storage_system_once, *};
 
     macro_rules! assert_migration_doc_eq_api_doc {
         ($migration_doc:expr, $search_doc:expr) => {{

--- a/discovery_engine_core/core/src/storage/sqlite/setup.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/setup.rs
@@ -18,11 +18,6 @@ use std::{
     str::FromStr,
 };
 
-use crate::{
-    stack,
-    storage::{utils::SqlxPushTupleExt, DartMigrationData, Error, InitDbHint},
-    utils::{remove_file_if_exists, CompoundError, MiscErrorExt},
-};
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Pool,
@@ -32,6 +27,11 @@ use sqlx::{
 use xayn_discovery_engine_ai::Embedding;
 
 use super::SqliteStorage;
+use crate::{
+    stack,
+    storage::{utils::SqlxPushTupleExt, DartMigrationData, Error, InitDbHint},
+    utils::{remove_file_if_exists, CompoundError, MiscErrorExt},
+};
 
 /// Initializes the Sqlite storage system.
 ///
@@ -197,9 +197,8 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use crate::storage::Storage;
-
     use super::*;
+    use crate::storage::Storage;
 
     #[tokio::test]
     async fn test_missing_stacks_are_added_and_removed_stacks_removed() {

--- a/discovery_engine_core/core/src/storage/sqlite/utils.rs
+++ b/discovery_engine_core/core/src/storage/sqlite/utils.rs
@@ -51,9 +51,8 @@ impl<T> SqlxSqliteResultExt<T> for Result<T, sqlx::Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{document, storage::sqlite::setup::create_connection_pool};
-
     use super::*;
+    use crate::{document, storage::sqlite::setup::create_connection_pool};
 
     #[tokio::test]
     async fn test_fk_violation_is_invalid_document() {

--- a/discovery_engine_core/providers/src/error.rs
+++ b/discovery_engine_core/providers/src/error.rs
@@ -13,7 +13,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use displaydoc::Display as DisplayDoc;
-
 use thiserror::Error;
 
 /// Client errors.

--- a/discovery_engine_core/providers/src/newscatcher.rs
+++ b/discovery_engine_core/providers/src/newscatcher.rs
@@ -310,6 +310,7 @@ mod tests {
         ResponseTemplate,
     };
 
+    use super::*;
     use crate::{
         config::Config,
         models::{
@@ -319,8 +320,6 @@ mod tests {
         Filter,
         Market,
     };
-
-    use super::*;
 
     #[tokio::test]
     async fn test_simple_news_query() {

--- a/discovery_engine_core/rustfmt.toml
+++ b/discovery_engine_core/rustfmt.toml
@@ -2,3 +2,4 @@
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
 imports_layout = "HorizontalVertical"
+group_imports = "StdExternalCrate"

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -17,6 +17,8 @@ mod errors;
 mod newscatcher;
 mod routes;
 
+use std::net::IpAddr;
+
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use envconfig::Envconfig;
 use errors::BackendError;
@@ -24,7 +26,6 @@ use log::info;
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
-use std::net::IpAddr;
 use tokio::sync::RwLock;
 
 use crate::routes::{popular_get, popular_post, search_get, search_post};

--- a/discovery_engine_core/web-api/src/embedding.rs
+++ b/discovery_engine_core/web-api/src/embedding.rs
@@ -12,13 +12,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::utils::RelativePathBuf;
-
 use serde::{Deserialize, Serialize};
 use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_bert::{AveragePooler, AvgBert, Config as BertConfig};
 
-use crate::{error::common::InternalError, server::SetupError};
+use crate::{error::common::InternalError, server::SetupError, utils::RelativePathBuf};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {

--- a/discovery_engine_core/web-api/src/error/application.rs
+++ b/discovery_engine_core/web-api/src/error/application.rs
@@ -35,9 +35,8 @@ use serde_json::Value;
 use thiserror::Error;
 use tracing::error;
 
-use crate::middleware::tracing::RequestId;
-
 use super::json_error::JsonErrorResponseBuilder;
+use crate::middleware::tracing::RequestId;
 
 #[derive(Display, Debug, Deref)]
 #[display(fmt = "{}", error)]

--- a/discovery_engine_core/web-api/src/error/common.rs
+++ b/discovery_engine_core/web-api/src/error/common.rs
@@ -20,9 +20,8 @@ use displaydoc::Display;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::{impl_application_error, models::DocumentId, Error};
-
 use super::application::ApplicationError;
+use crate::{impl_application_error, models::DocumentId, Error};
 
 /// The requested document was not found.
 #[derive(Debug, Error, Display, Serialize)]

--- a/discovery_engine_core/web-api/src/ingestion/routes.rs
+++ b/discovery_engine_core/web-api/src/ingestion/routes.rs
@@ -22,6 +22,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 use tokio::time::Instant;
 use tracing::{error, info, instrument};
 
+use super::AppState;
 use crate::{
     elastic::{BulkInsertionError, ElasticDocument},
     error::{
@@ -36,8 +37,6 @@ use crate::{
     models::{DocumentId, DocumentProperties, DocumentProperty, DocumentPropertyId},
     Error,
 };
-
-use super::AppState;
 
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     config

--- a/discovery_engine_core/web-api/src/logging.rs
+++ b/discovery_engine_core/web-api/src/logging.rs
@@ -14,7 +14,6 @@
 
 //! Setup tracing on different platforms.
 
-use crate::utils::RelativePathBuf;
 use std::{fs::OpenOptions, sync::Once};
 
 use serde::{Deserialize, Serialize};
@@ -24,6 +23,8 @@ use tracing_subscriber::{
     layer::SubscriberExt,
     util::SubscriberInitExt,
 };
+
+use crate::utils::RelativePathBuf;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Config {

--- a/discovery_engine_core/web-api/src/middleware/json_error.rs
+++ b/discovery_engine_core/web-api/src/middleware/json_error.rs
@@ -25,9 +25,8 @@ use derive_more::Display;
 use futures_util::TryFutureExt;
 use serde_json::{json, Value};
 
-use crate::error::json_error::JsonErrorResponseBuilder;
-
 use super::tracing::RequestId;
+use crate::error::json_error::JsonErrorResponseBuilder;
 
 pub(crate) fn wrap_non_json_errors<S, B>(
     request: ServiceRequest,

--- a/discovery_engine_core/web-api/src/middleware/tracing.rs
+++ b/discovery_engine_core/web-api/src/middleware/tracing.rs
@@ -12,15 +12,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use futures_util::FutureExt;
-use serde::Serialize;
 use std::future::Future;
 
 use actix_web::{
     dev::{Service, ServiceRequest, ServiceResponse},
     HttpMessage,
 };
-
+use futures_util::FutureExt;
+use serde::Serialize;
 use tracing::{info_span, trace, Instrument};
 use uuid::Uuid;
 

--- a/discovery_engine_core/web-api/src/personalization/routes.rs
+++ b/discovery_engine_core/web-api/src/personalization/routes.rs
@@ -22,7 +22,6 @@ use actix_web::{
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-
 use tracing::{error, warn};
 use xayn_discovery_engine_ai::{
     compute_coi_relevances,
@@ -32,6 +31,7 @@ use xayn_discovery_engine_ai::{
     PositiveCoi,
 };
 
+use super::{AppState, PersonalizationConfig};
 use crate::{
     elastic::KnnSearchParams,
     error::{
@@ -41,8 +41,6 @@ use crate::{
     models::{DocumentId, PersonalizedDocument, UserId, UserInteractionType},
     Error,
 };
-
-use super::{AppState, PersonalizationConfig};
 
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     let scope = web::scope("/users/{user_id}")

--- a/discovery_engine_core/web-api/src/server.rs
+++ b/discovery_engine_core/web-api/src/server.rs
@@ -16,10 +16,6 @@ mod app_state;
 mod cli;
 mod config;
 
-use clap::Parser;
-use serde::{de::DeserializeOwned, Serialize};
-use tracing::error;
-
 use actix_web::{
     middleware,
     web::{self, JsonConfig, ServiceConfig},
@@ -27,16 +23,18 @@ use actix_web::{
     HttpResponse,
     HttpServer,
 };
-
-use crate::{
-    load_config::load_config,
-    logging::init_tracing,
-    middleware::{json_error::wrap_non_json_errors, tracing::tracing_log_request},
-};
+use clap::Parser;
+use serde::{de::DeserializeOwned, Serialize};
+use tracing::error;
 
 pub use self::{
     app_state::AppState,
     config::{Config, NetConfig},
+};
+use crate::{
+    load_config::load_config,
+    logging::init_tracing,
+    middleware::{json_error::wrap_non_json_errors, tracing::tracing_log_request},
 };
 
 pub trait Application {

--- a/discovery_engine_core/web-api/src/server/app_state.rs
+++ b/discovery_engine_core/web-api/src/server/app_state.rs
@@ -14,9 +14,8 @@
 
 use derive_more::{AsRef, Deref};
 
-use crate::{db::Database, elastic::ElasticSearchClient};
-
 use super::{Config, SetupError};
+use crate::{db::Database, elastic::ElasticSearchClient};
 
 #[derive(Deref, AsRef)]
 pub struct AppState<CE, AE> {

--- a/discovery_engine_core/web-api/tests/config.rs
+++ b/discovery_engine_core/web-api/tests/config.rs
@@ -18,6 +18,7 @@ use std::{
     os::unix::prelude::OsStrExt,
     sync::Mutex,
 };
+
 use trycmd::TestCases;
 
 fn with_env_guard(


### PR DESCRIPTION
This enables the `group_imports` option. With this rustfmt automatically groups the imports in `std`, `external`, and `crate.
This is almost what we already wanted but we lose control of some things:
* it is not able to differentiate between workspace and external so all our crates will go in that section,
* it does not understand local import: 
```rust
mod foo {
    struct Foo;
}

use foo::Foo;
use rand::random;
```
instead of having a separate group for `foo`. 
* It does not respect groups that we create manually
```rust
use tokio;

use itertools;
```
the imports will be merged.

Looking at the changeset we are not too bad at maintaining this style. Most of the changes are the position of `crate` wr.t. to `self` or `super`, fusing groups, and moving our workspace crates to the external one.
But this will be our only option to enforce this style with a tool.

https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#group_imports
https://github.com/rust-lang/rustfmt/issues/4709
https://github.com/rust-lang/rustfmt/issues/4693
