### PR TITLE
[Merged by Bors] - ET-3564 date filter elastic search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time",
+ "time 0.3.17",
  "url",
 ]
 
@@ -405,9 +405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -1264,7 +1267,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1874,7 +1877,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -1899,7 +1902,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time",
+ "time 0.3.17",
  "unicode-segmentation",
 ]
 
@@ -2061,7 +2064,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -3281,6 +3284,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -3840,6 +3854,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.66.1"
 [workspace.dependencies]
 criterion = "0.4.0"
 csv = "1.1.6"
+chrono = "0.4.23"
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "display", "from", "into"] }
 displaydoc = "0.2.3"
 figment = "0.10.8"

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -10,9 +10,9 @@ license = "AGPL-3.0-only"
 actix-cors = "0.6.4"
 actix-web = { version = "4.2.1", default-features = false, features = ["compress-gzip", "compress-zstd"] }
 anyhow = "1.0.68"
-async-trait = "0.1.61"
-clap = { version = "4.1.1", features = ["derive"] }
+async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+clap = { version = "4.0.30", features = ["derive"] }
 csv = { workspace = true }
 derive_more = { workspace = true }
 displaydoc = { workspace = true }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -12,6 +12,7 @@ actix-web = { version = "4.2.1", default-features = false, features = ["compress
 anyhow = "1.0.68"
 async-trait = "0.1.61"
 clap = { version = "4.1.1", features = ["derive"] }
+chrono = { workspace = true, features = ["serde"] }
 csv = { workspace = true }
 derive_more = { workspace = true }
 displaydoc = { workspace = true }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPL-3.0-only"
 actix-cors = "0.6.4"
 actix-web = { version = "4.2.1", default-features = false, features = ["compress-gzip", "compress-zstd"] }
 anyhow = "1.0.68"
-async-trait = { workspace = true }
+async-trait = "0.1.61"
 chrono = { workspace = true, features = ["serde"] }
 clap = { version = "4.0.30", features = ["derive"] }
 csv = { workspace = true }

--- a/web-api/elastic-search/mapping.json
+++ b/web-api/elastic-search/mapping.json
@@ -9,6 +9,13 @@
                 "dims": 128,
                 "index": true,
                 "similarity": "dot_product"
+            },
+            "properties": {
+                "properties": {
+                    "publication_date": {
+                        "type": "date"
+                    }
+                }
             }
         }
     }

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -55,10 +55,7 @@ paths:
         **Important note:** Currently we allow up to a maximum of 100 documents per batch size. If you need to add more, then
         please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
 
-        **Important note:** Documents which have no `publication_date` (in `properties`) or a `publication_date` in the future are
-        treated as unpublished and as such are filtered out from personalized documents. This allows ingesting documents which e.g.
-        are scheduled to be published later on. Be aware that there is no way to update the snippet of a document. So ingestion
-        should only be done after the snippet is finalized.
+        **Important note:** Documents which have no `publication_date` are not included when using the `published_after` filter.
       operationId: createDocuments
       requestBody:
         required: true

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -56,8 +56,8 @@ paths:
         please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
 
         **Important note:** Documents which have no `publication_date` (in `properties`) or a `publication_date` in the future are
-        treated as unpublished and as such are filtered out from personalized documents. This allows ingesting document which e.g.
-        are scheduled to be published later on. Be aware that there is no way to update the snippet of an document. So ingestion
+        treated as unpublished and as such are filtered out from personalized documents. This allows ingesting documents which e.g.
+        are scheduled to be published later on. Be aware that there is no way to update the snippet of a document. So ingestion
         should only be done after the snippet is finalized.
       operationId: createDocuments
       requestBody:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -58,7 +58,7 @@ paths:
           description: Only include documents which have been published after given datetime
           required: false
           schema:
-            $ref: './time.yml#PublicationDate'
+            $ref: './schemas/time.yml#PublicationDate'
       responses:
         '200':
           description: successful operation

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -53,6 +53,12 @@ paths:
             minimum: 1
             maximum: 100
             default: 10
+        - name: published_after
+          in: query
+          description: Only include documents which have been published after given datetime
+          required: false
+          schema:
+            $ref: './time.yml#PublicationDate'
       responses:
         '200':
           description: successful operation

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -58,7 +58,7 @@ paths:
           description: Only include documents which have been published after given datetime
           required: false
           schema:
-            $ref: './schemas/time.yml#PublicationDate'
+            $ref: './schemas/time.yml#/PublicationDate'
       responses:
         '200':
           description: successful operation

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -55,7 +55,10 @@ paths:
             default: 10
         - name: published_after
           in: query
-          description: Only include documents which have been published after given datetime
+          description: |-
+            Only include documents which have been published after given datetime.
+
+            If used documents without a `properties.publication_date` will be ignored.
           required: false
           schema:
             $ref: './schemas/time.yml#/PublicationDate'

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -12,21 +12,7 @@ DocumentProperties:
   type: object
   properties:
     publication_date:
-      type: string
-      format: date-time
-      minLength: 10
-      # 35 should be enough (20 normally + up to 10 for subsec + up to 5 for offset),
-      # but to avoid any accidents we go with 40
-      maxLength: 40
-      example: "2000-05-14T20:22:50Z"
-      description: |
-        A RFC3339 compatible date-time
-
-        - can be in the future
-        - will be converted to and then stored as UTC
-        - sub-second resolution is not guaranteed.
-        - if this property is not set or set into the future this
-          document will be ignored for personalization
+      $ref: './time.yml#PublicationDate'
   additionalProperties:
     $ref: '#/DocumentProperty'
   example:

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -12,7 +12,7 @@ DocumentProperties:
   type: object
   properties:
     publication_date:
-      $ref: './time.yml#PublicationDate'
+      $ref: './time.yml#/PublicationDate'
   additionalProperties:
     $ref: '#/DocumentProperty'
   example:

--- a/web-api/openapi/schemas/time.yml
+++ b/web-api/openapi/schemas/time.yml
@@ -1,0 +1,16 @@
+PublicationDate:
+  type: string
+  format: date-time
+  minLength: 10
+  # 35 should be enough (20 normally + up to 10 for subsec + up to 5 for offset),
+  # but to avoid any accidents we go with 40
+  maxLength: 40
+  example: "2000-05-14T20:22:50Z"
+  description: |
+    A RFC3339 compatible date-time
+
+    - can be in the future
+    - will be converted to and then stored as UTC
+    - sub-second resolution is not guaranteed.
+    - if this `properties.publication_date` is not set or set into the future this
+      document will be ignored for personalization

--- a/web-api/openapi/schemas/time.yml
+++ b/web-api/openapi/schemas/time.yml
@@ -12,5 +12,6 @@ PublicationDate:
     - can be in the future
     - will be converted to and then stored as UTC
     - sub-second resolution is not guaranteed.
-    - if this `properties.publication_date` is not set or set into the future this
-      document will be ignored for personalization
+    - while `properties.publication_date` is in the future the document will not be
+      returned for personalized documents, once it is no longer in the future it will
+      automatically be considered for personalization from then on

--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -364,7 +364,10 @@ async fn run_persona_benchmark() -> Result<(), Error> {
             let personalised_documents = state
                 .personalize(
                     user_id,
-                    PersonalizeBy::KnnSearch(benchmark_config.n_documents),
+                    PersonalizeBy::KnnSearch {
+                        count: benchmark_config.n_documents,
+                        published_after: None,
+                    },
                 )
                 .await
                 .unwrap();

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -21,6 +21,7 @@ mod utils;
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -47,6 +48,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) k_neighbors: usize,
     // must be >= k_neighbors
     pub(crate) num_candidates: usize,
+    pub(crate) published_after: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Error, From)]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -414,14 +414,14 @@ impl storage::Document for Storage {
                     "bool": {
                         "must": {
                             "range": {
-                                "publication_date": range,
+                                "publication_date": range
                             }
                         },
                         "must_not": {
                             "ids": {
                                 "values": params.excluded.iter().map(AsRef::as_ref).collect_vec()
                             }
-                        },
+                        }
                     }
                 }
             },

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -488,7 +488,7 @@ impl storage::Document for Storage {
                         .map_err(Into::into),
                     serde_json::to_value(IngestedDocument {
                         snippet: &document.snippet,
-                        properties: dbg!(&document.properties),
+                        properties: &document.properties,
                         embedding: &embedding,
                         tags: &document.tags,
                     })

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -422,12 +422,16 @@ impl storage::Document for Storage {
             json!({
                 "bool": {
                     "must_not": [
-                        { "ids": excluded_ids },
-                        { "range": {
-                            "properties.publication_date": {
-                                "gt": "now"
+                        {
+                            "ids": excluded_ids
+                        },
+                        {
+                            "range": {
+                                "properties.publication_date": {
+                                    "gt": "now"
+                                }
                             }
-                        }}
+                        }
                     ]
                 }
             })
@@ -440,7 +444,7 @@ impl storage::Document for Storage {
                 "query_vector": params.embedding.normalize()?,
                 "k": params.k_neighbors,
                 "num_candidates": params.num_candidates,
-                "filter": filter,
+                "filter": filter
             },
             "_source": ["properties", "embedding", "tags"]
         }));

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -398,7 +398,7 @@ impl storage::Document for Storage {
     ) -> Result<Vec<models::PersonalizedDocument>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
         let mut range = serde_json::Map::default();
-        range.insert("lte".into(), Utc::now().to_rfc3339().into());
+        range.insert("lte".into(), "now/d".into());
         if let Some(published_after) = params.published_after {
             range.insert("gte".into(), published_after.to_rfc3339().into());
         }

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -15,7 +15,6 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
-use chrono::Utc;
 use itertools::Itertools;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -402,7 +402,7 @@ impl storage::Document for Storage {
             range.insert("gte".into(), published_after.to_rfc3339().into());
         }
 
-        // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/knn-search.html#approximate-knn
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
         let body = Some(json!({
             "size": params.k_neighbors,
             "knn": {

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use chrono::Utc;
 use itertools::Itertools;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
@@ -396,6 +397,13 @@ impl storage::Document for Storage {
         params: KnnSearchParams<'a>,
     ) -> Result<Vec<models::PersonalizedDocument>, Error> {
         // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
+        let mut range = serde_json::Map::default();
+        range.insert("lte".into(), Utc::now().to_rfc3339().into());
+        if let Some(published_after) = params.published_after {
+            range.insert("gte".into(), published_after.to_rfc3339().into());
+        }
+
+        // https://www.elastic.co/guide/en/elasticsearch/reference/8.4/knn-search.html#approximate-knn
         let body = Some(json!({
             "size": params.k_neighbors,
             "knn": {
@@ -405,11 +413,16 @@ impl storage::Document for Storage {
                 "num_candidates": params.num_candidates,
                 "filter": {
                     "bool": {
+                        "must": {
+                            "range": {
+                                "publication_date": range,
+                            }
+                        },
                         "must_not": {
                             "ids": {
                                 "values": params.excluded.iter().map(AsRef::as_ref).collect_vec()
                             }
-                        }
+                        },
                     }
                 }
             },

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -641,6 +641,7 @@ mod tests {
                 embedding,
                 k_neighbors: 2,
                 num_candidates: 2,
+                published_after: None,
             },
         )
         .await
@@ -657,6 +658,7 @@ mod tests {
                 embedding,
                 k_neighbors: 3,
                 num_candidates: 3,
+                published_after: None,
             },
         )
         .await

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -285,6 +285,10 @@ impl storage::Document for Storage {
         &self,
         params: KnnSearchParams<'a>,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
+        if params.published_after.is_some() {
+            unimplemented!(/*we don't need it for memory.rs*/);
+        }
+
         let excluded = params.excluded.iter().collect::<HashSet<_>>();
         let documents = self.documents.read().await;
         let documents = documents


### PR DESCRIPTION
- create a `mapping.json` file with the mapping we want to have
  - and update docker to use it
  - :pushpin: we also somehow need to update the deployment to somehow get that 
- add `properties.publication_date`
- add `/users/{user_id}/personalized_documents?published_after=<datetime>`
- filter when querying personalized documents to enforce `published_after <= date_published <= now`
- **not** implement the filter for memory.rs as it's not used there