### PR TITLE
[Merged by Bors] - ET-3895 define & impl tags constraints

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Back Office API
-  version: 1.0.0-rc7
+  version: 1.0.0-rc8
   description: |-
     # Back Office
     The back office is typically used within server-side apps.
@@ -260,6 +260,12 @@ components:
           pattern: '.+'
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
+        tags:
+          type: array
+          minItems: 0
+          maxItems: 10
+          items:
+            $ref: './schemas/document.yml#/DocumentTag'
     IngestionRequest:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Front Office API
-  version: 1.0.0-rc7
+  version: 1.0.0-rc8
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -28,7 +28,7 @@ DocumentPropertyId:
 DocumentTag:
   description: A tag of a document can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
   type: string
-  pattern: '[^\x00]+$'
+  pattern: '^[^\x00]+$'
   minLength: 1
   maxLength: 256
   example: "tag"

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -26,9 +26,9 @@ DocumentPropertyId:
   example: "title"
 
 DocumentTag:
-  description: A tag of a document can be any non-empty string that consists of alphanumerical characters, common punctuation and whitespace.
+  description: A tag of a document can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
   type: string
-  pattern: '^[a-zA-Z0-9.:,;\-_+*!?%&/\\() ]{1,100}$'
+  pattern: '[^\x00]+$'
   minLength: 1
-  maxLength: 100
+  maxLength: 256
   example: "tag"

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -24,3 +24,11 @@ DocumentPropertyId:
   description: Id of a property of a document.
   $ref: './id.yml#/Id'
   example: "title"
+
+DocumentTag:
+  description: A tag of a document can be any non-empty string that consists of alphanumerical characters, common punctuation and whitespace.
+  type: string
+  pattern: '^[a-zA-Z0-9.:,;\-_+*!?%&/\\() ]{1,100}$'
+  minLength: 1
+  maxLength: 100
+  example: "tag"

--- a/web-api/openapi/schemas/id.yml
+++ b/web-api/openapi/schemas/id.yml
@@ -2,7 +2,7 @@ Id:
   description: |-
     An id can be any non-empty string that consist of digits, latin letters, underscores, colons, minus signs, at signs, and dots.
   type: string
-  pattern: '^[a-zA-Z0-9_:@.-]+$'
+  pattern: '^[a-zA-Z0-9_:@.\-]{1,256}$'
   minLength: 1
   maxLength: 256
   example: "valid_id1"

--- a/web-api/openapi/schemas/id.yml
+++ b/web-api/openapi/schemas/id.yml
@@ -2,7 +2,7 @@ Id:
   description: |-
     An id can be any non-empty string that consist of digits, latin letters, underscores, colons, minus signs, at signs, and dots.
   type: string
-  pattern: '^[a-zA-Z0-9_:@.\-]{1,256}$'
+  pattern: '^[a-zA-Z0-9_:@.\-]+$'
   minLength: 1
   maxLength: 256
   example: "valid_id1"

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -46,27 +46,33 @@ impl_application_error!(PropertyNotFound => BAD_REQUEST);
 
 /// Malformed user id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidUserId {
-    pub(crate) id: String,
+pub(crate) struct InvalidUserId {
+    pub(crate) value: String,
 }
 
 impl_application_error!(InvalidUserId => BAD_REQUEST);
 
 /// Malformed document id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidDocumentId {
-    pub(crate) id: String,
+pub(crate) struct InvalidDocumentId {
+    pub(crate) value: String,
 }
 
 impl_application_error!(InvalidDocumentId => BAD_REQUEST);
 
 /// Malformed document property id.
 #[derive(Debug, Error, Display, Serialize)]
-pub struct InvalidDocumentPropertyId {
-    pub(crate) id: String,
+pub(crate) struct InvalidDocumentPropertyId {
+    pub(crate) value: String,
 }
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST);
+
+/// Malformed document tag.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct InvalidDocumentTag {
+    pub(crate) value: String,
+}
 
 /// Not enough interactions.
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -130,7 +130,11 @@ async fn new_documents(
                         .into_iter()
                         .map(|(id, property)| id.try_into().map(|id| (id, property)))
                         .try_collect()?,
-                    tags: document.tags,
+                    tags: document
+                        .tags
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .try_collect()?,
                 };
                 let embedding = state.embedder.run(&document.snippet)?;
 

--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -33,7 +33,14 @@ use xayn_ai_coi::{nan_safe_f32_cmp_desc, CoiConfig, CoiSystem};
 
 use crate::{
     embedding::{self, Embedder},
-    models::{DocumentId, DocumentProperties, IngestedDocument, UserId, UserInteractionType},
+    models::{
+        DocumentId,
+        DocumentProperties,
+        DocumentTag,
+        IngestedDocument,
+        UserId,
+        UserInteractionType,
+    },
     personalization::{
         routes::{personalize_documents_by, update_interactions, PersonalizeBy},
         PersonalizationConfig,
@@ -200,8 +207,8 @@ struct Impression {
 #[derive(Clone, Debug, Deserialize)]
 struct Document {
     id: DocumentId,
-    category: String,
-    subcategory: String,
+    category: DocumentTag,
+    subcategory: DocumentTag,
     title: String,
     snippet: String,
     url: String,
@@ -212,7 +219,7 @@ impl Document {
     fn is_interesting(&self, user_interests: &[String]) -> bool {
         user_interests.iter().any(|interest| {
             let (main_category, sub_category) = interest.split_once('/').unwrap();
-            self.category == main_category || self.subcategory == sub_category
+            self.category.as_ref() == main_category || self.subcategory.as_ref() == sub_category
         })
     }
 }

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -87,7 +87,7 @@ fn is_valid_id(value: &str) -> bool {
 }
 
 fn is_valid_tag(value: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^\x00]").unwrap());
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^\x00]+$").unwrap());
 
     (1..=256).contains(&value.len()) && RE.is_match(value)
 }

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -21,75 +21,82 @@ use serde::{Deserialize, Serialize};
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::Document as AiDocument;
 
-use crate::error::common::{InvalidDocumentId, InvalidDocumentPropertyId, InvalidUserId};
+use crate::error::common::{
+    InvalidDocumentId,
+    InvalidDocumentPropertyId,
+    InvalidDocumentTag,
+    InvalidUserId,
+};
 
 macro_rules! id_wrapper {
-    ($name:ident, $validate:expr, $error:ident) => {
-        /// A unique identifier of a document.
-        #[derive(
-            AsRef,
-            Into,
-            Clone,
-            Debug,
-            Display,
-            PartialEq,
-            Eq,
-            Hash,
-            Serialize,
-            Deserialize,
-            sqlx::Type,
-            sqlx::FromRow,
-        )]
-        #[sqlx(transparent)]
-        #[serde(try_from = "String", into = "String")]
-        pub struct $name(String);
+    ($($visibility:vis $name:ident, $error:ident, $is_valid:expr);* $(;)?) => {
+        $(
+            /// A unique identifier.
+            #[derive(
+                AsRef,
+                Into,
+                Clone,
+                Debug,
+                Display,
+                PartialEq,
+                Eq,
+                Hash,
+                Serialize,
+                Deserialize,
+                sqlx::Type,
+                sqlx::FromRow,
+            )]
+            #[sqlx(transparent)]
+            #[serde(try_from = "String", into = "String")]
+            $visibility struct $name(String);
 
-        impl $name {
-            pub fn new(id: impl Into<String> + AsRef<str>) -> Result<Self, $error> {
-                if ($validate)(id.as_ref()) {
-                    Ok(Self(id.into()))
-                } else {
-                    Err($error { id: id.into() })
+            impl $name {
+                $visibility fn new(value: impl Into<String> + AsRef<str>) -> Result<Self, $error> {
+                    if $is_valid(value.as_ref()) {
+                        Ok(Self(value.into()))
+                    } else {
+                        Err($error { value: value.into() })
+                    }
                 }
             }
-        }
 
-        impl TryFrom<String> for $name {
-            type Error = $error;
+            impl TryFrom<String> for $name {
+                type Error = $error;
 
-            fn try_from(value: String) -> Result<Self, Self::Error> {
-                Self::new(value)
+                fn try_from(value: String) -> Result<Self, Self::Error> {
+                    Self::new(value)
+                }
             }
-        }
 
-        impl TryFrom<&str> for $name {
-            type Error = $error;
+            impl TryFrom<&str> for $name {
+                type Error = $error;
 
-            fn try_from(value: &str) -> Result<Self, Self::Error> {
-                Self::new(value)
+                fn try_from(value: &str) -> Result<Self, Self::Error> {
+                    Self::new(value)
+                }
             }
-        }
 
-        impl FromStr for $name {
-            type Err = $error;
+            impl FromStr for $name {
+                type Err = $error;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
-                Self::new(s)
+                fn from_str(value: &str) -> Result<Self, Self::Err> {
+                    Self::new(value)
+                }
             }
-        }
+        )*
     };
 }
 
-fn is_valid_id(id: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_\-:@.]+$").unwrap());
-    RE.is_match(id)
+static ID_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9_\-:@.]{1,256}$").unwrap());
+static TAG_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9.:,;\-_+*!?%&/\\() ]{1,100}$").unwrap());
+
+id_wrapper! {
+    pub(crate) DocumentId, InvalidDocumentId, |id| ID_REGEX.is_match(id);
+    pub(crate) DocumentPropertyId, InvalidDocumentPropertyId, |id| ID_REGEX.is_match(id);
+    pub(crate) UserId, InvalidUserId, |id| ID_REGEX.is_match(id);
+    pub(crate) DocumentTag, InvalidDocumentTag, |tag| TAG_REGEX.is_match(tag);
 }
-
-id_wrapper!(DocumentId, is_valid_id, InvalidDocumentId);
-
-id_wrapper!(DocumentPropertyId, is_valid_id, InvalidDocumentPropertyId);
-
-id_wrapper!(UserId, is_valid_id, InvalidUserId);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct DocumentProperty(serde_json::Value);
@@ -107,7 +114,7 @@ pub(crate) struct InteractedDocument {
     pub(crate) embedding: NormalizedEmbedding,
 
     /// The tags associated to the document.
-    pub(crate) tags: Vec<String>,
+    pub(crate) tags: Vec<DocumentTag>,
 }
 
 /// Represents a result from a personalization query.
@@ -126,7 +133,7 @@ pub(crate) struct PersonalizedDocument {
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
-    pub(crate) tags: Vec<String>,
+    pub(crate) tags: Vec<DocumentTag>,
 }
 
 impl AiDocument for PersonalizedDocument {
@@ -159,5 +166,32 @@ pub(crate) struct IngestedDocument {
     pub(crate) properties: DocumentProperties,
 
     /// The tags associated to the document.
-    pub(crate) tags: Vec<String>,
+    pub(crate) tags: Vec<DocumentTag>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id() {
+        assert!(DocumentId::new("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentId::new("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentId::new("0123456789").is_ok());
+        assert!(DocumentId::new("_-:@.").is_ok());
+        assert!(DocumentId::new("").is_err());
+        assert!(DocumentId::new(["a"; 257].join("")).is_err());
+        assert!(DocumentId::new("!?ß").is_err());
+    }
+
+    #[test]
+    fn test_tag() {
+        assert!(DocumentTag::new("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentTag::new("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentTag::new("0123456789").is_ok());
+        assert!(DocumentTag::new(".:,;-_+*!?%&/\\() ").is_ok());
+        assert!(DocumentTag::new("").is_err());
+        assert!(DocumentTag::new(["a"; 101].join("")).is_err());
+        assert!(DocumentTag::new("ß@|").is_err());
+    }
 }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -115,7 +115,7 @@ pub(crate) async fn update_interactions(
             UserInteractionType::Positive => {
                 for tag in &context.document.tags {
                     *context.tag_weight_diff
-                            .get_mut(tag.as_str())
+                            .get_mut(tag)
                             .unwrap(/* update_interactions assures all tags are given */) += 1;
                 }
                 coi.log_positive_user_reaction(context.positive_cois, &context.document.embedding)

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -34,6 +34,7 @@ use crate::{
         self,
         DocumentId,
         DocumentPropertyId,
+        DocumentTag,
         IngestedDocument,
         InteractedDocument,
         PersonalizedDocument,
@@ -132,7 +133,7 @@ pub(crate) trait Interest {
 
 pub(crate) struct InteractionUpdateContext<'s, 'l> {
     pub(crate) document: &'s InteractedDocument,
-    pub(crate) tag_weight_diff: &'s mut HashMap<&'l str, i32>,
+    pub(crate) tag_weight_diff: &'s mut HashMap<&'l DocumentTag, i32>,
     pub(crate) positive_cois: &'s mut Vec<PositiveCoi>,
 }
 
@@ -154,7 +155,7 @@ pub(crate) trait Interaction {
 
 #[async_trait]
 pub(crate) trait Tag {
-    async fn get(&self, user_id: &UserId) -> Result<HashMap<String, usize>, Error>;
+    async fn get(&self, user_id: &UserId) -> Result<HashMap<DocumentTag, usize>, Error>;
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -31,7 +31,14 @@ use xayn_ai_bert::NormalizedEmbedding;
 
 use crate::{
     error::common::InternalError,
-    models::{self, DocumentId, DocumentProperties, DocumentProperty, DocumentPropertyId},
+    models::{
+        self,
+        DocumentId,
+        DocumentProperties,
+        DocumentProperty,
+        DocumentPropertyId,
+        DocumentTag,
+    },
     server::SetupError,
     storage::{self, DeletionError, InsertionError, KnnSearchParams, Storage},
     utils::{serialize_redacted, serialize_to_ndjson},
@@ -239,7 +246,7 @@ struct SearchResponse<T> {
 struct InteractedDocument {
     embedding: NormalizedEmbedding,
     #[serde(default)]
-    tags: Vec<String>,
+    tags: Vec<DocumentTag>,
 }
 
 impl From<SearchResponse<InteractedDocument>> for Vec<models::InteractedDocument> {
@@ -263,7 +270,7 @@ struct PersonalizedDocument {
     properties: DocumentProperties,
     embedding: NormalizedEmbedding,
     #[serde(default)]
-    tags: Vec<String>,
+    tags: Vec<DocumentTag>,
 }
 
 impl From<SearchResponse<PersonalizedDocument>> for Vec<models::PersonalizedDocument> {
@@ -288,7 +295,7 @@ struct IngestedDocument<'a> {
     snippet: &'a str,
     properties: &'a DocumentProperties,
     embedding: &'a NormalizedEmbedding,
-    tags: &'a [String],
+    tags: &'a [DocumentTag],
 }
 
 fn is_success_status(status: u16, allow_not_found: bool) -> bool {


### PR DESCRIPTION
**Reference**

- [ET-3894]
- [ET-3895]
- requires #782

**Summary**

- define tags in the spec
- impl tag validation, validate tags from incomming web requests & use validated tags internally


[ET-3894]: https://xainag.atlassian.net/browse/ET-3894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-3895]: https://xainag.atlassian.net/browse/ET-3895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ