### PR TITLE
[Merged by Bors] - ET-3565 update spec

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -39,7 +39,7 @@ module.exports = {
     'delete-body': 'off',
     'prohibit-summary-sentence-style': 'off',
     'collection-array-property': 'off',
-    // the rule set wants to enforce a specific erorr shcema
+    // the rule set wants to enforce a specific erorr schema
     'response-error-response-schema': 'off',
     'patch-request-content-type': 'off',
   }

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Back Office API
-  version: 1.0.0-rc6
+  version: 1.0.0-rc7
   description: |-
     # Back Office
     The back office is typically used within server-side apps.
@@ -47,11 +47,18 @@ paths:
       tags:
         - back office
       summary: Add documents to the system
-      description: |-
-        Add documents to the system. The system will create a representation of the document
-        that will be used to match it against the preferences of a user.
-        Important note: currently we allow up to a maximum of 100 documents per batch size.
-        If you need to add more, then please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
+      description: |
+        Add documents to the system.
+
+        The system will create a representation of the document that will be used to match it against the preferences of a user.
+
+        **Important note:** Currently we allow up to a maximum of 100 documents per batch size. If you need to add more, then
+        please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
+
+        **Important note:** Documents which have no `publication_date` (in `properties`) or a `publication_date` in the future are
+        treated as unpublished and as such are filtered out from personalized documents. This allows ingesting document which e.g.
+        are scheduled to be published later on. Be aware that there is no way to update the snippet of an document. So ingestion
+        should only be done after the snippet is finalized.
       operationId: createDocuments
       requestBody:
         required: true

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Front Office API
-  version: 1.0.0-rc6
+  version: 1.0.0-rc7
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -10,7 +10,7 @@ DocumentProperty:
 DocumentProperties:
   description: Mostly arbitrary properties that can be attached to a document. A key must be a valid `DocumentPropertyId`.
   type: object
-  property:
+  properties:
     publication_date:
       type: string
       format: date-time

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -8,8 +8,22 @@ DocumentProperty:
   example: "News title"
 
 DocumentProperties:
-  description: Arbitrary properties that can be attached to a document. A key must be a valid `DocumentPropertyId`.
+  description: Mostly arbitrary properties that can be attached to a document. A key must be a valid `DocumentPropertyId`.
   type: object
+  property:
+    publication_date:
+      type: string
+      format: date-time
+      example: "2000-05-14T20:22:50Z"
+      summary: A RFC3339 compatible date-time
+      description: |
+        A RFC3339 compatible date-time
+
+        - can be in the future
+        - will be converted to and then stored as UTC
+        - sub-second resolution is not guaranteed.
+        - if this property is not set or set into the future this
+          document will be ignored for personalization
   additionalProperties:
     $ref: '#/DocumentProperty'
   example:

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -14,8 +14,11 @@ DocumentProperties:
     publication_date:
       type: string
       format: date-time
+      minLength: 10
+      # 35 should be enough (20 normally + up to 10 for subsec + up to 5 for offset),
+      # but to avoid any accidents we go with 40
+      maxLength: 40
       example: "2000-05-14T20:22:50Z"
-      summary: A RFC3339 compatible date-time
       description: |
         A RFC3339 compatible date-time
 


### PR DESCRIPTION

 -  `publication_date` is now in `properties` 
    -  it's updatable, deletable but limited to a RFC3339 timestamp
 -  conceptually documents with a publication_date in the future, or without one are no treated as unpublished. This means they will be filtered out from personalized documents. But they will not be directly discarded. They still will be ingested and the date can be set later allowing for scheduled or delayed publishing. Making it easier to integrate our service into a typical news paper workflow (which often involves scheduled publishing, canceled scheduled publishing, delayed publishing, ubpublishing etc. all now possible)