### PR TITLE
[Merged by Bors] - Remove required-features from benchmark

### DIFF
--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -32,4 +32,3 @@ test = false
 name = "bert"
 harness = false
 test = false
-required-features = ["onnxruntime"]

--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -15,8 +15,7 @@
 use std::path::Path;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ndarray::s;
-use xayn_ai_bert::{tokenizer::Tokenizer, Config, Embedding2, NonePooler};
+use xayn_ai_bert::{Config, NonePooler};
 use xayn_ai_test_utils::asset::smbert;
 
 const TOKEN_SIZE: usize = 64;


### PR DESCRIPTION
Some bench was enabled only with a feature enable but that feature was removed.
cargo prints a warning for that that was missed, I could not find a way to turn that warning in an error :/