### PR TITLE
[Merged by Bors] - ET-3518 error handling improvements (5)

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -4595,8 +4595,10 @@ name = "web-api2"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "clap 4.0.10",
  "derive_more",
+ "displaydoc",
  "dotenvy",
  "figment",
  "futures-util",

--- a/discovery_engine_core/web-api/openapi.yaml
+++ b/discovery_engine_core/web-api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Personalization API
-  version: 1.0.0-rc3
+  version: 1.0.0-rc4
   description: |-
     # Overview
     The personalization system is divided into two parts: one to manage documents and one to manage users.
@@ -379,10 +379,17 @@ components:
       example: "user_id"
     BaseError:
       type: object
+      required: [request_id, kind]
       properties:
         request_id:
           description: Request ID optionally generated from the service. It can be communicated to xayn to help debugging.
           type: string
+        kind:
+          description: What kind of error this is.
+          type: String
+        details:
+          description: Additional error details. Might differ depending on debug options.
+          type: object
     PersonalizedDocumentData:
       type: object
       required: [id, score]
@@ -409,7 +416,7 @@ components:
           properties:
             kind:
               type: string
-              enum: [not_enough_interactions]
+              enum: [NotEnoughInteractions]
     UserInteractionType:
       type: string
       enum: [positive]
@@ -436,7 +443,7 @@ components:
           properties:
             kind:
               type: string
-              enum: [invalid_user_id, invalid_document_id]
+              enum: [InvalidUserId, InvalidDocumentId]
     IngestedDocument:
       type: object
       required: [id, snippet]
@@ -460,16 +467,20 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseError'
         - type: object
-          required: [documents]
+          required: [details]
           properties:
-            documents:
-              type: array
-              items:
-                type: object
-                required: [id]
-                properties:
-                  id:
-                    $ref: '#/components/schemas/DocumentId'
+            details:
+              type: object
+              required: [documents]
+              properties:
+                documents:
+                  type: array
+                  items:
+                    type: object
+                    required: [id]
+                    properties:
+                      id:
+                        $ref: '#/components/schemas/DocumentId'
     DeleteDocumentsRequest:
       type: object
       required: [documents]

--- a/discovery_engine_core/web-api2/Cargo.toml
+++ b/discovery_engine_core/web-api2/Cargo.toml
@@ -9,8 +9,10 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 actix-web = { version = "4.2.1", default-features = false }
+anyhow = { workspace = true }
 clap = { workspace = true }
 derive_more = { workspace = true, features = ["display", "deref"] }
+displaydoc = { workspace = true }
 dotenvy = "0.15.5"
 figment = { version = "0.10.7", features = ["toml", "env"] }
 futures-util = { workspace = true }

--- a/discovery_engine_core/web-api2/src/error.rs
+++ b/discovery_engine_core/web-api2/src/error.rs
@@ -13,4 +13,5 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pub(crate) mod application;
+pub(crate) mod common;
 pub(crate) mod json_error;

--- a/discovery_engine_core/web-api2/src/error/application.rs
+++ b/discovery_engine_core/web-api2/src/error/application.rs
@@ -92,7 +92,7 @@ pub trait ApplicationError: std::error::Error + Send + Sync + 'static {
     }
 }
 
-/// Implements [`ApplicationError`] for given type using given http status code.
+/// Implements `ApplicationError` for given type using given http status code.
 #[macro_export]
 macro_rules! impl_application_error {
     ($name:ident => $code:ident) => {

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -27,32 +27,32 @@ use super::application::ApplicationError;
 pub struct DocumentNotFound;
 impl_application_error!(DocumentNotFound => NOT_FOUND);
 
-/// The requested property was not found
+/// The requested property was not found.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct PropertyNotFound;
 impl_application_error!(PropertyNotFound => NOT_FOUND);
 
-/// Malformed user id
+/// Malformed user id.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct InvalidUserId;
 impl_application_error!(InvalidUserId => BAD_REQUEST);
 
-/// Malformed document id
+/// Malformed document id.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct InvalidDocumentId;
 impl_application_error!(InvalidDocumentId => BAD_REQUEST);
 
-/// Malformed document property id
+/// Malformed document property id.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct InvalidPropertyId;
 impl_application_error!(InvalidPropertyId => BAD_REQUEST);
 
-/// Not enough interactions
+/// Not enough interactions.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct NotEnoughInteractions;
 impl_application_error!(NotEnoughInteractions => NOT_FOUND);
 
-/// The ingestion of some documents failed
+/// The ingestion of some documents failed.
 #[derive(Debug, Error, Display, Serialize)]
 pub struct IngestingDocumentsFailed {
     documents: Vec<MappedDocumentId>,

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -42,6 +42,11 @@ impl_application_error!(InvalidUserId => BAD_REQUEST);
 pub struct InvalidDocumentId;
 impl_application_error!(InvalidDocumentId => BAD_REQUEST);
 
+/// Malformed document property id
+#[derive(Debug, Error, Display, Serialize)]
+pub struct InvalidPropertyId;
+impl_application_error!(InvalidPropertyId => BAD_REQUEST);
+
 /// Not enough interactions
 #[derive(Debug, Error, Display, Serialize)]
 pub struct NotEnoughInteractions;

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -1,0 +1,92 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use actix_web::http::StatusCode;
+use displaydoc::Display;
+use serde::Serialize;
+use thiserror::Error;
+use tracing::error;
+
+use crate::impl_application_error;
+
+use super::application::ApplicationError;
+
+/// The requested document was not found.
+#[derive(Debug, Error, Display, Serialize)]
+pub struct DocumentNotFound;
+impl_application_error!(DocumentNotFound => NOT_FOUND);
+
+/// The requested property was not found
+#[derive(Debug, Error, Display, Serialize)]
+pub struct PropertyNotFound;
+impl_application_error!(PropertyNotFound => NOT_FOUND);
+
+/// Malformed user id
+#[derive(Debug, Error, Display, Serialize)]
+pub struct InvalidUserId;
+impl_application_error!(InvalidUserId => BAD_REQUEST);
+
+/// Malformed document id
+#[derive(Debug, Error, Display, Serialize)]
+pub struct InvalidDocumentId;
+impl_application_error!(InvalidDocumentId => BAD_REQUEST);
+
+/// Not enough interactions
+#[derive(Debug, Error, Display, Serialize)]
+pub struct NotEnoughInteractions;
+impl_application_error!(NotEnoughInteractions => NOT_FOUND);
+
+/// The ingestion of some documents failed
+#[derive(Debug, Error, Display, Serialize)]
+pub struct IngestingDocumentsFailed {
+    documents: Vec<MappedDocumentId>,
+}
+
+#[derive(Serialize, Debug)]
+struct MappedDocumentId {
+    //TODO use DocumentId once it's moved to web-api2
+    id: String,
+}
+
+impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR);
+
+/// Internal Error: {0}
+#[derive(Debug, Display, Error)]
+pub struct InternalError(anyhow::Error);
+
+impl InternalError {
+    #[allow(dead_code)]
+    pub fn from_std(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self(anyhow::Error::new(error))
+    }
+
+    #[allow(dead_code)]
+    pub fn from_anyhow(error: anyhow::Error) -> Self {
+        Self(error)
+    }
+}
+
+impl ApplicationError for InternalError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn kind(&self) -> &str {
+        "InternalServerError"
+    }
+
+    fn encode_details(&self) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+}


### PR DESCRIPTION
- log errors before rendering them
- update openapi.yaml
  - using camel case for error kinds allows us to use `stringify!($typename)` in a macro to easily implement error simple types
  - all details are now under `details:` this makes implementation a bit easier and avoid name collision problems between error details and additional base error fields
- added implementations for all common errors 
  - `InternalError` uses `anyhow::Error`
- `NotEnoughInteractions` is now `404 Not Found`, it's returned if personalized documents do not yet exist because there where not interactions yet, so 404 is more appropriate then 422 which was designed for post/put/patch requests with a body.
  

**References:**

- [ET-3518]
- based on:
  - #669
  - #668
  - #667
  - #659

[ET-3518]: https://xainag.atlassian.net/browse/ET-3518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ