### PR TITLE
[Merged by Bors] - ET-3501 move ingestion endpoints (part 1) (11)

### DIFF
--- a/discovery_engine_core/web-api2/src/elastic.rs
+++ b/discovery_engine_core/web-api2/src/elastic.rs
@@ -117,7 +117,7 @@ impl ElasticSearchClient {
             let mut errors = Vec::new();
             for mut response in response.items.into_iter() {
                 if let Some(response) = response.remove("delete") {
-                    if is_success_status(response.status, true) {
+                    if !is_success_status(response.status, true) {
                         error!(document_id=%response.id, error=%response.error);
                         errors.push(response.id);
                     }
@@ -158,7 +158,7 @@ impl ElasticSearchClient {
                 .into_iter()
                 .filter_map(|mut response| {
                     if let Some(response) = response.remove("index") {
-                        if is_success_status(response.status, false) {
+                        if !is_success_status(response.status, false) {
                             error!(document_id=%response.id, error=%response.error, "Elastic failed to ingest document.");
                             return Some(response.id.into());
                         }

--- a/discovery_engine_core/web-api2/src/embedding.rs
+++ b/discovery_engine_core/web-api2/src/embedding.rs
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_bert::{AveragePooler, AvgBert, Config as BertConfig};
 
-
 use crate::{error::common::InternalError, server::SetupError};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -41,13 +40,12 @@ impl Default for Config {
 }
 
 pub(crate) struct Embedder {
-    #[allow(dead_code)]
     bert: AvgBert,
 }
 
 impl Embedder {
     pub(crate) fn run(&self, s: &str) -> Result<Embedding, InternalError> {
-        self.smbert.run(s).map_err(InternalError::from_std)
+        self.bert.run(s).map_err(InternalError::from_std)
     }
 
     pub(crate) fn load(config: &Config) -> Result<Self, SetupError> {

--- a/discovery_engine_core/web-api2/src/embedding.rs
+++ b/discovery_engine_core/web-api2/src/embedding.rs
@@ -15,9 +15,11 @@
 use crate::utils::RelativePathBuf;
 
 use serde::{Deserialize, Serialize};
+use xayn_discovery_engine_ai::Embedding;
 use xayn_discovery_engine_bert::{AveragePooler, AvgBert, Config as BertConfig};
 
-use crate::server::SetupError;
+
+use crate::{error::common::InternalError, server::SetupError};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -44,6 +46,10 @@ pub(crate) struct Embedder {
 }
 
 impl Embedder {
+    pub(crate) fn run(&self, s: &str) -> Result<Embedding, InternalError> {
+        self.smbert.run(s).map_err(InternalError::from_std)
+    }
+
     pub(crate) fn load(config: &Config) -> Result<Self, SetupError> {
         let bert = BertConfig::new(&config.directory.relative())?
             .with_pooler::<AveragePooler>()

--- a/discovery_engine_core/web-api2/src/error/common.rs
+++ b/discovery_engine_core/web-api2/src/error/common.rs
@@ -98,6 +98,14 @@ impl From<&'static str> for BadRequest {
     }
 }
 
+impl From<String> for BadRequest {
+    fn from(message: String) -> Self {
+        Self {
+            message: Cow::Owned(message),
+        }
+    }
+}
+
 #[derive(Serialize, Debug, From)]
 pub(crate) struct DocumentIdAsObject {
     pub(crate) id: DocumentId,

--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -64,7 +64,7 @@ pub struct IngestionConfig {
     #[allow(dead_code)]
     #[as_ref]
     #[serde(default = "default_max_document_batch_size")]
-    pub(crate) max_document_batch_size: u64,
+    pub(crate) max_document_batch_size: usize,
 }
 
 impl Default for IngestionConfig {
@@ -75,7 +75,7 @@ impl Default for IngestionConfig {
     }
 }
 
-fn default_max_document_batch_size() -> u64 {
+fn default_max_document_batch_size() -> usize {
     100
 }
 

--- a/discovery_engine_core/web-api2/src/utils.rs
+++ b/discovery_engine_core/web-api2/src/utils.rs
@@ -16,6 +16,8 @@ use figment::value::magic::RelativePathBuf as FigmentRelativePathBuf;
 use secrecy::Secret;
 use serde::{Deserialize, Serialize, Serializer};
 
+use crate::Error;
+
 #[derive(Serialize, Deserialize, Debug, Deref)]
 #[serde(transparent)]
 pub struct RelativePathBuf {
@@ -40,4 +42,16 @@ where
     S: Serializer,
 {
     serializer.serialize_str("[REDACTED]")
+}
+
+/// Serialize a sequence of serializable items into ndjson.
+pub(crate) fn serialize_to_ndjson(
+    items: impl IntoIterator<Item = Result<impl Serialize, Error>>,
+) -> Result<Vec<u8>, Error> {
+    let mut body = Vec::new();
+    for item in items {
+        serde_json::to_writer(&mut body, &item?)?;
+        body.push(b'\n');
+    }
+    Ok(body)
 }


### PR DESCRIPTION
Moves the new_documents endpoint to actix.

Split out from the rest as it also merges the two different bulk request implementations.

**References:**

- [ET-3501]
- based on:
  - #684
  - #674
  - #673   
  - #672 
  - #671   



[ET-3501]: https://xainag.atlassian.net/browse/ET-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ