### PR TITLE
[Merged by Bors] - ET-3523 build ci image on workflow dispatch

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,12 +1,6 @@
 name: Build docker ci image
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - .env
-      - discovery_engine_core/rust-toolchain.toml
+on: workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-ci-image.yml
+++ b/.github/workflows/release-ci-image.yml
@@ -1,7 +1,6 @@
 name: Release docker ci image
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 permissions:
   contents: read


### PR DESCRIPTION
**References**

- [ET-3523]
- #695

**Summary**

- run the build-ci-image workflow on dispatch to avoid multiple prs for a version update


[ET-3523]: https://xainag.atlassian.net/browse/ET-3523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ