### PR TITLE
[Merged by Bors] - Fix use of cache in CI

### DIFF
--- a/.github/actions/setup-job-docker/action.yml
+++ b/.github/actions/setup-job-docker/action.yml
@@ -16,12 +16,6 @@ runs:
     - name: Load .env
       uses: xom9ikk/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0 # v2
 
-    - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
-      if: inputs.rust != 'false'
-      with:
-        key: ${{ inputs.cache-key }}
-        workspaces: ${{ env.RUST_WORKSPACE }} -> target
-
     - name: Configure cargo
       shell: bash
       run: |
@@ -29,3 +23,11 @@ runs:
         # and if multiple cargo build jobs run at max parallelism it ends up
         # slowing all builds down.
         echo "CARGO_BUILD_JOBS=6" >> $GITHUB_ENV
+
+    # This action uses env vars for hash used in the key, therefore we keep it as last. 
+    - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+      if: inputs.rust != 'false'
+      with:
+        key: ${{ inputs.cache-key }}
+        workspaces: ${{ env.RUST_WORKSPACE }} -> target
+

--- a/.github/docker/Dockerfile.ci-image
+++ b/.github/docker/Dockerfile.ci-image
@@ -9,7 +9,7 @@ USER root
 
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends software-properties-common build-essential wget curl git; \
+    apt-get install -y --no-install-recommends ca-certificates wget curl git zstd gcc libc6-dev; \
     rm -rf /var/lib/apt/lists/*;
 
 # Begin: Rust base


### PR DESCRIPTION
* Adds ` zstd` to the docker image
* Invert the setting of the env var `CARGO_BUILD_JOBS`  and the action that handles the cache. rust-cache uses all the env vars that start with `CARGO`  to generate the hash of the cache. Setting the variable after the cache action leads to uploading a cache with a different id than the one we want to restore