### PR TITLE
[Merged by Bors] - ET-3507 implement relative path buf

### DIFF
--- a/discovery_engine_core/web-api2/src/embedding.rs
+++ b/discovery_engine_core/web-api2/src/embedding.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
+use crate::utils::RelativePathBuf;
 
 use serde::{Deserialize, Serialize};
 use xayn_discovery_engine_bert::{AveragePooler, AvgBert, Config as BertConfig};
@@ -23,10 +23,10 @@ use crate::server::SetupError;
 pub struct Config {
     #[allow(dead_code)]
     #[serde(default = "default_directory")]
-    directory: PathBuf,
+    directory: RelativePathBuf,
 }
 
-fn default_directory() -> PathBuf {
+fn default_directory() -> RelativePathBuf {
     "assets".into()
 }
 
@@ -45,7 +45,7 @@ pub(crate) struct Embedder {
 
 impl Embedder {
     pub(crate) fn load(config: &Config) -> Result<Self, SetupError> {
-        let bert = BertConfig::new(&config.directory)?
+        let bert = BertConfig::new(&config.directory.relative())?
             .with_pooler::<AveragePooler>()
             .with_token_size(64)?
             .build()?;

--- a/discovery_engine_core/web-api2/src/logging.rs
+++ b/discovery_engine_core/web-api2/src/logging.rs
@@ -14,7 +14,8 @@
 
 //! Setup tracing on different platforms.
 
-use std::{fs::OpenOptions, path::PathBuf, sync::Once};
+use crate::utils::RelativePathBuf;
+use std::{fs::OpenOptions, sync::Once};
 
 use serde::{Deserialize, Serialize};
 use tracing::Level;
@@ -26,7 +27,7 @@ use tracing_subscriber::{
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Config {
-    pub(crate) file: Option<PathBuf>,
+    pub(crate) file: Option<RelativePathBuf>,
 }
 
 static INIT_TRACING: Once = Once::new();
@@ -50,13 +51,13 @@ fn init_tracing_once(log_config: &Config) {
 
     let file_log = log_config
         .file
-        .as_deref()
+        .as_ref()
         .map(|log_file| {
             OpenOptions::new()
                 .write(true)
                 .truncate(true)
                 .create(true)
-                .open(log_file)
+                .open(log_file.relative())
                 .map(|writer| {
                     tracing_subscriber::fmt::layer()
                         .with_writer(writer)

--- a/discovery_engine_core/web-api2/src/utils.rs
+++ b/discovery_engine_core/web-api2/src/utils.rs
@@ -11,8 +11,25 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 
+use derive_more::Deref;
+use figment::value::magic::RelativePathBuf as FigmentRelativePathBuf;
 use secrecy::Secret;
-use serde::Serializer;
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize, Debug, Deref)]
+#[serde(transparent)]
+pub struct RelativePathBuf {
+    #[serde(serialize_with = "FigmentRelativePathBuf::serialize_relative")]
+    inner: FigmentRelativePathBuf,
+}
+
+impl From<&str> for RelativePathBuf {
+    fn from(s: &str) -> Self {
+        Self {
+            inner: FigmentRelativePathBuf::from(s),
+        }
+    }
+}
 
 /// Serialize a `Secret<String>` as `"[REDACTED]"`.
 pub(crate) fn serialize_redacted<S>(

--- a/discovery_engine_core/web-api2/tests/cmd/cli_overrides.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/cli_overrides.auto.toml
@@ -5,7 +5,7 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
   },
   "net": {
     "bind_to": "127.4.3.2:1099",

--- a/discovery_engine_core/web-api2/tests/cmd/env_overrides.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/env_overrides.toml
@@ -5,7 +5,7 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/discovery_engine_core/web-api2/tests/cmd/load_config.auto.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/load_config.auto.toml
@@ -5,7 +5,7 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/discovery_engine_core/web-api2/tests/cmd/mixed_overrides.toml
+++ b/discovery_engine_core/web-api2/tests/cmd/mixed_overrides.toml
@@ -5,7 +5,7 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
   },
   "net": {
     "bind_to": "127.4.3.2:1099",


### PR DESCRIPTION
Use `RelativePathBuf` instead of `PathBuf` for config files.

**References:**

- [ET-3507]
- based on:
  - #673   

[ET-3507]: https://xainag.atlassian.net/browse/ET-3507