### PR TITLE
[Merged by Bors] - ET-3771 configurable keep alive

### DIFF
--- a/web-api/src/server.rs
+++ b/web-api/src/server.rs
@@ -77,6 +77,7 @@ where
         }
 
         let addr = config.net.bind_to;
+        let keep_alive = config.net.keep_alive;
         init_tracing(config.as_ref());
 
         let json_config = JsonConfig::default().limit(config.net.max_body_size);
@@ -95,6 +96,7 @@ where
                 .wrap(Cors::permissive())
         })
         .bind(addr)?
+        .keep_alive(keep_alive)
         .run()
         .await?;
 

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.4.3.2:1099",
-    "max_body_size": 64
+    "max_body_size": 64,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.0.1:4252",
-    "max_body_size": 524288
+    "max_body_size": 524288,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.0.1:4252",
-    "max_body_size": 524288
+    "max_body_size": 524288,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.1.1:3040",
-    "max_body_size": 4422
+    "max_body_size": 4422,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.1.1:3040",
-    "max_body_size": 64
+    "max_body_size": 64,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -9,7 +9,8 @@ stdout = """
   },
   "net": {
     "bind_to": "127.4.3.2:1099",
-    "max_body_size": 64
+    "max_body_size": 64,
+    "keep_alive": 61
   },
   "storage": {
     "elastic": {


### PR DESCRIPTION
**Reference**

- [ET-3771]

**Summary**

- make the keep alive timeout of the services configurable
- set the default timeout to `61s`


[ET-3771]: https://xainag.atlassian.net/browse/ET-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ