### PR TITLE
[Merged by Bors] - ET-3499 Add Actix Web Json parsing configuration 

### DIFF
--- a/discovery_engine_core/web-api2/src/server/config.rs
+++ b/discovery_engine_core/web-api2/src/server/config.rs
@@ -29,14 +29,14 @@ pub struct NetConfig {
     /// Max body size limit which should be applied to all endpoints
     #[allow(dead_code)]
     #[serde(default = "default_max_body_size")]
-    pub(crate) max_body_size: u64,
+    pub(crate) max_body_size: usize,
 }
 
 fn default_bind_address() -> SocketAddr {
     SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4252).into()
 }
 
-fn default_max_body_size() -> u64 {
+fn default_max_body_size() -> usize {
     524288
 }
 


### PR DESCRIPTION
**Reference**

- [ET-3499]

**Summary**

set up JsonConfig type in actix using the net.max_body_size config then add it to the actix-web App::new()...  function chain in server.rs

[ET-3499]: https://xainag.atlassian.net/browse/ET-3499

