### PR TITLE
[Merged by Bors] - ET-3774 configurable client request timeout

### DIFF
--- a/web-api/src/server.rs
+++ b/web-api/src/server.rs
@@ -78,6 +78,7 @@ where
 
         let addr = config.net.bind_to;
         let keep_alive = config.net.keep_alive;
+        let client_request_timeout = config.net.client_request_timeout;
         init_tracing(config.as_ref());
 
         let json_config = JsonConfig::default().limit(config.net.max_body_size);
@@ -97,6 +98,7 @@ where
         })
         .bind(addr)?
         .keep_alive(keep_alive)
+        .client_request_timeout(client_request_timeout)
         .run()
         .await?;
 

--- a/web-api/src/server/config.rs
+++ b/web-api/src/server/config.rs
@@ -57,6 +57,11 @@ pub struct NetConfig {
     #[serde(with = "serde_duration_as_seconds")]
     #[serde(default = "default_keep_alive")]
     pub(crate) keep_alive: Duration,
+
+    /// Client request timeout in seconds
+    #[serde(with = "serde_duration_as_seconds")]
+    #[serde(default = "default_client_request_timeout")]
+    pub(crate) client_request_timeout: Duration,
 }
 
 fn default_bind_address() -> SocketAddr {
@@ -71,12 +76,17 @@ const fn default_keep_alive() -> Duration {
     Duration::from_secs(61)
 }
 
+const fn default_client_request_timeout() -> Duration {
+    Duration::from_secs(0)
+}
+
 impl Default for NetConfig {
     fn default() -> Self {
         Self {
             bind_to: default_bind_address(),
             max_body_size: default_max_body_size(),
             keep_alive: default_keep_alive(),
+            client_request_timeout: default_client_request_timeout(),
         }
     }
 }

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.4.3.2:1099",
     "max_body_size": 64,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.0.0.1:4252",
     "max_body_size": 524288,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.0.0.1:4252",
     "max_body_size": 524288,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.0.1.1:3040",
     "max_body_size": 4422,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.0.1.1:3040",
     "max_body_size": 64,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -10,7 +10,8 @@ stdout = """
   "net": {
     "bind_to": "127.4.3.2:1099",
     "max_body_size": 64,
-    "keep_alive": 61
+    "keep_alive": 61,
+    "client_request_timeout": 0
   },
   "storage": {
     "elastic": {


### PR DESCRIPTION
**Reference**

- [ET-3774]

**Summary**

- make the client request timeout of the services configurable
- set the default timeout to `0s` (ie disabled)


[ET-3774]: https://xainag.atlassian.net/browse/ET-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ