### PR TITLE
[Merged by Bors] - ET-3862 normalize coi embeddings for elastic

### DIFF
--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -45,7 +45,15 @@ pub mod tokenizer;
 pub use crate::{
     config::Config,
     pipeline::{Pipeline, PipelineError},
-    pooler::{AveragePooler, Embedding, Embedding1, Embedding2, FirstPooler, NonePooler},
+    pooler::{
+        AveragePooler,
+        Embedding,
+        Embedding1,
+        Embedding2,
+        FirstPooler,
+        InvalidEmbedding,
+        NonePooler,
+    },
 };
 
 /// A Bert pipeline with an average pooler.

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -41,7 +41,7 @@ impl Embedding<Ix1> {
         self.iter().flat_map(|value| value.to_le_bytes()).collect()
     }
 
-    pub fn normalize(&self) -> Result<Self, InvalidVectorEncounteredError> {
+    pub fn normalize(&self) -> Result<Self, InvalidEmbedding> {
         let view = self.view();
         let norm = view.dot(&view).sqrt();
         if norm.is_finite() {
@@ -52,7 +52,7 @@ impl Embedding<Ix1> {
             };
             Ok(normalized.into())
         } else {
-            Err(InvalidVectorEncounteredError)
+            Err(InvalidEmbedding)
         }
     }
 }
@@ -216,9 +216,9 @@ impl AveragePooler {
     }
 }
 
-#[derive(Clone, Debug, Display, Error)]
-/// Bytes do not represent a valid embedding.
-pub struct InvalidVectorEncounteredError;
+#[derive(Clone, Debug, Display, Error, Serialize)]
+/// Values don't represent a valid embedding.
+pub struct InvalidEmbedding;
 
 #[cfg(test)]
 mod tests {

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -19,9 +19,12 @@ use derive_more::From;
 use displaydoc::Display;
 use serde::Serialize;
 use thiserror::Error;
+use xayn_ai_bert::InvalidEmbedding;
 
 use super::application::ApplicationError;
 use crate::{impl_application_error, models::DocumentId, Error};
+
+impl_application_error!(InvalidEmbedding => BAD_REQUEST);
 
 /// The requested document was not found.
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -400,7 +400,7 @@ impl storage::Document for Storage {
             "size": params.k_neighbors,
             "knn": {
                 "field": "embedding",
-                "query_vector": params.embedding,
+                "query_vector": params.embedding.normalize()?,
                 "k": params.k_neighbors,
                 "num_candidates": params.num_candidates,
                 "filter": {


### PR DESCRIPTION
**Reference**

- [ET-3862]

**Summary**

- normalize coi embeddings before we query elastic with dot product metric


[ET-3862]: https://xainag.atlassian.net/browse/ET-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ