### PR TITLE
[Merged by Bors] - ET-3722 Fix OpenApi spec issues

### DIFF
--- a/web-api/openapi.yaml
+++ b/web-api/openapi.yaml
@@ -39,6 +39,7 @@ paths:
         Returns a list of documents personalized for the given `user_id`.
         Each document contains the id, the score and the properties that are attached to the document.
         The score is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
+      operationId: getPersonalizedDocuments
       parameters:
         - name: user_id
           in: path
@@ -81,6 +82,7 @@ paths:
       summary: Add interaction between a user and a document
       description: |-
         The interaction is used to provide personalized documents to the user.
+      operationId: documentInteraction
       parameters:
         - name: user_id
           in: path
@@ -111,6 +113,7 @@ paths:
       description: |-
         Add documents to the system. The system will create a representation of the document
         that will be used to match it against the preferences of a user.
+      operationId: ingestDocuments
       requestBody:
         content:
           application/json:
@@ -135,6 +138,7 @@ paths:
         Delete all documents listed in the request body. The endpoint is
         idempotent. I.e. if the list contains one or multiple non-existing
         documents, no error is produced.
+      operationId: deleteDocuments
       requestBody:
         content:
           application/json:
@@ -154,6 +158,7 @@ paths:
       description: |-
         Permanently deletes the document from the system. The endpoint is
         idempotent. Deleting a non-existing document does not produce an error.
+      operationId: deleteDocument
       parameters:
         - name: document_id
           in: path
@@ -173,6 +178,7 @@ paths:
         - documents
       summary: Get all document properties
       description: Gets all the properties of the document.
+      operationId: getDocumentProperties
       parameters:
         - name: document_id
           in: path
@@ -196,6 +202,7 @@ paths:
         - documents
       summary: Set all document properties
       description: Sets or replaces all the properties of the document.
+      operationId: setDocumentProperties
       parameters:
         - name: document_id
           in: path
@@ -220,6 +227,7 @@ paths:
         - documents
       summary: Delete all document properties
       description: Deletes all the properties of the document.
+      operationId: deleteDocumentProperties
       parameters:
         - name: document_id
           in: path
@@ -241,6 +249,7 @@ paths:
         - documents
       summary: Get a document property
       description: Gets the property of the document.
+      operationId: getDocumentProperty
       parameters:
         - name: document_id
           in: path
@@ -270,6 +279,7 @@ paths:
         - documents
       summary: Set a document property
       description: Sets or replaces the property of the document.
+      operationId: setDocumentProperty
       parameters:
         - name: document_id
           in: path
@@ -300,6 +310,7 @@ paths:
         - documents
       summary: Delete a document property
       description: Deletes the property of the document.
+      operationId: deleteDocumentProperty
       parameters:
         - name: document_id
           in: path
@@ -386,7 +397,7 @@ components:
           type: string
         kind:
           description: What kind of error this is.
-          type: String
+          type: string
         details:
           description: Additional error details. Might differ depending on debug options.
           type: object

--- a/web-api/openapi.yaml
+++ b/web-api/openapi.yaml
@@ -29,6 +29,9 @@ tags:
   - name: documents
     description: Management of the documents in the system.
 
+security:
+  - ApiKeyAuth: []    
+
 paths:
   /users/{user_id}/personalized_documents:
     get:

--- a/web-api/openapi.yaml
+++ b/web-api/openapi.yaml
@@ -333,6 +333,11 @@ paths:
           description: document id or property id not found
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: authorizationToken
   schemas:
     DocumentId:
       description: |-


### PR DESCRIPTION
This PR addresses a few minor issues found in the spec:

- rename `String` to `string`, as lowercase is the correct Type name
- add operationId entries on all API calls, this is used by codegen to create the method name for that API call, if omitted, codegen will instead generate a very ugly name, eg `useruseridPersonalizedDocuments`
- add securityScheme for our token, so that codegen adds it to the Header when performing calls