### PR TITLE
[Merged by Bors] - ET-3674 multiple tags per document

### DIFF
--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -72,20 +72,11 @@ impl State {
         let documents = documents
             .into_iter()
             .map(|document| {
-                let tags = if document.category.is_empty() {
-                    if document.subcategory.is_empty() {
-                        None
-                    } else {
-                        Some(document.subcategory)
-                    }
-                } else {
-                    Some(document.category)
-                };
                 let document = IngestedDocument {
                     id: document.id,
                     snippet: document.snippet,
                     properties: DocumentProperties::default(),
-                    tags,
+                    tags: vec![document.category, document.subcategory],
                 };
                 let embedding = self.embedder.run(&document.snippet)?;
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -113,7 +113,7 @@ pub(crate) struct PersonalizedDocument {
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
-    pub(crate) tags: Option<String>,
+    pub(crate) tags: Vec<String>,
 }
 
 impl AiDocument for PersonalizedDocument {
@@ -160,8 +160,7 @@ pub(crate) struct IngestedDocument {
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
-    #[serde(default, deserialize_with = "deserialize_empty_option_string_as_none")]
-    pub(crate) tags: Option<String>,
+    pub(crate) tags: Vec<String>,
 }
 
 fn deserialize_string_not_empty_or_zero_byte<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -176,13 +175,4 @@ where
     } else {
         Ok(s)
     }
-}
-
-fn deserialize_empty_option_string_as_none<'de, D>(
-    deserializer: D,
-) -> Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Option::<String>::deserialize(deserializer).map(|s| s.filter(|s| !s.is_empty()))
 }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -331,9 +331,12 @@ pub(crate) async fn personalize_documents_by(
     let mut documents_by_tags = all_documents
         .iter()
         .map(|document| {
-            let weight = document.tags.iter().fold(0, |weights, tag| {
-                tags.get(tag).map_or(weights, |weight| weights + *weight)
-            });
+            let weight = document
+                .tags
+                .iter()
+                .map(|tag| tags.get(tag))
+                .sum::<Option<usize>>()
+                .unwrap_or_default();
             (document.id.clone(), weight)
         })
         .collect_vec();

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -141,7 +141,7 @@ pub(crate) trait Interaction {
 pub(crate) trait Tag {
     async fn get(&self, user_id: &UserId) -> Result<HashMap<String, usize>, Error>;
 
-    async fn update(&self, user_id: &UserId, tags: &str) -> Result<(), Error>;
+    async fn update(&self, user_id: &UserId, tags: &[String]) -> Result<(), Error>;
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -247,7 +247,7 @@ pub struct Document {
     pub snippet: String,
     pub properties: DocumentProperties,
     pub embedding: Embedding,
-    pub tags: Option<String>,
+    pub tags: Vec<String>,
 }
 
 impl From<SearchResponse<Document>> for Vec<PersonalizedDocument> {


### PR DESCRIPTION
**Reference**

- [ET-3674]

**Summary**

- change document tags from `Option<String>` to `Vec<String>`
- sort documents by tags via accumulated tag weight


[ET-3674]: https://xainag.atlassian.net/browse/ET-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ