### PR TITLE
[Merged by Bors] - ET-3710 document race condition: add table for insert and delete

### DIFF
--- a/web-api/migrations/20220926145400_document.sql
+++ b/web-api/migrations/20220926145400_document.sql
@@ -12,12 +12,8 @@
 --  You should have received a copy of the GNU Affero General Public License
 --  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-CREATE TABLE IF NOT EXISTS document (
-    doc_id TEXT NOT NULL PRIMARY KEY
-);
-
 CREATE TABLE IF NOT EXISTS interaction (
-    doc_id TEXT NOT NULL REFERENCES document (doc_id) ON DELETE CASCADE,
+    doc_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
     time_stamp TIMESTAMPTZ NOT NULL DEFAULT Now(),
     user_reaction SMALLINT NOT NULL,

--- a/web-api/migrations/20220926145400_document.sql
+++ b/web-api/migrations/20220926145400_document.sql
@@ -12,8 +12,12 @@
 --  You should have received a copy of the GNU Affero General Public License
 --  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+CREATE TABLE IF NOT EXISTS document (
+    doc_id TEXT NOT NULL PRIMARY KEY
+);
+
 CREATE TABLE IF NOT EXISTS interaction (
-    doc_id TEXT NOT NULL,
+    doc_id TEXT NOT NULL REFERENCES document (doc_id) ON DELETE CASCADE,
     user_id TEXT NOT NULL,
     time_stamp TIMESTAMPTZ NOT NULL DEFAULT Now(),
     user_reaction SMALLINT NOT NULL,

--- a/web-api/migrations/20221213105300_document.sql
+++ b/web-api/migrations/20221213105300_document.sql
@@ -1,0 +1,22 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE IF NOT EXISTS document (
+    document_id TEXT NOT NULL PRIMARY KEY
+);
+
+ALTER TABLE interaction
+    ADD FOREIGN KEY (doc_id)
+    REFERENCES document (document_id)
+    ON DELETE CASCADE;

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -32,6 +32,7 @@ impl_application_error!(DocumentNotFound => NOT_FOUND);
 /// The requested document was found but not the requested property.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct DocumentPropertyNotFound;
+
 impl_application_error!(DocumentPropertyNotFound => NOT_FOUND);
 
 /// The requested property was not found.

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -16,6 +16,7 @@ pub(crate) mod elastic;
 #[cfg(test)]
 pub(crate) mod memory;
 pub(crate) mod postgres;
+mod utils;
 
 use std::collections::HashMap;
 
@@ -54,6 +55,12 @@ pub(crate) enum InsertionError {
     },
 }
 
+#[derive(Debug, From)]
+pub(crate) enum DeletionError {
+    General(Error),
+    PartialFailure { errors: Vec<DocumentIdAsObject> },
+}
+
 #[async_trait]
 pub(crate) trait Document {
     async fn get_by_ids(&self, ids: &[&DocumentId]) -> Result<Vec<PersonalizedDocument>, Error>;
@@ -68,7 +75,7 @@ pub(crate) trait Document {
         documents: Vec<(IngestedDocument, Embedding)>,
     ) -> Result<(), InsertionError>;
 
-    async fn delete(&self, documents: &[DocumentId]) -> Result<(), Error>;
+    async fn delete(&self, documents: &[DocumentId]) -> Result<(), DeletionError>;
 }
 
 #[async_trait]
@@ -123,8 +130,6 @@ pub(crate) trait Interest {
 #[async_trait]
 pub(crate) trait Interaction {
     async fn get(&self, user_id: &UserId) -> Result<Vec<DocumentId>, Error>;
-
-    async fn delete(&self, documents: &[DocumentId]) -> Result<(), Error>;
 
     async fn user_seen(&self, id: &UserId) -> Result<(), Error>;
 }

--- a/web-api/src/storage/utils.rs
+++ b/web-api/src/storage/utils.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Module containing non-database specific sqlx utilities.
+
+use sqlx::{Database, Encode, QueryBuilder, Type};
+
+pub(super) trait SqlxPushTupleExt<'args, DB: Database> {
+    fn push_tuple<I>(&mut self, values: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: 'args + Encode<'args, DB> + Send + Type<DB>;
+}
+
+impl<'args, DB> SqlxPushTupleExt<'args, DB> for QueryBuilder<'args, DB>
+where
+    DB: Database,
+{
+    fn push_tuple<I>(&mut self, values: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: 'args + Encode<'args, DB> + Send + Type<DB>,
+    {
+        let mut separated = self.push("(").separated(", ");
+        for value in values {
+            separated.push_bind(value);
+        }
+        separated.push_unseparated(")");
+        self
+    }
+}


### PR DESCRIPTION
**Reference**

-  [ET-3710]
- followed by #733

**Summary**

- declare `document` postgres table & link foreign key in `interaction` table
- `ON DELETE CASCADE` makes the trait method `Interaction::delete()` redundant, hence it's removed for elastic/postgres and it's moved into `Document::delete()` for in-memory
- add doc ids to postgres after successful insertion to elastic
- remove doc ids from postgres before deletion from elastic


[ET-3710]: https://xainag.atlassian.net/browse/ET-3710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ