### PR TITLE
[Merged by Bors] - ET-3530 Fix for elastic bulk insert

### DIFF
--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -16,12 +16,11 @@
 
 use std::{convert::Infallible, env, net::IpAddr, path::PathBuf, sync::Arc};
 
-use bytes::{BufMut, Bytes, BytesMut};
 use envconfig::Envconfig;
 use itertools::Itertools;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use tokio::time::Instant;
-use tracing::{debug, error, info, instrument};
+use tracing::{error, info, instrument};
 use tracing_subscriber::fmt::format::FmtSpan;
 use warp::{
     self,
@@ -121,51 +120,11 @@ impl IngestionError {
     }
 }
 
-/// Represents an instruction for bulk insert of data into Elastic Search service.
-#[derive(Debug, Serialize)]
-struct BulkOpInstruction {
-    index: IndexInfo,
-}
-
-impl BulkOpInstruction {
-    fn new(id: String) -> Self {
-        Self {
-            index: IndexInfo { id },
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct IndexInfo {
-    #[serde(rename(serialize = "_id"))]
-    id: String,
-}
-
 /// Represents body of a POST documents request.
 #[derive(Debug, Clone, Deserialize)]
 struct IngestionRequestBody {
     #[serde(deserialize_with = "deserialize_article_vec_not_empty")]
     documents: Vec<IngestedDocument>,
-}
-
-/// Represents body of Elastic bulk insert response.
-#[derive(Debug, Deserialize)]
-struct ElasticIngestionResponse {
-    errors: bool,
-    items: Vec<Hit>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Hit {
-    index: IngestionResult,
-}
-
-#[derive(Debug, Deserialize)]
-struct IngestionResult {
-    #[serde(rename(deserialize = "_id"))]
-    id: DocumentId,
-    status: usize,
-    error: Option<serde_json::Value>,
 }
 
 fn deserialize_string_not_empty_or_zero_byte<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -454,28 +413,7 @@ async fn handle_post_documents(
         start.elapsed().as_secs(),
     );
 
-    debug!("Serializing documents to ndjson");
-    let bytes = match serialize_to_ndjson(&documents) {
-        Ok(bytes) => bytes,
-        Err(error) => {
-            error!("Error serializing documents to ndjson: {error}");
-            return Ok(Box::new(
-                IngestionError::new(
-                    documents
-                        .into_iter()
-                        .map(|(id, _)| id)
-                        .chain(failed_documents)
-                        .collect_vec(),
-                )
-                .to_reply(),
-            ));
-        }
-    };
-
-    let response = match client
-        .query_elastic_search_raw::<Bytes, ElasticIngestionResponse>("_bulk?refresh", Some(bytes))
-        .await
-    {
+    let response = match client.bulk_insert_documents(&documents).await {
         Ok(response) => response,
         Err(error) => {
             error!("Error storing documents: {error}");
@@ -637,32 +575,4 @@ fn with_client(
     elastic: Arc<ElasticState>,
 ) -> impl Filter<Extract = (Arc<ElasticState>,), Error = Infallible> + Clone {
     warp::any().map(move || elastic.clone())
-}
-
-fn serialize_to_ndjson(
-    documents: &Vec<(DocumentId, ElasticDocumentData)>,
-) -> Result<Bytes, GenericError> {
-    let mut bytes = BytesMut::new();
-
-    fn write_record(
-        document_id: DocumentId,
-        document_data: &ElasticDocumentData,
-        bytes: &mut BytesMut,
-    ) -> Result<(), GenericError> {
-        let bulk_op_instruction = BulkOpInstruction::new(String::from(document_id));
-        let bulk_op_instruction = serde_json::to_vec(&bulk_op_instruction)?;
-        let documents_bytes = serde_json::to_vec(document_data)?;
-
-        bytes.put_slice(&bulk_op_instruction);
-        bytes.put_u8(b'\n');
-        bytes.put_slice(&documents_bytes);
-        bytes.put_u8(b'\n');
-        Ok(())
-    }
-
-    for (doc_id, doc_data) in documents {
-        write_record(doc_id.clone(), doc_data, &mut bytes)?;
-    }
-
-    Ok(bytes.freeze())
 }

--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -473,7 +473,7 @@ async fn handle_post_documents(
     };
 
     let response = match client
-        .query_elastic_search::<_, ElasticIngestionResponse>("_bulk?refresh", Some(bytes))
+        .query_elastic_search_raw::<Bytes, ElasticIngestionResponse>("_bulk?refresh", Some(bytes))
         .await
     {
         Ok(response) => response,

--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -252,7 +252,7 @@ impl ElasticState {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_TYPE,
-            HeaderValue::from_static("application/x+ndjson"),
+            HeaderValue::from_static("application/x-ndjson"),
         );
 
         self.query_bytes::<_, ElasticBulkOpResponse>("_bulk?refresh", Some(bytes), headers)

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -67,6 +67,9 @@ pub enum Error {
 
     /// Error receiving response: {0}
     Receiving(#[source] reqwest::Error),
+
+    /// Json serialization error: {0}.
+    JsonSerialization(#[source] serde_json::Error),
 }
 
 impl Reject for Error {}


### PR DESCRIPTION
**References**:
- [ET-3530]

**Summary**:
- moved ndjson serialization and related structs to elastic client
- introduced a dedicated client method `bulk_insert_documents`
- split internal `query_elastic_search` method into `query_json` and `query_bytes` for increased flexibility

[ET-3530]: https://xainag.atlassian.net/browse/ET-3530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ