### PR TITLE
[Merged by Bors] - ET-3519 actix common models (6)

### DIFF
--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -4615,6 +4615,7 @@ dependencies = [
  "tracing-subscriber",
  "trycmd",
  "url",
+ "urlencoding",
  "uuid",
  "xayn-discovery-engine-ai",
  "xayn-discovery-engine-bert",

--- a/discovery_engine_core/Cargo.lock
+++ b/discovery_engine_core/Cargo.lock
@@ -4605,6 +4605,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project",
+ "regex",
  "secrecy",
  "serde",
  "serde_json",

--- a/discovery_engine_core/web-api2/Cargo.toml
+++ b/discovery_engine_core/web-api2/Cargo.toml
@@ -11,7 +11,7 @@ license = "AGPL-3.0-only"
 actix-web = { version = "4.2.1", default-features = false }
 anyhow = { workspace = true }
 clap = { workspace = true }
-derive_more = { workspace = true, features = ["display", "deref"] }
+derive_more = { workspace = true, features = ["display", "deref", "as_ref"] }
 displaydoc = { workspace = true }
 dotenvy = "0.15.5"
 figment = { workspace = true, features = ["env", "toml"] }
@@ -28,6 +28,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 url = { workspace = true }
+urlencoding = "2.1.2"
 uuid = { workspace = true }
 xayn-discovery-engine-ai = { path = "../ai/ai" }
 xayn-discovery-engine-bert = { path = "../ai/bert" }

--- a/discovery_engine_core/web-api2/Cargo.toml
+++ b/discovery_engine_core/web-api2/Cargo.toml
@@ -11,7 +11,7 @@ license = "AGPL-3.0-only"
 actix-web = { version = "4.2.1", default-features = false }
 anyhow = { workspace = true }
 clap = { workspace = true }
-derive_more = { workspace = true, features = ["display", "deref", "as_ref"] }
+derive_more = { workspace = true, features = ["display", "deref", "as_ref", "into"] }
 displaydoc = { workspace = true }
 dotenvy = "0.15.5"
 figment = { workspace = true, features = ["env", "toml"] }
@@ -19,6 +19,7 @@ futures-util = { workspace = true }
 mime = "0.3.16"
 once_cell = { workspace = true }
 pin-project = { workspace = true }
+regex = { workspace = true }
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::error;
 
-use crate::impl_application_error;
+use crate::{impl_application_error, models::DocumentId};
 
 use super::application::ApplicationError;
 
@@ -60,8 +60,7 @@ pub struct IngestingDocumentsFailed {
 
 #[derive(Serialize, Debug)]
 struct MappedDocumentId {
-    //TODO use DocumentId once it's moved to web-api2
-    id: String,
+    id: DocumentId,
 }
 
 impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR);

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -44,8 +44,8 @@ impl_application_error!(InvalidDocumentId => BAD_REQUEST);
 
 /// Malformed document property id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidPropertyId;
-impl_application_error!(InvalidPropertyId => BAD_REQUEST);
+pub struct InvalidDocumentPropertyId;
+impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST);
 
 /// Not enough interactions.
 #[derive(Debug, Error, Display, Serialize)]

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -34,17 +34,23 @@ impl_application_error!(PropertyNotFound => NOT_FOUND);
 
 /// Malformed user id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidUserId;
+pub struct InvalidUserId {
+    pub(crate) id: String,
+}
 impl_application_error!(InvalidUserId => BAD_REQUEST);
 
 /// Malformed document id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidDocumentId;
+pub struct InvalidDocumentId {
+    pub(crate) id: String,
+}
 impl_application_error!(InvalidDocumentId => BAD_REQUEST);
 
 /// Malformed document property id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidDocumentPropertyId;
+pub struct InvalidDocumentPropertyId {
+    pub(crate) id: String,
+}
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST);
 
 /// Not enough interactions.

--- a/discovery_engine_core/web-api2/src/lib.rs
+++ b/discovery_engine_core/web-api2/src/lib.rs
@@ -20,6 +20,7 @@ mod ingestion;
 mod load_config;
 mod logging;
 mod middleware;
+mod models;
 mod personalization;
 mod server;
 mod utils;

--- a/discovery_engine_core/web-api2/src/models.rs
+++ b/discovery_engine_core/web-api2/src/models.rs
@@ -121,7 +121,7 @@ impl AiDocument for PersonalizedDocumentData {
         &self.id
     }
 
-    fn smbert_embedding(&self) -> &Embedding {
+    fn bert_embedding(&self) -> &Embedding {
         &self.embedding
     }
 }

--- a/discovery_engine_core/web-api2/src/models.rs
+++ b/discovery_engine_core/web-api2/src/models.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
 
-use crate::error::common::{InvalidDocumentId, InvalidPropertyId, InvalidUserId};
+use crate::error::common::{InvalidDocumentId, InvalidDocumentPropertyId, InvalidUserId};
 
 /// A unique identifier of a document.
 #[derive(
@@ -73,11 +73,11 @@ pub struct DocumentPropertyId(String);
 
 impl DocumentPropertyId {
     #[allow(dead_code)]
-    pub fn new(id: impl Into<String>) -> Result<Self, InvalidPropertyId> {
+    pub fn new(id: impl Into<String>) -> Result<Self, InvalidDocumentPropertyId> {
         let id = id.into();
 
         if id.is_empty() || id.contains('\u{0000}') {
-            Err(InvalidPropertyId)
+            Err(InvalidDocumentPropertyId)
         } else {
             Ok(Self(id))
         }
@@ -90,7 +90,7 @@ impl DocumentPropertyId {
 }
 
 impl FromStr for DocumentPropertyId {
-    type Err = InvalidPropertyId;
+    type Err = InvalidDocumentPropertyId;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::new(s)

--- a/discovery_engine_core/web-api2/src/models.rs
+++ b/discovery_engine_core/web-api2/src/models.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 use derive_more::{AsRef, Display};
 use serde::{Deserialize, Serialize};
@@ -38,12 +38,6 @@ use crate::error::common::{InvalidDocumentId, InvalidPropertyId, InvalidUserId};
 #[sqlx(transparent)]
 pub struct DocumentId(String);
 
-impl From<DocumentId> for String {
-    fn from(item: DocumentId) -> Self {
-        item.0
-    }
-}
-
 impl DocumentId {
     pub fn new(id: impl Into<String>) -> Result<Self, InvalidDocumentId> {
         let id = id.into();
@@ -57,6 +51,20 @@ impl DocumentId {
 
     pub fn encode(&self) -> Cow<str> {
         urlencoding::encode(self.as_ref())
+    }
+}
+
+impl FromStr for DocumentId {
+    type Err = InvalidDocumentId;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl From<DocumentId> for String {
+    fn from(item: DocumentId) -> Self {
+        item.0
     }
 }
 
@@ -78,6 +86,14 @@ impl DocumentPropertyId {
     #[allow(dead_code)]
     pub fn encode(&self) -> Cow<str> {
         urlencoding::encode(self.as_ref())
+    }
+}
+
+impl FromStr for DocumentPropertyId {
+    type Err = InvalidPropertyId;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
 }
 
@@ -160,5 +176,13 @@ impl UserId {
         } else {
             Ok(Self(id.to_string()))
         }
+    }
+}
+
+impl FromStr for UserId {
+    type Err = InvalidUserId;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
 }

--- a/discovery_engine_core/web-api2/src/models.rs
+++ b/discovery_engine_core/web-api2/src/models.rs
@@ -48,9 +48,7 @@ impl DocumentId {
     pub fn new(id: impl Into<String>) -> Result<Self, InvalidDocumentId> {
         let id = id.into();
 
-        if id.is_empty() {
-            Err(InvalidDocumentId)
-        } else if id.contains('\u{0000}') {
+        if id.is_empty() || id.contains('\u{0000}') {
             Err(InvalidDocumentId)
         } else {
             Ok(Self(id))
@@ -66,18 +64,18 @@ impl DocumentId {
 pub struct DocumentPropertyId(String);
 
 impl DocumentPropertyId {
+    #[allow(dead_code)]
     pub fn new(id: impl Into<String>) -> Result<Self, InvalidPropertyId> {
         let id = id.into();
 
-        if id.is_empty() {
-            Err(InvalidPropertyId)
-        } else if id.contains('\u{0000}') {
+        if id.is_empty() || id.contains('\u{0000}') {
             Err(InvalidPropertyId)
         } else {
             Ok(Self(id))
         }
     }
 
+    #[allow(dead_code)]
     pub fn encode(&self) -> Cow<str> {
         urlencoding::encode(self.as_ref())
     }
@@ -121,6 +119,7 @@ impl AiDocument for PersonalizedDocumentData {
 /// Represents personalized documents query params.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct PersonalizedDocumentsQuery {
+    #[allow(dead_code)]
     pub(crate) count: Option<usize>,
 }
 
@@ -132,8 +131,10 @@ pub(crate) enum UserInteractionType {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct UserInteractionData {
+    #[allow(dead_code)]
     #[serde(rename = "id")]
     pub(crate) document_id: DocumentId,
+    #[allow(dead_code)]
     #[serde(rename = "type")]
     pub(crate) interaction_type: UserInteractionType,
 }
@@ -141,6 +142,7 @@ pub(crate) struct UserInteractionData {
 /// Represents user interaction request body.
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct UserInteractionRequestBody {
+    #[allow(dead_code)]
     pub(crate) documents: Vec<UserInteractionData>,
 }
 
@@ -149,12 +151,11 @@ pub(crate) struct UserInteractionRequestBody {
 pub struct UserId(String);
 
 impl UserId {
+    #[allow(dead_code)]
     pub(crate) fn new(id: impl AsRef<str>) -> Result<Self, InvalidUserId> {
         let id = id.as_ref();
 
-        if id.is_empty() {
-            Err(InvalidUserId)
-        } else if id.contains('\u{0000}') {
+        if id.is_empty() || id.contains('\u{0000}') {
             Err(InvalidUserId)
         } else {
             Ok(Self(id.to_string()))

--- a/discovery_engine_core/web-api2/src/models.rs
+++ b/discovery_engine_core/web-api2/src/models.rs
@@ -1,0 +1,163 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{borrow::Cow, collections::HashMap};
+
+use derive_more::{AsRef, Display};
+use serde::{Deserialize, Serialize};
+
+use xayn_discovery_engine_ai::{Document as AiDocument, Embedding};
+
+use crate::error::common::{InvalidDocumentId, InvalidPropertyId, InvalidUserId};
+
+/// A unique identifier of a document.
+#[derive(
+    AsRef,
+    Clone,
+    Debug,
+    Display,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    sqlx::Type,
+    sqlx::FromRow,
+)]
+#[sqlx(transparent)]
+pub struct DocumentId(String);
+
+impl From<DocumentId> for String {
+    fn from(item: DocumentId) -> Self {
+        item.0
+    }
+}
+
+impl DocumentId {
+    pub fn new(id: impl Into<String>) -> Result<Self, InvalidDocumentId> {
+        let id = id.into();
+
+        if id.is_empty() {
+            Err(InvalidDocumentId)
+        } else if id.contains('\u{0000}') {
+            Err(InvalidDocumentId)
+        } else {
+            Ok(Self(id))
+        }
+    }
+
+    pub fn encode(&self) -> Cow<str> {
+        urlencoding::encode(self.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Display, Serialize, Deserialize, PartialEq, Eq, Hash, AsRef)]
+pub struct DocumentPropertyId(String);
+
+impl DocumentPropertyId {
+    pub fn new(id: impl Into<String>) -> Result<Self, InvalidPropertyId> {
+        let id = id.into();
+
+        if id.is_empty() {
+            Err(InvalidPropertyId)
+        } else if id.contains('\u{0000}') {
+            Err(InvalidPropertyId)
+        } else {
+            Ok(Self(id))
+        }
+    }
+
+    pub fn encode(&self) -> Cow<str> {
+        urlencoding::encode(self.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DocumentProperty(serde_json::Value);
+
+/// Arbitrary properties that can be attached to a document.
+pub type DocumentProperties = HashMap<DocumentPropertyId, DocumentProperty>;
+
+/// Represents a result from a query.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PersonalizedDocumentData {
+    /// Unique identifier of the document.
+    pub(crate) id: DocumentId,
+
+    /// Similarity score of the personalized document.
+    pub(crate) score: f32,
+
+    /// Embedding from smbert.
+    #[serde(skip_serializing)]
+    pub(crate) embedding: Embedding,
+
+    /// Contents of the document properties.
+    pub(crate) properties: DocumentProperties,
+}
+
+impl AiDocument for PersonalizedDocumentData {
+    type Id = DocumentId;
+
+    fn id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn smbert_embedding(&self) -> &Embedding {
+        &self.embedding
+    }
+}
+
+/// Represents personalized documents query params.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PersonalizedDocumentsQuery {
+    pub(crate) count: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub(crate) enum UserInteractionType {
+    #[serde(rename = "positive")]
+    Positive = 1,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct UserInteractionData {
+    #[serde(rename = "id")]
+    pub(crate) document_id: DocumentId,
+    #[serde(rename = "type")]
+    pub(crate) interaction_type: UserInteractionType,
+}
+
+/// Represents user interaction request body.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct UserInteractionRequestBody {
+    pub(crate) documents: Vec<UserInteractionData>,
+}
+
+/// Unique identifier for the user.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display, AsRef)]
+pub struct UserId(String);
+
+impl UserId {
+    pub(crate) fn new(id: impl AsRef<str>) -> Result<Self, InvalidUserId> {
+        let id = id.as_ref();
+
+        if id.is_empty() {
+            Err(InvalidUserId)
+        } else if id.contains('\u{0000}') {
+            Err(InvalidUserId)
+        } else {
+            Ok(Self(id.to_string()))
+        }
+    }
+}

--- a/discovery_engine_core/web-api2/src/personalization/routes.rs
+++ b/discovery_engine_core/web-api2/src/personalization/routes.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 
 use crate::{
     error::application::{Unimplemented, WithRequestIdExt},
+    models::UserId,
     Error,
 };
 
@@ -38,9 +39,6 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
 
     config.service(scope);
 }
-
-//FIXME use actual UserId
-type UserId = String;
 
 //FIXME use actual body
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
- copied models from web-api
- implemented `FromStr` for Id types so that they can be used directly in `Path`
- [x] propagate changes from `Id` validation 

**References:**

- [ET-3519]
- based on:
  - #670 
  - #669
  - #668
  - #667
  - #659


[ET-3519]: https://xainag.atlassian.net/browse/ET-3519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ