### PR TITLE
[Merged by Bors] - ET-3522 impl from specific error for error (8)

### DIFF
--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -75,12 +75,10 @@ impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR);
 pub struct InternalError(anyhow::Error);
 
 impl InternalError {
-    #[allow(dead_code)]
     pub fn from_std(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self(anyhow::Error::new(error))
     }
 
-    #[allow(dead_code)]
     pub fn from_anyhow(error: anyhow::Error) -> Self {
         Self(error)
     }

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -100,32 +100,26 @@ impl ApplicationError for InternalError {
     }
 }
 
-impl From<sqlx::Error> for Error {
-    fn from(error: sqlx::Error) -> Self {
-        InternalError::from_std(error).into()
-    }
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(error: reqwest::Error) -> Self {
-        InternalError::from_std(error).into()
-    }
-}
-
 impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
         InternalError::from_anyhow(error).into()
     }
 }
 
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        InternalError::from_std(error).into()
-    }
+macro_rules! impl_from_std_error {
+    ($($error:ty,)*) => {$(
+        impl From<$error> for Error {
+            fn from(error: $error) -> Self {
+                InternalError::from_std(error).into()
+            }
+        }
+    )*};
 }
 
-impl From<tokio::task::JoinError> for Error {
-    fn from(error: tokio::task::JoinError) -> Self {
-        InternalError::from_std(error).into()
-    }
-}
+impl_from_std_error!(
+    sqlx::Error,
+    reqwest::Error,
+    std::io::Error,
+    tokio::task::JoinError,
+    serde_json::Error,
+);

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -17,7 +17,7 @@ use displaydoc::Display;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::{impl_application_error, models::DocumentId};
+use crate::{impl_application_error, models::DocumentId, Error};
 
 use super::application::ApplicationError;
 
@@ -97,5 +97,35 @@ impl ApplicationError for InternalError {
 
     fn encode_details(&self) -> serde_json::Value {
         serde_json::Value::Null
+    }
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(error: sqlx::Error) -> Self {
+        InternalError::from_std(error).into()
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        InternalError::from_std(error).into()
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        InternalError::from_anyhow(error).into()
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        InternalError::from_std(error).into()
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(error: tokio::task::JoinError) -> Self {
+        InternalError::from_std(error).into()
     }
 }


### PR DESCRIPTION
impl From<T> for crate::Error where T is one of

- anyhow::Error
- sqlx::Error
- reqwest::Error
- std::io::Error
- tokio::task::JoinError
- serde_json::Error

all are nearly every time internal errors so this will use `InternalError::from_{std,anyhow}(error).into()`

A wildcard `impl From<E> where E: std::error::Error` or similar is not possible due to limitations of rust.

**References:**

- [ET-3522]
- based on:
  - #672 
  - #671   
  - #670 
  - #669
  - #668
  - #667
  - #659

[ET-3522]: https://xainag.atlassian.net/browse/ET-3522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ