### PR TITLE
[Merged by Bors] - ET-3882 impl semantic search

### DIFF
--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -99,23 +99,19 @@ impl Default for PersonalizationConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub(crate) struct SemanticSearchConfig {
     /// Max number of documents to return.
-    //NOTE: currently using the default from personalization
-    //      (the performance profile is quite similar)
-    #[serde(default = "default_max_number_documents")]
     pub(crate) max_number_documents: usize,
     /// Default number of documents to return.
-    //NOTE: currently using the default from personalization
-    #[serde(default = "default_default_number_documents")]
     pub(crate) default_number_documents: usize,
 }
 
 impl Default for SemanticSearchConfig {
     fn default() -> Self {
         Self {
-            max_number_documents: default_max_number_documents(),
-            default_number_documents: default_default_number_documents(),
+            max_number_documents: 100,
+            default_number_documents: 10,
         }
     }
 }

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -60,6 +60,10 @@ pub struct Config {
     pub(crate) storage: storage::Config,
     pub(crate) coi: CoiConfig,
     pub(crate) personalization: PersonalizationConfig,
+
+    #[as_ref]
+    #[serde(default)]
+    pub(crate) semantic_search: SemanticSearchConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -94,6 +98,27 @@ impl Default for PersonalizationConfig {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct SemanticSearchConfig {
+    /// Max number of documents to return.
+    //NOTE: currently using the default from personalization
+    //      (the performance profile is quite similar)
+    #[serde(default = "default_max_number_documents")]
+    pub(crate) max_number_documents: usize,
+    /// Default number of documents to return.
+    //NOTE: currently using the default from personalization
+    #[serde(default = "default_default_number_documents")]
+    pub(crate) default_number_documents: usize,
+}
+
+impl Default for SemanticSearchConfig {
+    fn default() -> Self {
+        Self {
+            max_number_documents: default_max_number_documents(),
+            default_number_documents: default_default_number_documents(),
+        }
+    }
+}
 #[derive(AsRef)]
 pub struct Extension {
     pub(crate) coi: CoiSystem,

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -60,9 +60,6 @@ pub struct Config {
     pub(crate) storage: storage::Config,
     pub(crate) coi: CoiConfig,
     pub(crate) personalization: PersonalizationConfig,
-
-    #[as_ref]
-    #[serde(default)]
     pub(crate) semantic_search: SemanticSearchConfig,
 }
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -189,7 +189,7 @@ async fn personalized_documents(
     .map(|documents| {
         if let Some(documents) = documents {
             Either::Left(Json(PersonalizedDocumentsResponse {
-                documents: documents.into_iter().map(Into::into).collect(),
+                documents: documents.into_iter().map_into().collect(),
             }))
         } else {
             Either::Right((
@@ -209,11 +209,11 @@ struct PersonalizedDocumentData {
 }
 
 impl From<PersonalizedDocument> for PersonalizedDocumentData {
-    fn from(value: PersonalizedDocument) -> Self {
+    fn from(document: PersonalizedDocument) -> Self {
         Self {
-            id: value.id,
-            score: value.score,
-            properties: value.properties,
+            id: document.id,
+            score: document.score,
+            properties: document.properties,
         }
     }
 }
@@ -493,7 +493,7 @@ async fn semantic_search(
     .await?;
 
     Ok(Json(SemanticSearchResponse {
-        documents: documents.into_iter().map(Into::into).collect(),
+        documents: documents.into_iter().map_into().collect(),
     }))
 }
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -444,6 +444,7 @@ pub(crate) async fn personalize_documents_by(
     Ok(Some(all_documents))
 }
 
+#[derive(Deserialize)]
 struct SemanticSearchQuery {
     count: Option<usize>,
 }
@@ -478,7 +479,7 @@ async fn semantic_search(
     let reference = storage::Document::get_personalized(&state.storage, &[&document_id])
         .await?
         .pop()
-        .ok_or_else(|| DocumentNotFound)?;
+        .ok_or(DocumentNotFound)?;
 
     let documents = storage::Document::get_by_embedding(
         &state.storage,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -483,7 +483,7 @@ async fn semantic_search(
     let documents = storage::Document::get_by_embedding(
         &state.storage,
         KnnSearchParams {
-            excluded: &[],
+            excluded: &[document_id],
             embedding: &embedding,
             k_neighbors: count,
             num_candidates: count,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -476,16 +476,15 @@ async fn semantic_search(
     let document_id = document_id.into_inner().try_into()?;
     let count = query.document_count(state.config.as_ref())?;
 
-    let reference = storage::Document::get_personalized(&state.storage, &[&document_id])
+    let embedding = storage::Document::get_embedding(&state.storage, &document_id)
         .await?
-        .pop()
         .ok_or(DocumentNotFound)?;
 
     let documents = storage::Document::get_by_embedding(
         &state.storage,
         KnnSearchParams {
             excluded: &[],
-            embedding: &reference.embedding,
+            embedding: &embedding,
             k_neighbors: count,
             num_candidates: count,
             published_after: None,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -78,6 +78,8 @@ pub(crate) trait Document {
         ids: &[&DocumentId],
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
+    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;
+
     async fn get_by_embedding<'a>(
         &self,
         params: KnnSearchParams<'a>,

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -284,8 +284,7 @@ impl storage::Document for Storage {
     }
 
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
-        let documents = self.documents.read().await;
-        Ok(documents.1.borrow_map().get(id).cloned())
+        Ok(self.documents.read().await.1.borrow_map().get(id).cloned())
     }
 
     async fn get_by_embedding<'a>(

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -283,6 +283,11 @@ impl storage::Document for Storage {
         Ok(documents)
     }
 
+    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
+        let documents = self.documents.read().await;
+        Ok(documents.1.borrow_map().get(id).cloned())
+    }
+
     async fn get_by_embedding<'a>(
         &self,
         params: KnnSearchParams<'a>,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -47,7 +47,7 @@ stdout = """
   },
   "semantic_search": {
     "max_number_documents": 100,
-    "default_number_documents": 100
+    "default_number_documents": 10
   }
 }
 """

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -44,6 +44,10 @@ stdout = """
     "max_cois_for_knn": 10,
     "interest_tag_bias": 0.8,
     "store_user_history": true
+  },
+  "semantic_search": {
+    "max_number_documents": 100,
+    "default_number_documents": 100
   }
 }
 """


### PR DESCRIPTION
Implement `/semantic_search/{document_id}` endpoint as specified in `front_office.yaml`.

**References:**

- ET-3882