### PR TITLE
[Merged by Bors] - ET-3714 rename category to tags

### DIFF
--- a/web-api/migrations/20221214154900_document.sql
+++ b/web-api/migrations/20221214154900_document.sql
@@ -1,0 +1,17 @@
+--  Copyright 2022 Xayn AG
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU Affero General Public License as
+--  published by the Free Software Foundation, version 3.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU Affero General Public License for more details.
+--
+--  You should have received a copy of the GNU Affero General Public License
+--  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ALTER TABLE weighted_category RENAME category TO tag;
+ALTER TABLE weighted_category RENAME TO weighted_tag;
+ALTER INDEX idx_category_by_user_id RENAME TO idx_tag_by_user_id;

--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -72,7 +72,7 @@ impl State {
         let documents = documents
             .into_iter()
             .map(|document| {
-                let category = if document.category.is_empty() {
+                let tags = if document.category.is_empty() {
                     if document.subcategory.is_empty() {
                         None
                     } else {
@@ -85,7 +85,7 @@ impl State {
                     id: document.id,
                     snippet: document.snippet,
                     properties: DocumentProperties::default(),
-                    category,
+                    tags,
                 };
                 let embedding = self.embedder.run(&document.snippet)?;
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -112,7 +112,7 @@ pub(crate) struct PersonalizedDocument {
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
 
-    /// The metadata of the document.
+    /// The tags associated to the document.
     pub(crate) tags: Option<String>,
 }
 
@@ -159,7 +159,7 @@ pub(crate) struct IngestedDocument {
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
 
-    /// The metadata of the document.
+    /// The tags associated to the document.
     #[serde(default, deserialize_with = "deserialize_empty_option_string_as_none")]
     pub(crate) tags: Option<String>,
 }

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -112,8 +112,8 @@ pub(crate) struct PersonalizedDocument {
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
 
-    /// The high-level category the document belongs to.
-    pub(crate) category: Option<String>,
+    /// The metadata of the document.
+    pub(crate) tags: Option<String>,
 }
 
 impl AiDocument for PersonalizedDocument {
@@ -159,9 +159,9 @@ pub(crate) struct IngestedDocument {
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
 
-    /// The high-level category the document belongs to.
+    /// The metadata of the document.
     #[serde(default, deserialize_with = "deserialize_empty_option_string_as_none")]
-    pub(crate) category: Option<String>,
+    pub(crate) tags: Option<String>,
 }
 
 fn deserialize_string_not_empty_or_zero_byte<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -70,9 +70,9 @@ pub(crate) struct PersonalizationConfig {
     /// Max number of positive cois to use in knn search.
     #[serde(default = "default_max_cois_for_knn")]
     pub(crate) max_cois_for_knn: usize,
-    /// Weighting of user interests vs document categories. Must be in the interval `[0, 1]`.
-    #[serde(default = "default_interest_category_bias")]
-    pub(crate) interest_category_bias: f32,
+    /// Weighting of user interests vs document tags. Must be in the interval `[0, 1]`.
+    #[serde(default = "default_interest_tag_bias")]
+    pub(crate) interest_tag_bias: f32,
 }
 
 fn default_max_number_documents() -> usize {
@@ -88,7 +88,7 @@ fn default_max_cois_for_knn() -> usize {
     10
 }
 
-fn default_interest_category_bias() -> f32 {
+fn default_interest_tag_bias() -> f32 {
     0.5
 }
 
@@ -98,7 +98,7 @@ impl Default for PersonalizationConfig {
             max_number_documents: default_max_number_documents(),
             default_number_documents: default_default_number_documents(),
             max_cois_for_knn: default_max_cois_for_knn(),
-            interest_category_bias: default_interest_category_bias(),
+            interest_tag_bias: default_interest_tag_bias(),
         }
     }
 }

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -138,10 +138,10 @@ pub(crate) trait Interaction {
 }
 
 #[async_trait]
-pub(crate) trait Category {
+pub(crate) trait Tag {
     async fn get(&self, user_id: &UserId) -> Result<HashMap<String, usize>, Error>;
 
-    async fn update(&self, user_id: &UserId, category: &str) -> Result<(), Error>;
+    async fn update(&self, user_id: &UserId, tags: &str) -> Result<(), Error>;
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -247,7 +247,6 @@ pub struct Document {
     pub snippet: String,
     pub properties: DocumentProperties,
     pub embedding: Embedding,
-    #[serde(alias = "category")] // deprecated
     pub tags: Option<String>,
 }
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -247,7 +247,8 @@ pub struct Document {
     pub snippet: String,
     pub properties: DocumentProperties,
     pub embedding: Embedding,
-    pub category: Option<String>,
+    #[serde(alias = "category")] // deprecated
+    pub tags: Option<String>,
 }
 
 impl From<SearchResponse<Document>> for Vec<PersonalizedDocument> {
@@ -261,7 +262,7 @@ impl From<SearchResponse<Document>> for Vec<PersonalizedDocument> {
                 score: hit.score,
                 embedding: hit.source.embedding,
                 properties: hit.source.properties,
-                category: hit.source.category,
+                tags: hit.source.tags,
             })
             .collect()
     }
@@ -369,7 +370,7 @@ impl storage::Document for Storage {
                         snippet: document.snippet,
                         properties: document.properties,
                         embedding,
-                        category: document.category,
+                        tags: document.tags,
                     })
                     .map_err(Into::into),
                 ]

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -39,7 +39,7 @@ stdout = """
     "max_number_documents": 100,
     "default_number_documents": 100,
     "max_cois_for_knn": 10,
-    "interest_category_bias": 0.5
+    "interest_tag_bias": 0.5
   }
 }
 """


### PR DESCRIPTION
**Reference**

- [ET-3714]

**Summary**

- rename `category` to `tags` (currently it's still a single `Option<String>`, which will be changed in the following pr)
- add postgres and elastic migration


[ET-3714]: https://xainag.atlassian.net/browse/ET-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ