### PR TITLE
[Merged by Bors] - ET-3314 Fixes sort for MIND api

### DIFF
--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -13,6 +13,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use serde::Deserialize;
+use serde_json::Value;
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct CountResponse {
@@ -35,7 +36,7 @@ pub struct Hit<T> {
     pub id: String,
     #[serde(rename(deserialize = "_source"))]
     pub source: T,
-    pub sort: String,
+    pub sort: Option<Value>,
 }
 
 /// An article in the MIND dataset.

--- a/discovery_engine_core/tooling/src/bin/backend/elastic.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/elastic.rs
@@ -32,9 +32,9 @@ pub struct Hits<T> {
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct Hit<T> {
-    #[serde(rename(deserialize = "_id"))]
+    #[serde(rename = "_id")]
     pub id: String,
-    #[serde(rename(deserialize = "_source"))]
+    #[serde(rename = "_source")]
     pub source: T,
     pub sort: Option<Value>,
 }
@@ -42,13 +42,13 @@ pub struct Hit<T> {
 /// An article in the MIND dataset.
 #[derive(Clone, Deserialize, Debug)]
 pub struct MindArticle {
-    #[serde(rename(deserialize = "Title"))]
+    #[serde(rename = "Title")]
     pub title: String,
-    #[serde(rename(deserialize = "Abstract"))]
+    #[serde(rename = "Abstract")]
     pub snippet: String,
-    #[serde(rename(deserialize = "URL"))]
+    #[serde(rename = "URL")]
     pub url: String,
-    #[serde(rename(deserialize = "Category"))]
+    #[serde(rename = "Category")]
     pub category: String,
     pub date_published: String,
 }

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -17,7 +17,6 @@ mod errors;
 mod newscatcher;
 mod routes;
 
-use std::net::IpAddr;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use envconfig::Envconfig;
 use errors::BackendError;
@@ -25,6 +24,7 @@ use log::info;
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
+use std::net::IpAddr;
 use tokio::sync::RwLock;
 
 use crate::routes::{popular_get, popular_post, search_get, search_post};

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -17,6 +17,7 @@ mod errors;
 mod newscatcher;
 mod routes;
 
+use std::net::IpAddr;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use envconfig::Envconfig;
 use errors::BackendError;
@@ -32,6 +33,12 @@ use crate::routes::{popular_get, popular_post, search_get, search_post};
 pub struct Config {
     #[envconfig(from = "MIND_ENDPOINT")]
     pub mind_endpoint: String,
+
+    #[envconfig(from = "PORT", default = "3000")]
+    pub(crate) port: u16,
+
+    #[envconfig(from = "IP_ADDR", default = "0.0.0.0")]
+    pub(crate) ip_addr: IpAddr,
 }
 
 struct AppState {
@@ -84,11 +91,12 @@ async fn main() -> std::io::Result<()> {
         total: response.count,
     });
 
+    let port = config.port;
+    let addr = config.ip_addr;
+
     let app_config = web::Data::new(config);
     let app_client = web::Data::new(client);
 
-    let addr = "0.0.0.0";
-    let port = 8080;
     info!("Starting server on {addr}:{port}");
 
     HttpServer::new(move || {

--- a/discovery_engine_core/tooling/src/bin/backend/main.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/main.rs
@@ -23,6 +23,7 @@ use errors::BackendError;
 use log::info;
 use reqwest::Client;
 use serde::Deserialize;
+use serde_json::Value;
 use tokio::sync::RwLock;
 
 use crate::routes::{popular_get, popular_post, search_get, search_post};
@@ -35,7 +36,7 @@ pub struct Config {
 
 struct AppState {
     index: RwLock<usize>,
-    from_index: RwLock<String>,
+    from_index: RwLock<Option<Value>>,
     history: RwLock<Vec<String>>,
     page_size: usize,
     total: usize,
@@ -77,7 +78,7 @@ async fn main() -> std::io::Result<()> {
 
     let app_state = web::Data::new(AppState {
         index: RwLock::new(0),
-        from_index: RwLock::new(String::new()),
+        from_index: RwLock::new(None),
         history: RwLock::new(Vec::new()),
         page_size: 200,
         total: response.count,

--- a/discovery_engine_core/tooling/src/bin/backend/routes.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/routes.rs
@@ -170,10 +170,12 @@ async fn fetch_popular_results(
         ]
     });
 
-    // after the first search also include search_after
+    // after the first search also include search_after\
+    let index = app_state.index.read().await;
     let from_index = app_state.from_index.read().await;
 
-    if let Some(value) = &*from_index {
+    if *index > 0 && from_index.is_some() {
+        let value = from_index.as_ref().unwrap(/* we check if Some above */);
         let map = body.as_object_mut().unwrap(/* body is Object */);
         map.insert("search_after".to_string(), value.clone());
         body = json!(map);

--- a/discovery_engine_core/tooling/src/bin/backend/routes.rs
+++ b/discovery_engine_core/tooling/src/bin/backend/routes.rs
@@ -100,7 +100,7 @@ async fn handle_popular(
 
     if *index + app_state.page_size > app_state.total {
         *index = 0;
-        from_index.clear();
+        *from_index = None;
     } else {
         *index += app_state.page_size;
         *from_index = hits.last().unwrap(/* nonempty hits */).sort.clone();
@@ -171,13 +171,13 @@ async fn fetch_popular_results(
     });
 
     // after the first search also include search_after
-    let index = app_state.index.read().await;
     let from_index = app_state.from_index.read().await;
-    if *index > 0 || !from_index.is_empty() {
+
+    if let Some(value) = &*from_index {
         let map = body.as_object_mut().unwrap(/* body is Object */);
-        map.insert("search_after".to_string(), json!(from_index.clone()));
+        map.insert("search_after".to_string(), value.clone());
         body = json!(map);
-    };
+    }
 
     query_elastic_search(config, client, body).await
 }


### PR DESCRIPTION
**References**:
- [ET-3314]
- https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after

**Summary**:
- changed type for "sort", as it can be present or not, and it's not a `String`, it might be an array of different types, like:
```json
"sort" : [
  1463538857,
  "654323"
]
```

[ET-3314]: https://xainag.atlassian.net/browse/ET-3314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ