### PR TITLE
[Merged by Bors] - ET-3940 validate route parameters

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -115,8 +115,9 @@ impl From<String> for BadRequest {
 }
 
 #[derive(Serialize, Debug, From)]
+#[from(types(DocumentId))]
 pub(crate) struct DocumentIdAsObject {
-    pub(crate) id: DocumentId,
+    pub(crate) id: String,
 }
 
 /// Internal Error: {0}

--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -35,12 +35,7 @@ use crate::{
     embedding::{self, Embedder},
     models::{DocumentId, DocumentProperties, IngestedDocument, UserId, UserInteractionType},
     personalization::{
-        routes::{
-            personalize_documents_by,
-            update_interactions,
-            PersonalizeBy,
-            UserInteractionData,
-        },
+        routes::{personalize_documents_by, update_interactions, PersonalizeBy},
         PersonalizationConfig,
     },
     storage::{self, memory::Storage},
@@ -95,10 +90,7 @@ impl State {
     async fn interact(&self, user: &UserId, documents: &[DocumentId]) -> Result<(), Error> {
         let interactions = documents
             .iter()
-            .map(|id| UserInteractionData {
-                document_id: id.clone(),
-                interaction_type: UserInteractionType::Positive,
-            })
+            .map(|id| (id.clone(), UserInteractionType::Positive))
             .collect_vec();
 
         update_interactions(&self.storage, &self.coi, user, &interactions)


### PR DESCRIPTION
**Reference**

- [ET-3940]

**Summary**

- validate parameters in the routes: instead of deserializing directly into the type which skips validation, we now take parameters of basic type like `String` and then validate them to be a well formed type like `DocumentId` before calling further logic. we don't want to change the serde of types like `DocumentId` to be able to still do unvalidated deserialization from the databases.


[ET-3940]: https://xainag.atlassian.net/browse/ET-3940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ