### PR TITLE
[Merged by Bors] - ET-3767 configurable log level

### DIFF
--- a/coi/src/config.rs
+++ b/coi/src/config.rs
@@ -41,23 +41,23 @@ pub struct Config {
     horizon: Duration,
 }
 
-fn default_shift_factor() -> f32 {
+const fn default_shift_factor() -> f32 {
     0.1
 }
 
-fn default_threshold() -> f32 {
+const fn default_threshold() -> f32 {
     0.67
 }
 
-fn default_min_positive_cois() -> usize {
+const fn default_min_positive_cois() -> usize {
     1
 }
 
-fn default_min_negative_cois() -> usize {
+const fn default_min_negative_cois() -> usize {
     0
 }
 
-fn default_horizon() -> Duration {
+const fn default_horizon() -> Duration {
     Duration::from_secs(SECONDS_PER_DAY_U64 * 30)
 }
 

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -30,7 +30,7 @@ fn default_directory() -> RelativePathBuf {
     "assets".into()
 }
 
-fn default_token_size() -> usize {
+const fn default_token_size() -> usize {
     250
 }
 

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -74,7 +74,7 @@ impl Default for IngestionConfig {
     }
 }
 
-fn default_max_document_batch_size() -> usize {
+const fn default_max_document_batch_size() -> usize {
     100
 }
 

--- a/web-api/src/load_config.rs
+++ b/web-api/src/load_config.rs
@@ -48,11 +48,10 @@ use serde::{de::DeserializeOwned, Serialize};
 /// environment if they don't already exist there (keeping priority as described above).
 ///
 /// When creating the config type instance, only environment variables with the
-/// `XAYN_WEB_API_` prefix will be considered and the prefix is stripped.
+/// `XAYN_WEB_API__` prefix will be considered and the prefix is stripped.
 ///
 /// Env variables are split at `__`. I.e. `XAYN_WEB_API__FOO__BAR=12` will be treated like
-/// the json `{ "foo": { "bar": 12 } }` wrt. deserializing the config. The `__` is needed, otherwise
-/// there would be no way to have fields like `bind_to` in the config.
+/// the json `{ "foo": { "bar": 12 } }` wrt. deserializing the config.
 pub(crate) fn load_config<C, U>(
     config_file: Option<&Path>,
     update_with: U,

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -75,20 +75,20 @@ pub(crate) struct PersonalizationConfig {
     pub(crate) interest_tag_bias: f32,
 }
 
-fn default_max_number_documents() -> usize {
+const fn default_max_number_documents() -> usize {
     100
 }
 
-fn default_default_number_documents() -> usize {
+const fn default_default_number_documents() -> usize {
     100
 }
 
-fn default_max_cois_for_knn() -> usize {
+const fn default_max_cois_for_knn() -> usize {
     //FIXME what is a default value we know works well with how we do knn?
     10
 }
 
-fn default_interest_tag_bias() -> f32 {
+const fn default_interest_tag_bias() -> f32 {
     0.5
 }
 

--- a/web-api/src/server/config.rs
+++ b/web-api/src/server/config.rs
@@ -68,7 +68,7 @@ fn default_bind_address() -> SocketAddr {
     SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4252).into()
 }
 
-fn default_max_body_size() -> usize {
+const fn default_max_body_size() -> usize {
     524_288
 }
 

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log",
+    "level": "info"
   },
   "net": {
     "bind_to": "127.4.3.2:1099",

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": null
+    "file": null,
+    "level": "info"
   },
   "net": {
     "bind_to": "127.0.0.1:4252",

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": null
+    "file": null,
+    "level": "info"
   },
   "net": {
     "bind_to": "127.0.0.1:4252",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log",
+    "level": "trace"
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log",
+    "level": "info"
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -5,7 +5,8 @@ stderr = ""
 stdout = """
 {
   "logging": {
-    "file": "[CWD]/tests/cmd/assets/foo/bar.log"
+    "file": "[CWD]/tests/cmd/assets/foo/bar.log",
+    "level": "info"
   },
   "net": {
     "bind_to": "127.4.3.2:1099",

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -60,6 +60,7 @@ fn test_loading_config_with_env_overrides() {
         [
             ("XAYN_WEB_API__STORAGE__POSTGRES__PORT", "3532"),
             ("XAYN_WEB_API__NET__MAX_BODY_SIZE", "4422"),
+            ("XAYN_WEB_API__LOGGING__LEVEL", "trace"),
         ],
         || {
             TestCases::new().case("tests/cmd/env_overrides.toml");


### PR DESCRIPTION
**Reference**

- [ET-3767]
- [ET-3444]

**Summary**

- make the log level of the rust apis configurable
- set the default log level to `"info"`


[ET-3767]: https://xainag.atlassian.net/browse/ET-3767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-3444]: https://xainag.atlassian.net/browse/ET-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ