### PR TITLE
[Merged by Bors] - ET-3521 remove remaining dead code annotations (13)

### DIFF
--- a/discovery_engine_core/web-api2/src/db.rs
+++ b/discovery_engine_core/web-api2/src/db.rs
@@ -140,7 +140,6 @@ impl Config {
 }
 
 pub(crate) struct Database {
-    #[allow(dead_code)]
     pool: Pool<Postgres>,
 }
 

--- a/discovery_engine_core/web-api2/src/elastic.rs
+++ b/discovery_engine_core/web-api2/src/elastic.rs
@@ -44,16 +44,12 @@ use crate::{
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
-    #[allow(dead_code)]
     #[serde(default = "default_url")]
     url: String,
-    #[allow(dead_code)]
     #[serde(default = "default_user")]
     user: String,
-    #[allow(dead_code)]
     #[serde(default = "default_password", serialize_with = "serialize_redacted")]
     password: Secret<String>,
-    #[allow(dead_code)]
     #[serde(default = "default_index_name")]
     index_name: String,
 }
@@ -532,8 +528,6 @@ struct SearchResponse<T> {
 #[derive(Clone, Debug, Deserialize)]
 struct Hits<T> {
     hits: Vec<Hit<T>>,
-    #[allow(dead_code)]
-    total: Total,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -544,12 +538,6 @@ struct Hit<T> {
     source: T,
     #[serde(rename = "_score")]
     score: f32,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct Total {
-    #[allow(dead_code)]
-    value: usize,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/discovery_engine_core/web-api2/src/embedding.rs
+++ b/discovery_engine_core/web-api2/src/embedding.rs
@@ -22,7 +22,6 @@ use crate::{error::common::InternalError, server::SetupError};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
-    #[allow(dead_code)]
     #[serde(default = "default_directory")]
     directory: RelativePathBuf,
 }

--- a/discovery_engine_core/web-api2/src/ingestion.rs
+++ b/discovery_engine_core/web-api2/src/ingestion.rs
@@ -49,11 +49,9 @@ type AppState = server::AppState<
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
 pub struct ConfigExtension {
-    #[allow(dead_code)]
     #[as_ref]
     #[serde(default)]
     pub(crate) ingestion: IngestionConfig,
-    #[allow(dead_code)]
     #[as_ref]
     #[serde(default)]
     pub(crate) embedding: embedding::Config,
@@ -61,7 +59,6 @@ pub struct ConfigExtension {
 
 #[derive(AsRef, Debug, Deserialize, Serialize)]
 pub struct IngestionConfig {
-    #[allow(dead_code)]
     #[as_ref]
     #[serde(default = "default_max_document_batch_size")]
     pub(crate) max_document_batch_size: usize,
@@ -81,7 +78,6 @@ fn default_max_document_batch_size() -> usize {
 
 #[derive(AsRef)]
 pub struct AppStateExtension {
-    #[allow(dead_code)]
     #[as_ref]
     pub(crate) embedder: Embedder,
 }

--- a/discovery_engine_core/web-api2/src/personalization.rs
+++ b/discovery_engine_core/web-api2/src/personalization.rs
@@ -46,7 +46,6 @@ type AppState = server::AppState<
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
 pub struct ConfigExtension {
-    #[allow(dead_code)]
     #[as_ref]
     #[serde(default)]
     pub(crate) coi: CoiConfig,
@@ -92,6 +91,5 @@ impl Default for PersonalizationConfig {
 #[derive(AsRef)]
 pub struct AppStateExtension {
     #[as_ref]
-    #[allow(dead_code)]
     pub(crate) coi: CoiSystem,
 }

--- a/discovery_engine_core/web-api2/src/personalization/routes.rs
+++ b/discovery_engine_core/web-api2/src/personalization/routes.rs
@@ -66,10 +66,8 @@ pub(crate) struct UpdateInteractions {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct UserInteractionData {
-    #[allow(dead_code)]
     #[serde(rename = "id")]
     pub(crate) document_id: DocumentId,
-    #[allow(dead_code)]
     #[serde(rename = "type")]
     pub(crate) interaction_type: UserInteractionType,
 }
@@ -233,7 +231,6 @@ pub(crate) struct PersonalizedDocumentsResponse {
 }
 
 impl PersonalizedDocumentsResponse {
-    #[allow(dead_code)]
     pub(crate) fn new(documents: impl Into<Vec<PersonalizedDocument>>) -> Self {
         Self {
             documents: documents.into(),

--- a/discovery_engine_core/web-api2/src/server/app_state.rs
+++ b/discovery_engine_core/web-api2/src/server/app_state.rs
@@ -20,13 +20,10 @@ use super::{Config, SetupError};
 
 #[derive(Deref, AsRef)]
 pub struct AppState<CE, AE> {
-    #[allow(dead_code)]
     #[as_ref]
     pub(crate) config: Config<CE>,
-    #[allow(dead_code)]
     #[as_ref]
     pub(crate) db: Database,
-    #[allow(dead_code)]
     #[as_ref]
     pub(crate) elastic: ElasticSearchClient,
     #[deref]

--- a/discovery_engine_core/web-api2/src/server/config.rs
+++ b/discovery_engine_core/web-api2/src/server/config.rs
@@ -27,7 +27,6 @@ pub struct NetConfig {
     pub(crate) bind_to: SocketAddr,
 
     /// Max body size limit which should be applied to all endpoints
-    #[allow(dead_code)]
     #[serde(default = "default_max_body_size")]
     pub(crate) max_body_size: usize,
 }


### PR DESCRIPTION
Remove `allow(dead_code)` annotations and dead code.

**References:**

- [ET-3521]
- based on:
  - #686
  - #685 
  - #684
  - #674
  - #673   
  - #672 
  - #671   


[ET-3521]: https://xainag.atlassian.net/browse/ET-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ