### PR TITLE
[Merged by Bors] - ET-3725 fix copyright.sh

### DIFF
--- a/.github/scripts/copyright.sh
+++ b/.github/scripts/copyright.sh
@@ -4,7 +4,7 @@ set -e
 
 files_to_check() {
     find . \
-         -or -type d -name target -prune \
+         -type d -name target -prune \
          -or -name "*.rs" \
          -print
 }


### PR DESCRIPTION
A leading `-or` caused a warning, through as far I can tell it otherwise still worked as expected.