### PR TITLE
[Merged by Bors] - ET-3766 exclude unnecessary fields from elastic queries

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -111,8 +111,6 @@ components:
           $ref: './schemas/document.yml#/DocumentId'
         score:
           type: number
-        properties:
-          $ref: './schemas/document.yml#/DocumentProperties'
     PersonalizedDocumentsResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -111,6 +111,8 @@ components:
           $ref: './schemas/document.yml#/DocumentId'
         score:
           type: number
+        properties:
+          $ref: './schemas/document.yml#/DocumentProperties'
     PersonalizedDocumentsResponse:
       type: object
       required: [documents]

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -96,16 +96,21 @@ pub(crate) struct DocumentProperty(serde_json::Value);
 /// Arbitrary properties that can be attached to a document.
 pub(crate) type DocumentProperties = HashMap<DocumentPropertyId, DocumentProperty>;
 
-#[derive(Debug, Deserialize)]
+/// Represents a result from an interaction query.
+#[derive(Debug)]
 pub(crate) struct InteractedDocument {
+    /// Unique identifier of the document.
     pub(crate) id: DocumentId,
+
+    /// Embedding from smbert.
     pub(crate) embedding: Embedding,
-    #[serde(default)]
+
+    /// The tags associated to the document.
     pub(crate) tags: Vec<String>,
 }
 
 /// Represents a result from a personalization query.
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub(crate) struct PersonalizedDocument {
     /// Unique identifier of the document.
     pub(crate) id: DocumentId,
@@ -117,11 +122,9 @@ pub(crate) struct PersonalizedDocument {
     pub(crate) embedding: Embedding,
 
     /// Contents of the document properties.
-    #[serde(default)]
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
-    #[serde(default)]
     pub(crate) tags: Vec<String>,
 }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -91,13 +91,13 @@ id_wrapper!(DocumentPropertyId, is_valid_id, InvalidDocumentPropertyId);
 id_wrapper!(UserId, is_valid_id, InvalidUserId);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DocumentProperty(serde_json::Value);
+pub(crate) struct DocumentProperty(serde_json::Value);
 
 /// Arbitrary properties that can be attached to a document.
 pub(crate) type DocumentProperties = HashMap<DocumentPropertyId, DocumentProperty>;
 
 /// Represents a result from a query.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct PersonalizedDocument {
     /// Unique identifier of the document.
     pub(crate) id: DocumentId,
@@ -106,12 +106,7 @@ pub(crate) struct PersonalizedDocument {
     pub(crate) score: f32,
 
     /// Embedding from smbert.
-    #[serde(skip_serializing)]
     pub(crate) embedding: Embedding,
-
-    /// Contents of the document properties.
-    #[serde(default)]
-    pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
     #[serde(default)]
@@ -119,18 +114,6 @@ pub(crate) struct PersonalizedDocument {
 }
 
 impl AiDocument for PersonalizedDocument {
-    type Id = DocumentId;
-
-    fn id(&self) -> &Self::Id {
-        &self.id
-    }
-
-    fn bert_embedding(&self) -> &Embedding {
-        &self.embedding
-    }
-}
-
-impl AiDocument for &PersonalizedDocument {
     type Id = DocumentId;
 
     fn id(&self) -> &Self::Id {

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -96,7 +96,15 @@ pub(crate) struct DocumentProperty(serde_json::Value);
 /// Arbitrary properties that can be attached to a document.
 pub(crate) type DocumentProperties = HashMap<DocumentPropertyId, DocumentProperty>;
 
-/// Represents a result from a query.
+#[derive(Debug, Deserialize)]
+pub(crate) struct InteractedDocument {
+    pub(crate) id: DocumentId,
+    pub(crate) embedding: Embedding,
+    #[serde(default)]
+    pub(crate) tags: Vec<String>,
+}
+
+/// Represents a result from a personalization query.
 #[derive(Debug, Deserialize)]
 pub(crate) struct PersonalizedDocument {
     /// Unique identifier of the document.

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -108,6 +108,10 @@ pub(crate) struct PersonalizedDocument {
     /// Embedding from smbert.
     pub(crate) embedding: Embedding,
 
+    /// Contents of the document properties.
+    #[serde(default)]
+    pub(crate) properties: DocumentProperties,
+
     /// The tags associated to the document.
     #[serde(default)]
     pub(crate) tags: Vec<String>,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -153,14 +153,30 @@ async fn personalized_documents(
         PersonalizeBy::KnnSearch(options.document_count(&state.config.personalization)?),
     )
     .await
-    .map(|documents| Json(PersonalizedDocumentsResponse { documents }))
+    .map(|documents| {
+        Json(PersonalizedDocumentsResponse {
+            documents: documents
+                .into_iter()
+                .map(|document| PersonalizedDocumentData {
+                    id: document.id,
+                    score: document.score,
+                })
+                .collect(),
+        })
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct PersonalizedDocumentData {
+    id: DocumentId,
+    score: f32,
 }
 
 /// Represents response from personalized documents endpoint.
-#[derive(Debug, Clone, Serialize)]
-pub(crate) struct PersonalizedDocumentsResponse {
+#[derive(Debug, Serialize)]
+struct PersonalizedDocumentsResponse {
     /// A list of documents personalized for a specific user.
-    pub(crate) documents: Vec<PersonalizedDocument>,
+    documents: Vec<PersonalizedDocumentData>,
 }
 
 /// Computes [`PositiveCoi`]s weights used to determine how many documents to fetch using each centers' embedding.

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -38,7 +38,7 @@ use crate::{
         application::WithRequestIdExt,
         common::{BadRequest, InternalError, NotEnoughInteractions},
     },
-    models::{DocumentId, PersonalizedDocument, UserId, UserInteractionType},
+    models::{DocumentId, DocumentProperties, PersonalizedDocument, UserId, UserInteractionType},
     storage::{self, KnnSearchParams},
     Error,
 };
@@ -160,6 +160,7 @@ async fn personalized_documents(
                 .map(|document| PersonalizedDocumentData {
                     id: document.id,
                     score: document.score,
+                    properties: document.properties,
                 })
                 .collect(),
         })
@@ -170,6 +171,8 @@ async fn personalized_documents(
 struct PersonalizedDocumentData {
     id: DocumentId,
     score: f32,
+    #[serde(skip_serializing_if = "DocumentProperties::is_empty")]
+    properties: DocumentProperties,
 }
 
 /// Represents response from personalized documents endpoint.
@@ -319,7 +322,7 @@ pub(crate) async fn personalize_documents_by(
             .await?
         }
         PersonalizeBy::Documents(documents) => {
-            storage::Document::get_by_ids(storage, documents).await?
+            storage::Document::get_by_ids(storage, documents, true).await?
         }
     };
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -322,7 +322,7 @@ pub(crate) async fn personalize_documents_by(
             .await?
         }
         PersonalizeBy::Documents(documents) => {
-            storage::Document::get_by_ids(storage, documents, true).await?
+            storage::Document::get_personalized(storage, documents).await?
         }
     };
 

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -66,7 +66,11 @@ pub(crate) enum DeletionError {
 
 #[async_trait]
 pub(crate) trait Document {
-    async fn get_by_ids(&self, ids: &[&DocumentId]) -> Result<Vec<PersonalizedDocument>, Error>;
+    async fn get_by_ids(
+        &self,
+        ids: &[&DocumentId],
+        with_properties: bool,
+    ) -> Result<Vec<PersonalizedDocument>, Error>;
 
     async fn get_by_embedding<'a>(
         &self,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -33,6 +33,7 @@ use crate::{
         DocumentId,
         DocumentPropertyId,
         IngestedDocument,
+        InteractedDocument,
         PersonalizedDocument,
         UserId,
     },
@@ -66,10 +67,11 @@ pub(crate) enum DeletionError {
 
 #[async_trait]
 pub(crate) trait Document {
-    async fn get_by_ids(
+    async fn get_interacted(&self, ids: &[&DocumentId]) -> Result<Vec<InteractedDocument>, Error>;
+
+    async fn get_personalized(
         &self,
         ids: &[&DocumentId],
-        with_properties: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
     async fn get_by_embedding<'a>(

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -128,7 +128,7 @@ pub(crate) trait Interest {
 }
 
 pub(crate) struct InteractionUpdateContext<'s, 'l> {
-    pub(crate) document: &'s PersonalizedDocument,
+    pub(crate) document: &'s InteractedDocument,
     pub(crate) tag_weight_diff: &'s mut HashMap<&'l str, i32>,
     pub(crate) positive_cois: &'s mut Vec<PositiveCoi>,
 }

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -236,9 +236,33 @@ struct SearchResponse<T> {
 }
 
 #[derive(Debug, Deserialize)]
+struct InteractedDocument {
+    embedding: Embedding,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+impl From<SearchResponse<InteractedDocument>> for Vec<models::InteractedDocument> {
+    fn from(response: SearchResponse<InteractedDocument>) -> Self {
+        response
+            .hits
+            .hits
+            .into_iter()
+            .map(|hit| models::InteractedDocument {
+                id: hit.id,
+                embedding: hit.source.embedding,
+                tags: hit.source.tags,
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct PersonalizedDocument {
+    #[serde(default)]
     properties: DocumentProperties,
     embedding: Embedding,
+    #[serde(default)]
     tags: Vec<String>,
 }
 
@@ -253,27 +277,6 @@ impl From<SearchResponse<PersonalizedDocument>> for Vec<models::PersonalizedDocu
                 score: hit.score,
                 embedding: hit.source.embedding,
                 properties: hit.source.properties,
-                tags: hit.source.tags,
-            })
-            .collect()
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct InteractedDocument {
-    embedding: Embedding,
-    tags: Vec<String>,
-}
-
-impl From<SearchResponse<InteractedDocument>> for Vec<models::InteractedDocument> {
-    fn from(response: SearchResponse<InteractedDocument>) -> Self {
-        response
-            .hits
-            .hits
-            .into_iter()
-            .map(|hit| models::InteractedDocument {
-                id: hit.id,
-                embedding: hit.source.embedding,
                 tags: hit.source.tags,
             })
             .collect()

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -237,6 +237,8 @@ struct SearchResponse<T> {
 
 #[derive(Debug, Deserialize)]
 struct PersonalizedDocument {
+    #[serde(default)]
+    properties: DocumentProperties,
     embedding: Embedding,
     tags: Vec<String>,
 }
@@ -251,6 +253,7 @@ impl From<SearchResponse<PersonalizedDocument>> for Vec<models::PersonalizedDocu
                 id: hit.id,
                 score: hit.score,
                 embedding: hit.source.embedding,
+                properties: hit.source.properties,
                 tags: hit.source.tags,
             })
             .collect()
@@ -296,7 +299,7 @@ impl Storage {
                     "values" : values,
                 }
             },
-            "_source": ["embedding", "tags"]
+            "_source": &["properties", "embedding", "tags"][usize::from(!with_properties)..]
         }));
 
         Ok(self
@@ -342,7 +345,7 @@ impl storage::Document for Storage {
                     }
                 }
             },
-            "_source": ["embedding", "tags"]
+            "_source": ["properties", "embedding", "tags"]
         }));
 
         // the existing documents are not filtered in the elastic query to avoid too much work for a

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -524,7 +524,7 @@ impl storage::Interaction for Storage {
         F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Send + Sync,
     {
         // Note: This doesn't have the exact same concurrency semantics as the postgres version
-        let documents = self.get_by_ids(updated_document_ids).await?;
+        let documents = self.get_interacted(updated_document_ids).await?;
         let mut interests = self.interests.write().await;
         let mut interactions = self.interactions.write().await;
         let interactions = interactions.entry(user_id.clone()).or_default();

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -241,7 +241,6 @@ impl storage::Document for Storage {
                             id: id.clone(),
                             score: 1.,
                             embedding: embedding.clone(),
-                            properties: document.properties.clone(),
                             tags: document.tags.clone(),
                         })
                 })
@@ -273,7 +272,6 @@ impl storage::Document for Storage {
                         id: id.clone(),
                         score: item.distance,
                         embedding: item.point.as_ref().clone(),
-                        properties: document.properties.clone(),
                         tags: document.tags.clone(),
                     })
                 }
@@ -674,7 +672,6 @@ mod tests {
             .unwrap();
         assert_eq!(documents[0].id, DocumentId::new("42").unwrap());
         assert_eq!(documents[0].embedding, Embedding::from([1., 2., 3.]));
-        assert!(documents[0].properties.is_empty());
         assert_eq!(documents[0].tags, vec![String::from("tag")]);
         assert_eq!(
             storage::Tag::get(&storage, &UserId::new("abc").unwrap())

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -512,7 +512,7 @@ impl storage::Interaction for Storage {
         Database::acquire_user_coi_lock(&mut tx, user_id).await?;
 
         let documents = self
-            .get_by_ids_with_transaction(updated_document_ids, Some(&mut tx))
+            .get_interacted_with_transaction(updated_document_ids, Some(&mut tx))
             .await?;
 
         let now = Utc::now();


### PR DESCRIPTION
**Reference**

- [ET-3766]

**Summary**

- return the smaller `PersonalizedDocumentData` instead of the `PersonalizedDocument` from the `personalized_documents` route
- restrict elastic to only return the necessary fields in the storage calls


[ET-3766]: https://xainag.atlassian.net/browse/ET-3766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ