### PR TITLE
[Merged by Bors] - ET-3472 Healthcheck for warp

### DIFF
--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -32,6 +32,7 @@ use warp::{
 };
 
 use web_api::{
+    get_health,
     DocumentId,
     DocumentProperties,
     DocumentProperty,
@@ -246,7 +247,8 @@ async fn main() -> Result<(), GenericError> {
         password: config.elastic_password.clone(),
     }));
 
-    let routes = post_documents(config.clone(), model, client.clone())
+    let routes = get_health()
+        .or(post_documents(config.clone(), model, client.clone()))
         .or(get_document_properties(client.clone()))
         .or(put_document_properties(config.clone(), client.clone()))
         .or(delete_document_properties(client.clone()))

--- a/discovery_engine_core/web-api/src/lib.rs
+++ b/discovery_engine_core/web-api/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
         UserId,
         COUNT_PARAM_RANGE,
     },
-    routes::api_routes,
+    routes::{api_routes, get_health},
     state::{AppState, InitConfig},
     storage::UserState,
 };

--- a/discovery_engine_core/web-api/src/routes.rs
+++ b/discovery_engine_core/web-api/src/routes.rs
@@ -13,7 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{convert::Infallible, sync::Arc};
-use warp::{self, Filter, Rejection, Reply};
+use warp::{http::StatusCode, Filter, Rejection, Reply};
 
 use crate::{
     handlers,
@@ -24,7 +24,14 @@ use crate::{
 pub fn api_routes(
     state: Arc<AppState>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_personalized_documents(state.clone()).or(patch_user_interactions(state))
+    get_health()
+        .or(get_personalized_documents(state.clone()))
+        .or(patch_user_interactions(state))
+}
+
+// GET /health
+pub fn get_health() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::get().and(warp::path("health")).map(|| StatusCode::OK)
 }
 
 // GET /users/:user_id/personalized_documents


### PR DESCRIPTION
**References**:
- [ET-3472]

**Summary**:
- added `GET /health` endpoint for warp based services

[ET-3472]: https://xainag.atlassian.net/browse/ET-3472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ