### PR TITLE
[Merged by Bors] - Make token_size configurable

### DIFF
--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -22,16 +22,23 @@ use crate::{error::common::InternalError, server::SetupError, utils::RelativePat
 pub struct Config {
     #[serde(default = "default_directory")]
     directory: RelativePathBuf,
+    #[serde(default = "default_token_size")]
+    token_size: usize,
 }
 
 fn default_directory() -> RelativePathBuf {
     "assets".into()
 }
 
+fn default_token_size() -> usize {
+    250
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
             directory: default_directory(),
+            token_size: default_token_size(),
         }
     }
 }
@@ -48,7 +55,7 @@ impl Embedder {
     pub(crate) fn load(config: &Config) -> Result<Self, SetupError> {
         let bert = BertConfig::new(&config.directory.relative())?
             .with_pooler::<AveragePooler>()
-            .with_token_size(64)?
+            .with_token_size(config.token_size)?
             .build()?;
 
         Ok(Embedder { bert })

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -32,7 +32,8 @@ stdout = """
     "max_document_batch_size": 999999
   },
   "embedding": {
-    "directory": "assets"
+    "directory": "assets",
+    "token_size": 250
   }
 }
 """

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -32,7 +32,8 @@ stdout = """
     "max_document_batch_size": 100
   },
   "embedding": {
-    "directory": "assets"
+    "directory": "assets",
+    "token_size": 250
   }
 }
 """

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -32,7 +32,8 @@ stdout = """
     "max_document_batch_size": 999999
   },
   "embedding": {
-    "directory": "assets"
+    "directory": "assets",
+    "token_size": 250
   }
 }
 """

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -32,7 +32,8 @@ stdout = """
     "max_document_batch_size": 999999
   },
   "embedding": {
-    "directory": "assets"
+    "directory": "assets",
+    "token_size": 250
   }
 }
 """

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -32,7 +32,8 @@ stdout = """
     "max_document_batch_size": 999999
   },
   "embedding": {
-    "directory": "assets"
+    "directory": "assets",
+    "token_size": 250
   }
 }
 """


### PR DESCRIPTION
Make `token_size` configurable and increase the default size to have better results from the model.