### PR TITLE
[Merged by Bors] - NO_ISSUE: Remove dependency on unix

### DIFF
--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -15,7 +15,6 @@ use std::{
     collections::HashMap,
     env,
     ffi::{OsStr, OsString},
-    os::unix::prelude::OsStrExt,
     sync::Mutex,
 };
 
@@ -29,8 +28,10 @@ fn with_env_guard(
 
     let guard = GUARD.lock();
     for (key, _) in env::vars_os() {
-        if key.as_bytes().starts_with(b"XAYN_") {
-            env::remove_var(key);
+        if let Some(key_str )= key.to_str() {
+            if key_str.as_bytes().starts_with(b"XAYN_") {
+                env::remove_var(key);
+            }
         }
     }
 

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -28,7 +28,7 @@ fn with_env_guard(
 
     let guard = GUARD.lock();
     for (key, _) in env::vars_os() {
-        if let Some(key_str )= key.to_str() {
+        if let Some(key_str)= key.to_str() {
             if key_str.as_bytes().starts_with(b"XAYN_") {
                 env::remove_var(key);
             }

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -28,7 +28,7 @@ fn with_env_guard(
 
     let guard = GUARD.lock();
     for (key, _) in env::vars_os() {
-        if let Some(key_str)= key.to_str() {
+        if let Some(key_str) = key.to_str() {
             if key_str.as_bytes().starts_with(b"XAYN_") {
                 env::remove_var(key);
             }


### PR DESCRIPTION
I'm running Windows (yes.. I know...)
While I can also run a Linux subsystem, it's finically to work with.

and os::unix is unavailable, this small change should get rid of that dependency