### PR TITLE
[Merged by Bors] - FIX: missing optional fields during ingestion

### DIFF
--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -158,9 +158,11 @@ pub(crate) struct IngestedDocument {
     pub(crate) snippet: String,
 
     /// Contents of the document properties.
+    #[serde(default)]
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
+    #[serde(default)]
     pub(crate) tags: Vec<String>,
 }
 


### PR DESCRIPTION
**Summary**

- use defaults for missing optional ingested fields, only `id` and `snippet` are required by the spec, but neither `properties` nor `tags`
