### PR TITLE
[Merged by Bors] - ET-3531 Fixes for document properties endpoints

### DIFF
--- a/discovery_engine_core/web-api/src/bin/ingestion.rs
+++ b/discovery_engine_core/web-api/src/bin/ingestion.rs
@@ -262,6 +262,7 @@ fn post_documents(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::post()
         .and(warp::path("documents"))
+        .and(warp::path::end())
         .and(warp::body::content_length_limit(config.max_body_size))
         .and(warp::body::json())
         .and(with_model(model))
@@ -311,6 +312,7 @@ fn get_document_properties(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::get()
         .and(document_properties_path())
+        .and(warp::path::end())
         .and(with_client(client))
         .and_then(handle_get_document_properties)
 }
@@ -322,6 +324,7 @@ fn put_document_properties(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::put()
         .and(document_properties_path())
+        .and(warp::path::end())
         .and(warp::body::content_length_limit(config.max_body_size))
         .and(warp::body::json())
         .and(with_client(client))
@@ -334,6 +337,7 @@ fn delete_document_properties(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::delete()
         .and(document_properties_path())
+        .and(warp::path::end())
         .and(with_client(client))
         .and_then(handle_delete_document_properties)
 }
@@ -344,6 +348,7 @@ fn get_document_property(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::get()
         .and(document_property_path())
+        .and(warp::path::end())
         .and(with_client(client))
         .and_then(handle_get_document_property)
 }
@@ -355,6 +360,7 @@ fn put_document_property(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::put()
         .and(document_property_path())
+        .and(warp::path::end())
         .and(warp::body::content_length_limit(config.max_body_size))
         .and(warp::body::json())
         .and(with_client(client))
@@ -367,6 +373,7 @@ fn delete_document_property(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::delete()
         .and(document_property_path())
+        .and(warp::path::end())
         .and(with_client(client))
         .and_then(handle_delete_document_property)
 }

--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -184,7 +184,7 @@ impl ElasticState {
         prop_id: &DocumentPropertyId,
     ) -> Result<Option<DocumentProperty>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/docs-get.html
-        self.query_json::<Value, DocumentPropertyResponse>(
+        self.query_json::<Value, DocumentPropertiesResponse>(
             &format!(
                 "_source/{}?_source_includes=properties.{}",
                 doc_id.encode(),
@@ -193,7 +193,7 @@ impl ElasticState {
             None,
         )
         .await
-        .map(|mut response| response.0.remove(prop_id))
+        .map(|mut response| response.properties.remove(prop_id))
         .or_not_found(Ok(None))
     }
 
@@ -434,9 +434,6 @@ struct DocumentPropertiesResponse {
     #[serde(default)]
     properties: DocumentProperties,
 }
-
-#[derive(Clone, Debug, Deserialize)]
-struct DocumentPropertyResponse(DocumentProperties);
 
 pub(crate) mod serde_embedding_as_vec {
     use ndarray::Array;


### PR DESCRIPTION
**References**:
- [ET-3531]

**Summary**:
- added path termination for routes because without it routing didn't work properly
- fixed `get_document_property` deserialization to align response payload with api spec

[ET-3531]: https://xainag.atlassian.net/browse/ET-3531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ