### PR TITLE
NO_ISSUE: remove cartesian_product from pairwise_cosine_similarity

### DIFF
--- a/coi/src/embedding.rs
+++ b/coi/src/embedding.rs
@@ -73,7 +73,6 @@ where
         .collect::<Vec<_>>();
     let size = data.len();
     let mut similarities = Array2::ones((size, size));
-    
     for t in (0..size)
         .flat_map(move |i| (i + 1..size).map(move |j| (i, j)))
         .filter_map(|(i, j)| {


### PR DESCRIPTION
Leftover from an old PR which improves performance a bit.

Can be ignored/closed if no longer relevant.

- avoids unnecessary iterations via cartesian_product
- minor cleanup to avoid copy