### PR TITLE
[Merged by Bors] - ET-3879 semantic search spec update

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -107,6 +107,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserInteractionError'
 
+  /documents/{document_id}/semantic_search:
+    get:
+      tags:
+        - front office
+      summary: Returns documents similar to the given document.
+      description: |-
+        This endpoints get-queries a virtual collection do documents containing documents
+        semantically similar to the specific documents ranked/ordered from the most to the
+        least similar. Access is limited a a configurable number of most similar documents.
+      operationId: semanticSearch
+      parameters:
+        - $ref: './parameters/path/document_id.yml'
+        - name: count
+          in: query
+          description: Maximum number of semantic similar documents to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 10
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalizedDocumentsResponse'
+        '400':
+            $ref: './responses/generic.yml#/BadRequest'
+
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -123,6 +155,22 @@ components:
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
     PersonalizedDocumentsResponse:
+      type: object
+      required: [documents]
+      properties:
+        documents:
+          type: array
+          minItems: 0
+          maxItems: 100
+          items:
+            $ref: '#/components/schemas/PersonalizedDocumentData'
+      example:
+        documents:
+          - id: 'document_id0'
+            score: 0.87
+            properties:
+              title: "News title"
+    SemanticSearchResponse:
       type: object
       required: [documents]
       properties:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -135,7 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonalizedDocumentsResponse'
+                $ref: '#/components/schemas/SemanticSearchResponse'
         '400':
             $ref: './responses/generic.yml#/BadRequest'
 

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -107,7 +107,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserInteractionError'
 
-  /documents/{document_id}/semantic_search:
+  /semantic_search/{document_id}:
     get:
       tags:
         - front office
@@ -115,7 +115,7 @@ paths:
       description: |-
         This endpoints get-queries a virtual collection do documents containing documents
         semantically similar to the specific documents ranked/ordered from the most to the
-        least similar. Access is limited a a configurable number of most similar documents.
+        least similar.
       operationId: semanticSearch
       parameters:
         - $ref: './parameters/path/document_id.yml'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -113,9 +113,9 @@ paths:
         - front office
       summary: Returns documents similar to the given document.
       description: |-
-        This endpoints get-queries a virtual collection do documents containing documents
-        semantically similar to the specific documents ranked/ordered from the most to the
-        least similar.
+        Returns a list of documents that are semantically similar to the one given as input.
+        Each document contains the id, the score and the properties.
+        The score is a value between 0 and 1 where a higher value means that the document is more similar to the one in input
       operationId: getSimilarDocuments
       parameters:
         - $ref: './parameters/path/document_id.yml'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -116,7 +116,7 @@ paths:
         This endpoints get-queries a virtual collection do documents containing documents
         semantically similar to the specific documents ranked/ordered from the most to the
         least similar.
-      operationId: semanticSearch
+      operationId: getSimilarDocuments
       parameters:
         - $ref: './parameters/path/document_id.yml'
         - name: count


### PR DESCRIPTION
Following  went into the decisions about using:

`/semantic_search/{document_id}`

I.e. roughtly:  `semantic_search` is a (**virtual**) container resource contains all "semantic search results" indexed/identified by document for which the search was done.

Initially `/documents/{document_id}/semantic_search` was used which is a bit nicer but makes it harder to have path based rules for resource limits etc. which are independent of any other potential `/documents` endpoints.

If we add a personalization of the ranking (i.e. rerank, but not the choice of which document to pick) we would do so using a query parameter. This could be something similar to:

`/semantic_search/{document_id}?personalize_for={user_id}`

_But that is not part of this PR._

Following aspects where taken into consideration:

- (feedback) should be by default _not_ personalized
  - so we should not place it under `/users`
  - [ ] speak with ops about it 
- (feedback) should contain "semantic search" is in it's name
- should be extendible to allow a second step which reranks the results, i.e. it stays mainly semantic search and
  any personalization is some secondary aspect (hence why it better to make user_id a query parameter)
- should fit in with potentially future changes and extensions
- should work well with gateway rate limites and similar

**References:**

- ET-3879