### PR TITLE
[Merged by Bors] - ET-3969 Allow k/v Map for additionalProperties, which fixes SDK codegen

### DIFF
--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -13,8 +13,7 @@ DocumentProperties:
   properties:
     publication_date:
       $ref: './time.yml#/PublicationDate'
-  additionalProperties:
-    $ref: '#/DocumentProperty'
+  additionalProperties: true
   example:
     title: "News title"
     image_url: "http://example.com/news_image.jpg"


### PR DESCRIPTION
As the title reads,

Using `DocumentProperty` somehow messed up codegen, to fix we can just allow a Map instead.