### PR TITLE
[Merged by Bors] - ET-3559 update category weight on interaction

### DIFF
--- a/discovery_engine_core/web-api/migrations/20220926145400_document.sql
+++ b/discovery_engine_core/web-api/migrations/20220926145400_document.sql
@@ -22,3 +22,13 @@ CREATE TABLE IF NOT EXISTS interaction (
 
 CREATE INDEX IF NOT EXISTS idx_interaction_by_user_id
     ON interaction(user_id);
+
+CREATE TABLE IF NOT EXISTS weighted_category (
+    user_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    weight INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_category_by_user_id
+    ON weighted_category(user_id);

--- a/discovery_engine_core/web-api/src/elastic.rs
+++ b/discovery_engine_core/web-api/src/elastic.rs
@@ -516,6 +516,7 @@ impl From<SearchResponse<ElasticDocument>> for Vec<PersonalizedDocument> {
                 score: hit.score,
                 embedding: hit.source.embedding,
                 properties: hit.source.properties,
+                category: hit.source.category,
             })
             .collect()
     }

--- a/discovery_engine_core/web-api/src/models.rs
+++ b/discovery_engine_core/web-api/src/models.rs
@@ -111,6 +111,9 @@ pub(crate) struct PersonalizedDocument {
 
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
+
+    /// The high-level category the document belongs to.
+    pub(crate) category: Option<String>,
 }
 
 impl AiDocument for PersonalizedDocument {

--- a/discovery_engine_core/web-api/src/personalization/routes.rs
+++ b/discovery_engine_core/web-api/src/personalization/routes.rs
@@ -94,7 +94,6 @@ async fn update_interactions(
         match document.interaction_type {
             UserInteractionType::Positive => {
                 if let Some(document) = documents.get(&document.document_id) {
-                    //TODO for some reason this was returning a BAD_REQUEST error????
                     state
                         .db
                         .update_positive_cois(&document.id, &user_id, |positive_cois| {

--- a/discovery_engine_core/web-api/src/personalization/routes.rs
+++ b/discovery_engine_core/web-api/src/personalization/routes.rs
@@ -23,7 +23,7 @@ use futures_util::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use tracing::error;
+use tracing::{error, warn};
 use xayn_discovery_engine_ai::{
     compute_coi_relevances,
     nan_safe_f32_cmp,
@@ -85,24 +85,30 @@ async fn update_interactions(
         .map(|document| &document.document_id)
         .collect_vec();
     let documents = state.elastic.get_documents_by_ids(&ids).await?;
-    let embeddings = documents
-        .into_iter()
-        .map(|document| (document.id, document.embedding))
+    let documents = documents
+        .iter()
+        .map(|document| (&document.id, document))
         .collect::<HashMap<_, _>>();
 
     for document in interactions.documents {
         match document.interaction_type {
             UserInteractionType::Positive => {
-                //TODO for some reason this was returning a BAD_REQUEST error????
-                state
-                    .db
-                    .update_positive_cois(&document.document_id, &user_id, |positive_cois| {
-                        state.coi.log_positive_user_reaction(
-                            positive_cois,
-                            &embeddings[&document.document_id],
-                        )
-                    })
-                    .await?;
+                if let Some(document) = documents.get(&document.document_id) {
+                    //TODO for some reason this was returning a BAD_REQUEST error????
+                    state
+                        .db
+                        .update_positive_cois(&document.id, &user_id, |positive_cois| {
+                            state
+                                .coi
+                                .log_positive_user_reaction(positive_cois, &document.embedding)
+                        })
+                        .await?;
+                    if let Some(category) = &document.category {
+                        state.db.update_category_weight(&user_id, category).await?;
+                    }
+                } else {
+                    warn!(%document.document_id, "interacted document doesn't exist anymore");
+                }
             }
         }
     }


### PR DESCRIPTION
**Reference**

- [ET-3559]
- requires #692
- followed by #694

**Summary**

- add db table for category weights
- update category weights during interaction update


[ET-3559]: https://xainag.atlassian.net/browse/ET-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ