### PR TITLE
Expose the correct PORT of the backend

### DIFF
--- a/discovery_engine_core/tooling/Dockerfile
+++ b/discovery_engine_core/tooling/Dockerfile
@@ -6,6 +6,6 @@ COPY ./ ./
 
 RUN chmod +x ./backend
 
-EXPOSE 3000
+EXPOSE 8080
 
 CMD ["./backend"]


### PR DESCRIPTION
The port used in the  backend is 8080 
The better change probably would be to pass a param to the backend itself.