### PR TITLE
[Merged by Bors] - Don't consider partial files as downloaded

### DIFF
--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -21,12 +21,15 @@ download()
   VERSION="$2"
   ARCHIVE_BASENAME="${NAME}_$VERSION"
   ARCHIVE_NAME="$ARCHIVE_BASENAME.tgz"
+  TMP_ARCHIVE_NAME="$ARCHIVE_NAME.tmp"
   URL="http://s3-de-central.profitbricks.com/xayn-yellow-bert/$NAME/$ARCHIVE_NAME"
 
   if [  -f "$DATA_DIR/$ARCHIVE_NAME" ]; then
     echo "skip downloading $DATA_DIR/$ARCHIVE_NAME"
   else
-    curl "$URL" -o "$DATA_DIR/$ARCHIVE_NAME" -C -
+
+    curl "$URL" -o "$DATA_DIR/$TMP_ARCHIVE_NAME" -C -
+    mv "$DATA_DIR/$TMP_ARCHIVE_NAME" "$DATA_DIR/$ARCHIVE_NAME"
 
     cd "$DATA_DIR"
     tar -zxf "$ARCHIVE_NAME"


### PR DESCRIPTION
The current download script download an asset directly in the name we give. If the connections drops that we think that the file has been downloaded. This PR fix this by downloading to a temporary file, this also allows curl to resume the download from the previous state instead of starting from scratch.