### PR TITLE
[Merged by Bors] - ET-3558 take category during ingestion

### DIFF
--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -502,6 +502,7 @@ pub struct ElasticDocument {
     pub properties: DocumentProperties,
     #[serde(with = "serde_embedding_as_vec")]
     pub embedding: Embedding,
+    pub category: Option<String>,
 }
 
 impl From<SearchResponse<ElasticDocument>> for Vec<PersonalizedDocument> {

--- a/discovery_engine_core/web-api/src/ingestion/routes.rs
+++ b/discovery_engine_core/web-api/src/ingestion/routes.rs
@@ -108,8 +108,7 @@ fn deserialize_empty_option_string_as_none<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    Option::<String>::deserialize(deserializer)
-        .map(|s| s.and_then(|s| (!s.is_empty()).then_some(s)))
+    Option::<String>::deserialize(deserializer).map(|s| s.filter(|s| !s.is_empty()))
 }
 
 #[instrument(skip(state))]

--- a/discovery_engine_core/web-api/src/ingestion/routes.rs
+++ b/discovery_engine_core/web-api/src/ingestion/routes.rs
@@ -82,6 +82,10 @@ struct IngestedDocument {
 
     /// Contents of the document properties.
     properties: DocumentProperties,
+
+    /// The high-level category the document belongs to.
+    #[serde(default, deserialize_with = "deserialize_empty_option_string_as_none")]
+    category: Option<String>,
 }
 
 fn deserialize_string_not_empty_or_zero_byte<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -96,6 +100,16 @@ where
     } else {
         Ok(s)
     }
+}
+
+fn deserialize_empty_option_string_as_none<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)
+        .map(|s| s.and_then(|s| (!s.is_empty()).then_some(s)))
 }
 
 #[instrument(skip(state))]
@@ -128,6 +142,7 @@ async fn new_documents(
                     snippet: document.snippet,
                     properties: document.properties,
                     embedding,
+                    category: document.category,
                 },
             )),
             Err(err) => {


### PR DESCRIPTION
**Reference**

- [ET-3558]
- requires #690
- followed by #693

**Summary**

- deserialize an optional category for the ingested documents


[ET-3558]: https://xainag.atlassian.net/browse/ET-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ