### PR TITLE
[Merged by Bors] - ET-3516 db migration files in web api2 (4)

### DIFF
--- a/discovery_engine_core/web-api2/migrations/20220908090717_coi.sql
+++ b/discovery_engine_core/web-api2/migrations/20220908090717_coi.sql
@@ -1,0 +1,26 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS center_of_interest (
+    coi_id UUID NOT NULL PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    is_positive BOOLEAN NOT NULL,
+    embedding FLOAT4[] NOT NULL,
+    view_count INTEGER NOT NULL DEFAULT 0,
+    view_time_ms BIGINT NOT NULL DEFAULT 0,
+    last_view TIMESTAMPTZ NOT NULL DEFAULT Now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coi_by_user_id
+    ON center_of_interest(user_id);

--- a/discovery_engine_core/web-api2/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api2/migrations/20220926145400_document.sql
@@ -1,0 +1,24 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS interaction (
+    doc_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    time_stamp TIMESTAMPTZ NOT NULL DEFAULT Now(),
+    user_reaction SMALLINT NOT NULL,
+    PRIMARY KEY (doc_id, user_id, time_stamp)
+);
+
+CREATE INDEX IF NOT EXISTS idx_interaction_by_user_id
+    ON interaction(user_id);

--- a/discovery_engine_core/web-api2/migrations/20221005135633_user_last_seen.sql
+++ b/discovery_engine_core/web-api2/migrations/20221005135633_user_last_seen.sql
@@ -1,0 +1,18 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS users(
+    user_id TEXT NOT NULL PRIMARY KEY,
+    last_seen TIMESTAMPTZ NOT NULL
+);

--- a/discovery_engine_core/web-api2/migrations/20221012132833_coi_update_lock.sql
+++ b/discovery_engine_core/web-api2/migrations/20221012132833_coi_update_lock.sql
@@ -1,0 +1,17 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS coi_update_lock (
+    user_id TEXT NOT NULL PRIMARY KEY
+);

--- a/discovery_engine_core/web-api2/src/db.rs
+++ b/discovery_engine_core/web-api2/src/db.rs
@@ -123,5 +123,6 @@ impl Config {
 }
 
 pub(crate) struct Database {
+    #[allow(dead_code)]
     pool: Pool<Postgres>,
 }

--- a/discovery_engine_core/web-api2/src/db.rs
+++ b/discovery_engine_core/web-api2/src/db.rs
@@ -48,6 +48,10 @@ pub struct Config {
     /// Defaults to `xayn-web-{CARGO_BIN_NAME}`.
     #[serde(default = "default_application_name")]
     application_name: Option<String>,
+
+    /// If true skips running db migrations on start up.
+    #[serde(default)]
+    skip_migrations: bool,
 }
 
 impl Default for Config {
@@ -59,6 +63,7 @@ impl Default for Config {
             db: None,
             port: None,
             application_name: default_application_name(),
+            skip_migrations: false,
         }
     }
 }
@@ -76,12 +81,16 @@ fn default_application_name() -> Option<String> {
 }
 
 impl Config {
-    pub(crate) async fn create_connection_pool(&self) -> Result<Pool<Postgres>, sqlx::Error> {
-        let options = self.create_connection_options()?;
-        PoolOptions::new().connect_with(options).await
+    pub(crate) async fn setup_database(&self) -> Result<Database, sqlx::Error> {
+        let options = self.build_connection_options()?;
+        let pool = PoolOptions::new().connect_with(options).await?;
+        if !self.skip_migrations {
+            sqlx::migrate!().run(&pool).await?;
+        }
+        Ok(Database { pool })
     }
 
-    fn create_connection_options(&self) -> Result<PgConnectOptions, sqlx::Error> {
+    fn build_connection_options(&self) -> Result<PgConnectOptions, sqlx::Error> {
         let Self {
             base_url,
             port,
@@ -89,6 +98,7 @@ impl Config {
             password,
             db,
             application_name,
+            skip_migrations: _,
         } = &self;
 
         let mut options = base_url
@@ -110,4 +120,8 @@ impl Config {
 
         Ok(options)
     }
+}
+
+pub(crate) struct Database {
+    pool: Pool<Postgres>,
 }

--- a/discovery_engine_core/web-api2/src/server/app_state.rs
+++ b/discovery_engine_core/web-api2/src/server/app_state.rs
@@ -13,7 +13,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use derive_more::{AsRef, Deref};
-use sqlx::{Pool, Postgres};
+
+use crate::db::Database;
 
 use super::{Config, SetupError};
 
@@ -24,7 +25,7 @@ pub struct AppState<CE, AE> {
     pub(crate) config: Config<CE>,
     #[allow(dead_code)]
     #[as_ref]
-    pub(crate) db: Pool<Postgres>,
+    pub(crate) db: Database,
     #[deref]
     pub(crate) extension: AE,
 }
@@ -34,7 +35,7 @@ impl<CE, AE> AppState<CE, AE> {
         config: Config<CE>,
         create_extension: impl FnOnce(&Config<CE>) -> Result<AE, SetupError>,
     ) -> Result<Self, SetupError> {
-        let db = config.db.create_connection_pool().await?;
+        let db = config.db.setup_database().await?;
         let extension = create_extension(&config)?;
         Ok(Self {
             config,

--- a/discovery_engine_core/web-api2/tests/cmd/cli_overrides.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/cli_overrides.auto.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": "postgres",
     "password": "[REDACTED]",
     "db": "mydb",
-    "application_name": "the-application"
+    "application_name": "the-application",
+    "skip_migrations": false
   },
   "ingestion": {
     "max_document_batch_size": 999999

--- a/discovery_engine_core/web-api2/tests/cmd/default_ingestion_config.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/default_ingestion_config.auto.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": null,
     "password": "[REDACTED]",
     "db": null,
-    "application_name": null
+    "application_name": null,
+    "skip_migrations": false
   },
   "ingestion": {
     "max_document_batch_size": 100

--- a/discovery_engine_core/web-api2/tests/cmd/default_personalization_config.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/default_personalization_config.auto.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": null,
     "password": "[REDACTED]",
     "db": null,
-    "application_name": null
+    "application_name": null,
+    "skip_migrations": false
   },
   "coi": {
     "shift_factor": 0.1,

--- a/discovery_engine_core/web-api2/tests/cmd/env_overrides.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/env_overrides.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": "postgres",
     "password": "[REDACTED]",
     "db": "mydb",
-    "application_name": "the-application"
+    "application_name": "the-application",
+    "skip_migrations": false
   },
   "ingestion": {
     "max_document_batch_size": 999999

--- a/discovery_engine_core/web-api2/tests/cmd/load_config.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/load_config.auto.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": "postgres",
     "password": "[REDACTED]",
     "db": "mydb",
-    "application_name": "the-application"
+    "application_name": "the-application",
+    "skip_migrations": false
   },
   "ingestion": {
     "max_document_batch_size": 999999

--- a/discovery_engine_core/web-api2/tests/cmd/mixed_overrides.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/mixed_overrides.toml
@@ -23,7 +23,8 @@ stdout = """
     "user": "postgres",
     "password": "[REDACTED]",
     "db": "mydb",
-    "application_name": "the-application"
+    "application_name": "the-application",
+    "skip_migrations": false
   },
   "ingestion": {
     "max_document_batch_size": 999999


### PR DESCRIPTION
- Copies the `migrations` folder from `web-api` to `web-api2`. 
  - now placed under `web-api2/migrations` which is the default folder location from `sqlx`
- Run db migrations on startup by default.
- Migrations can be skipped by setting `db.skip_migrations` to `true`.
- Also encapsulate the `Pool<Postgres>` type into a `Database` type.

**References:**

- [ET-3516]
- based on 
  - #668 
  - #667
  - #659


[ET-3516]: https://xainag.atlassian.net/browse/ET-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ