### PR TITLE
[Merged by Bors] - Update interest tag bias

### DIFF
--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -89,7 +89,7 @@ const fn default_max_cois_for_knn() -> usize {
 }
 
 const fn default_interest_tag_bias() -> f32 {
-    0.5
+    0.8
 }
 
 impl Default for PersonalizationConfig {

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -42,7 +42,7 @@ stdout = """
     "max_number_documents": 100,
     "default_number_documents": 100,
     "max_cois_for_knn": 10,
-    "interest_tag_bias": 0.5
+    "interest_tag_bias": 0.8
   }
 }
 """


### PR DESCRIPTION
**Summary**

- update default `interest_tag_bias` to `0.8`
