### PR TITLE
[Merged by Bors] - More api changes

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -46,7 +46,6 @@ module.exports = {
     'response-example-provided': 'off',
     'collection-array-property': 'off',
     'response-error-response-schema': 'off',
-    'enum-case-convention': 'off',
     'operation-id-case-convention': 'off',
     'patch-request-content-type': 'off',
   }

--- a/.spectral.js
+++ b/.spectral.js
@@ -34,7 +34,6 @@ module.exports = {
     'major-version-in-path': 'off',
     'schema-description': 'off',
     'inline-property-schema': 'off',
-    'content-entry-provided': 'off',
     'property-description': 'off',
     'oas3-api-servers': 'off',
     'delete-body': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -40,7 +40,6 @@ module.exports = {
     'delete-body': 'off',
     'optional-request-body': 'off',
     'prohibit-summary-sentence-style': 'off',
-    'response-status-codes': 'off',
     'response-example-provided': 'off',
     'collection-array-property': 'off',
     'response-error-response-schema': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -46,7 +46,6 @@ module.exports = {
     'response-example-provided': 'off',
     'collection-array-property': 'off',
     'response-error-response-schema': 'off',
-    'operation-id-case-convention': 'off',
     'patch-request-content-type': 'off',
   }
 };

--- a/.spectral.js
+++ b/.spectral.js
@@ -38,7 +38,6 @@ module.exports = {
     'oas3-api-servers': 'off',
     'delete-body': 'off',
     'prohibit-summary-sentence-style': 'off',
-    'response-example-provided': 'off',
     'collection-array-property': 'off',
     // the rule set wants to enforce a specific erorr shcema
     'response-error-response-schema': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -32,7 +32,6 @@ module.exports = {
       }
     },
     'major-version-in-path': 'off',
-    'array-boundary': 'off',
     'schema-description': 'off',
     'inline-property-schema': 'off',
     'content-entry-provided': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -40,6 +40,7 @@ module.exports = {
     'prohibit-summary-sentence-style': 'off',
     'response-example-provided': 'off',
     'collection-array-property': 'off',
+    // the rule set wants to enforce a specific erorr shcema
     'response-error-response-schema': 'off',
     'patch-request-content-type': 'off',
   }

--- a/.spectral.js
+++ b/.spectral.js
@@ -38,7 +38,6 @@ module.exports = {
     'property-description': 'off',
     'oas3-api-servers': 'off',
     'delete-body': 'off',
-    'optional-request-body': 'off',
     'prohibit-summary-sentence-style': 'off',
     'response-example-provided': 'off',
     'collection-array-property': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -37,7 +37,6 @@ module.exports = {
     'content-entry-provided': 'off',
     'property-description': 'off',
     'oas3-api-servers': 'off',
-    'operation-id-naming-convention': 'off',
     'delete-body': 'off',
     'optional-request-body': 'off',
     'prohibit-summary-sentence-style': 'off',

--- a/.spectral.js
+++ b/.spectral.js
@@ -32,7 +32,6 @@ module.exports = {
       }
     },
     'major-version-in-path': 'off',
-    'string-boundary': 'off',
     'array-boundary': 'off',
     'schema-description': 'off',
     'inline-property-schema': 'off',

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -38,7 +38,7 @@ paths:
             schema:
               $ref: '#/components/schemas/IngestionRequest'
       responses:
-        '204':
+        '201':
           description: successful operation
         '400':
           description: invalid request

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -246,25 +246,27 @@ components:
           items:
             $ref: '#/components/schemas/IngestedDocument'
     IngestionError:
-      allOf:
+      oneOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - type: object
-          required: [details]
-          properties:
-            details:
-              type: object
-              required: [documents]
-              properties:
-                documents:
-                  type: array
-                  minItems: 0
-                  maxItems: 100
-                  items:
-                    type: object
-                    required: [id]
-                    properties:
-                      id:
-                        $ref: './schemas/document.yml#/DocumentId'
+        - allOf:
+          - $ref: './schemas/error.yml#/GenericError'
+          - type: object
+            required: [details]
+            properties:
+              details:
+                type: object
+                required: [documents]
+                properties:
+                  documents:
+                    type: array
+                    minItems: 0
+                    maxItems: 100
+                    items:
+                      type: object
+                      required: [id]
+                      properties:
+                        id:
+                          $ref: './schemas/document.yml#/DocumentId'
     DeleteDocumentsRequest:
       type: object
       required: [documents]

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -246,27 +246,25 @@ components:
           items:
             $ref: '#/components/schemas/IngestedDocument'
     IngestionError:
-      oneOf:
+      allOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - allOf:
-          - $ref: './schemas/error.yml#/GenericError'
-          - type: object
-            required: [details]
-            properties:
-              details:
-                type: object
-                required: [documents]
-                properties:
-                  documents:
-                    type: array
-                    minItems: 0
-                    maxItems: 100
-                    items:
-                      type: object
-                      required: [id]
-                      properties:
-                        id:
-                          $ref: './schemas/document.yml#/DocumentId'
+        - type: object
+          required: [details]
+          properties:
+            details:
+              type: object
+              required: [documents]
+              properties:
+                documents:
+                  type: array
+                  minItems: 0
+                  maxItems: 100
+                  items:
+                    type: object
+                    required: [id]
+                    properties:
+                      id:
+                        $ref: './schemas/document.yml#/DocumentId'
     DeleteDocumentsRequest:
       type: object
       required: [documents]

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Back Office API
-  version: 1.0.0
+  version: 1.0.0-rc6
   description: |-
     # Back Office
     For this system, a document is anything that has an id, a snippet, and an arbitrary set of properties.

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -31,7 +31,7 @@ paths:
       description: |-
         Add documents to the system. The system will create a representation of the document
         that will be used to match it against the preferences of a user.
-      operationId: ingestDocuments
+      operationId: createDocuments
       requestBody:
         content:
           application/json:
@@ -93,7 +93,7 @@ paths:
         - back office
       summary: Get all document properties
       description: Gets all the properties of the document.
-      operationId: getDocumentProperties
+      operationId: listDocumentProperties
       responses:
         '200':
           description: successful operation
@@ -110,7 +110,7 @@ paths:
         - back office
       summary: Set all document properties
       description: Sets or replaces all the properties of the document.
-      operationId: setDocumentProperties
+      operationId: replaceDocumentProperties
       requestBody:
         content:
           application/json:
@@ -168,7 +168,7 @@ paths:
         - back office
       summary: Set a document property
       description: Sets or replaces the property of the document.
-      operationId: setDocumentProperty
+      operationId: replaceDocumentProperty
       requestBody:
         content:
           application/json:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -33,6 +33,7 @@ paths:
         that will be used to match it against the preferences of a user.
       operationId: createDocuments
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -58,6 +59,7 @@ paths:
         documents, no error is produced.
       operationId: deleteDocuments
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -112,6 +114,7 @@ paths:
       description: Sets or replaces all the properties of the document.
       operationId: replaceDocumentProperties
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -170,6 +173,7 @@ paths:
       description: Sets or replaces the property of the document.
       operationId: replaceDocumentProperty
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -233,6 +233,9 @@ components:
         snippet:
           description: Text that will be used to match the document against the user interests.
           type: string
+          minLength: 1
+          maxLength: 1024
+          pattern: '.+'
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
     IngestionRequest:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -40,9 +40,9 @@ paths:
               $ref: '#/components/schemas/IngestionRequest'
       responses:
         '201':
-          description: successful operation
+          $ref: './responses/generic.yml#/Created'
         '400':
-          description: invalid request
+          $ref: './responses/generic.yml#/BadRequest'
         '500':
           description: all or some of the documents were not successfully uploaded
           content:
@@ -68,7 +68,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid request
+          $ref: './responses/generic.yml#/BadRequest'
 
   /documents/{document_id}:
     parameters:
@@ -85,7 +85,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid request
+          $ref: './responses/generic.yml#/BadRequest'
 
   /documents/{document_id}/properties:
     parameters:
@@ -104,9 +104,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DocumentPropertiesResponse'
         '400':
-          description: invalid document id
-        '404':
-          description: document id not found
+          $ref: './responses/generic.yml#/BadRequest'
     put:
       tags:
         - back office
@@ -123,9 +121,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid document id
-        '404':
-          description: document id not found
+          $ref: './responses/generic.yml#/BadRequest'
     delete:
       tags:
         - back office
@@ -136,9 +132,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid document id
-        '404':
-          description: document id not found
+          $ref: './responses/generic.yml#/BadRequest'
 
   /documents/{document_id}/properties/{property_id}:
     parameters:
@@ -163,9 +157,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DocumentPropertyResponse'
         '400':
-          description: invalid document id or property id
-        '404':
-          description: document id or property id not found
+          $ref: './responses/generic.yml#/BadRequest'
     put:
       tags:
         - back office
@@ -182,9 +174,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid document id or property id
-        '404':
-          description: document id not found
+          $ref: './responses/generic.yml#/BadRequest'
     delete:
       tags:
         - back office
@@ -195,9 +185,7 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: invalid document id or property id
-        '404':
-          description: document id or property id not found
+          $ref: './responses/generic.yml#/BadRequest'
 
 components:
   securitySchemes:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -242,7 +242,7 @@ components:
             $ref: '#/components/schemas/IngestedDocument'
     IngestionError:
       allOf:
-        - $ref: './schemas/error.yml#/BaseError'
+        - $ref: './schemas/error.yml#/GenericError'
         - type: object
           required: [details]
           properties:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -204,6 +204,8 @@ components:
       properties:
         property:
           $ref: './schemas/document.yml#/DocumentProperty'
+      example:
+        property: "Any valid json value"
     DocumentPropertiesRequest:
       type: object
       required: [properties]
@@ -216,6 +218,9 @@ components:
       properties:
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
+      example:
+        properties:
+          title: "News title"
     IngestedDocument:
       type: object
       required: [id, snippet]

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -244,6 +244,8 @@ components:
       properties:
         documents:
           type: array
+          minItems: 1
+          maxItems: 100
           items:
             $ref: '#/components/schemas/IngestedDocument'
     IngestionError:
@@ -258,6 +260,8 @@ components:
               properties:
                 documents:
                   type: array
+                  minItems: 0
+                  maxItems: 100
                   items:
                     type: object
                     required: [id]
@@ -270,5 +274,7 @@ components:
       properties:
         documents:
           type: array
+          minItems: 1
+          maxItems: 1000
           items:
             $ref: './schemas/document.yml#/DocumentId'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -109,7 +109,7 @@ components:
             $ref: '#/components/schemas/PersonalizedDocumentData'
     PersonalizedDocumentsError:
       allOf:
-        - $ref: './schemas/error.yml#/BaseError'
+        - $ref: './schemas/error.yml#/GenericError'
         - type: object
           required: [kind]
           properties:
@@ -138,7 +138,7 @@ components:
             $ref: '#/components/schemas/UserInteractionData'
     UserInteractionError:
       allOf:
-        - $ref: './schemas/error.yml#/BaseError'
+        - $ref: './schemas/error.yml#/GenericError'
         - type: object
           required: [kind]
           properties:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -114,14 +114,16 @@ components:
             properties:
               title: "News title"
     PersonalizedDocumentsError:
-      allOf:
+      oneOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - type: object
-          required: [kind]
-          properties:
-            kind:
-              type: string
-              enum: [NotEnoughInteractions]
+        - allOf:
+          - $ref: './schemas/error.yml#/GenericError'
+          - type: object
+            required: [kind]
+            properties:
+              kind:
+                type: string
+                enum: [NotEnoughInteractions]
     UserInteractionType:
       type: string
       enum: [Positive]
@@ -143,11 +145,13 @@ components:
           items:
             $ref: '#/components/schemas/UserInteractionData'
     UserInteractionError:
-      allOf:
+      oneOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - type: object
-          required: [kind]
-          properties:
-            kind:
-              type: string
-              enum: [InvalidUserId, InvalidDocumentId]
+        - allOf:
+          - $ref: './schemas/error.yml#/GenericError'
+          - type: object
+            required: [kind]
+            properties:
+              kind:
+                type: string
+                enum: [InvalidUserId, InvalidDocumentId]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -51,7 +51,7 @@ paths:
           description: invalid user id.
         '404':
           description: user not found.
-        '422':
+        '409':
           description: impossible to create a personalized list for the user.
           content:
             application/json:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -107,6 +107,12 @@ components:
           maxItems: 100
           items:
             $ref: '#/components/schemas/PersonalizedDocumentData'
+      example:
+        documents:
+          - id: 'document_id0'
+            score: 0.87
+            properties:
+              title: "News title"
     PersonalizedDocumentsError:
       allOf:
         - $ref: './schemas/error.yml#/GenericError'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -48,9 +48,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PersonalizedDocumentsResponse'
         '400':
-          description: invalid user id.
-        '404':
-          description: user not found.
+           $ref: './responses/generic.yml#/BadRequest'
         '409':
           description: impossible to create a personalized list for the user.
           content:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -117,7 +117,7 @@ components:
               enum: [NotEnoughInteractions]
     UserInteractionType:
       type: string
-      enum: [positive]
+      enum: [Positive]
     UserInteractionData:
       type: object
       properties:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Front Office API
-  version: 1.0.0
+  version: 1.0.0-rc6
   description: |-
     # Front Office
     The system identifies a user with only an id.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -69,6 +69,7 @@ paths:
       parameters:
         - $ref: './parameters/path/user_id.yml'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -104,6 +104,8 @@ components:
       properties:
         documents:
           type: array
+          minItems: 0
+          maxItems: 100
           items:
             $ref: '#/components/schemas/PersonalizedDocumentData'
     PersonalizedDocumentsError:
@@ -131,6 +133,8 @@ components:
       properties:
         documents:
           type: array
+          minItems: 1
+          maxItems: 1000
           items:
             $ref: '#/components/schemas/UserInteractionData'
     UserInteractionError:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -114,16 +114,14 @@ components:
             properties:
               title: "News title"
     PersonalizedDocumentsError:
-      oneOf:
+      allOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - allOf:
-          - $ref: './schemas/error.yml#/GenericError'
-          - type: object
-            required: [kind]
-            properties:
-              kind:
-                type: string
-                enum: [NotEnoughInteractions]
+        - type: object
+          required: [kind]
+          properties:
+            kind:
+              type: string
+              enum: [NotEnoughInteractions]
     UserInteractionType:
       type: string
       enum: [Positive]
@@ -145,13 +143,11 @@ components:
           items:
             $ref: '#/components/schemas/UserInteractionData'
     UserInteractionError:
-      oneOf:
+      allOf:
         - $ref: './schemas/error.yml#/GenericError'
-        - allOf:
-          - $ref: './schemas/error.yml#/GenericError'
-          - type: object
-            required: [kind]
-            properties:
-              kind:
-                type: string
-                enum: [InvalidUserId, InvalidDocumentId]
+        - type: object
+          required: [kind]
+          properties:
+            kind:
+              type: string
+              enum: [InvalidUserId, InvalidDocumentId]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -65,7 +65,7 @@ paths:
       summary: Add interaction between a user and a document
       description: |-
         The interaction is used to provide personalized documents to the user.
-      operationId: documentInteraction
+      operationId: updateUserInteractions
       parameters:
         - $ref: './parameters/path/user_id.yml'
       requestBody:

--- a/web-api/openapi/responses/generic.yml
+++ b/web-api/openapi/responses/generic.yml
@@ -1,0 +1,14 @@
+Created:
+  description: Successful operation
+  content:
+    application/json:
+      schema:
+        type: object
+        example: {}
+
+BadRequest:
+  description: The request is invalid. Please check the path parameters, queries, and the request body.
+  content:
+    application/json:
+      schema:
+        $ref: '../schemas/error.yml#/GenericError'

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -1,8 +1,6 @@
 DocumentId:
-  description: |-
-    A document id can be any non-empty UTF-8 string that does not contain the null byte.
-    It may consist of digits, Latin letters, underscores, colons, minus signs, at signs, and dots.
-  type: string
+  description: Id of a document.
+  $ref: './id.yml#/Id'
   example: "document_id"
 
 DocumentProperty:
@@ -20,8 +18,6 @@ DocumentProperties:
     link: "http://example.com/this_news"
 
 DocumentPropertyId:
-  description: |-
-    A document property id can be any non-empty UTF-8 string that does not contain the null byte.
-    It may consist of digits, Latin letters, underscores, colons, minus signs, at signs, and dots.
-  type: string
-  example: "document_property_id"
+  description: Id of a property of a document.
+  $ref: './id.yml#/Id'
+  example: "title"

--- a/web-api/openapi/schemas/error.yml
+++ b/web-api/openapi/schemas/error.yml
@@ -1,6 +1,5 @@
 BaseError:
   type: object
-  required: [request_id, kind]
   properties:
     request_id:
       description: Request ID optionally generated from the service. It can be communicated to xayn to help debugging.

--- a/web-api/openapi/schemas/error.yml
+++ b/web-api/openapi/schemas/error.yml
@@ -1,4 +1,4 @@
-BaseError:
+GenericError:
   type: object
   properties:
     request_id:

--- a/web-api/openapi/schemas/id.yml
+++ b/web-api/openapi/schemas/id.yml
@@ -1,0 +1,8 @@
+Id:
+  description: |-
+    An id can be any non-empty string that consist of digits, latin letters, underscores, colons, minus signs, at signs, and dots.
+  type: string
+  pattern: '^[a-zA-Z0-9_:@.-]+$'
+  minLength: 1
+  maxLength: 256
+  example: "valid_id1"

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -1,6 +1,4 @@
 UserId:
-  description: |-
-    A user id can be any non-empty UTF-8 string that does not contain the null byte.
-    It may consist of digits, Latin letters, underscores, colons, minus signs, at signs, and dots.
-  type: string
+  description: Id of a user.
+  $ref: './id.yml#/Id'
   example: "user_id"

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -27,19 +27,19 @@ use crate::{impl_application_error, models::DocumentId, Error};
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct DocumentNotFound;
 
-impl_application_error!(DocumentNotFound => NOT_FOUND);
+impl_application_error!(DocumentNotFound => BAD_REQUEST);
 
 /// The requested document was found but not the requested property.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct DocumentPropertyNotFound;
 
-impl_application_error!(DocumentPropertyNotFound => NOT_FOUND);
+impl_application_error!(DocumentPropertyNotFound => BAD_REQUEST);
 
 /// The requested property was not found.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct PropertyNotFound;
 
-impl_application_error!(PropertyNotFound => NOT_FOUND);
+impl_application_error!(PropertyNotFound => BAD_REQUEST);
 
 /// Malformed user id.
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -69,7 +69,7 @@ impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST);
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct NotEnoughInteractions;
 
-impl_application_error!(NotEnoughInteractions => NOT_FOUND);
+impl_application_error!(NotEnoughInteractions => CONFLICT);
 
 /// Failed to delete some documents
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -132,7 +132,7 @@ async fn new_documents(
             }
         })?;
 
-    Ok(HttpResponse::NoContent())
+    Ok(HttpResponse::Created())
 }
 
 async fn delete_document(

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -142,7 +142,6 @@ impl AiDocument for &PersonalizedDocument {
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub(crate) enum UserInteractionType {
-    #[serde(rename = "positive")]
     Positive = 1,
 }
 


### PR DESCRIPTION
Depends on #741 
* Document ingestion now returns 201 instead of 204; error code 422 has been replaced with 409.
* Request bodies have been marked as required.
* A response always returns a body, even when empty.
* 404 is returned only if the request does not enter the handler. If it does, then a 400 will be returned instead.
* Now every error is a `GenericError`
* Specific error are now only one possible error that the endpoint can return, a generic error is always possible. In this way we can extend the kind of error we can return form an endpoint. 