### PR TITLE
[Merged by Bors] - ET-3957 optionally store user history

### DIFF
--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -100,9 +100,15 @@ impl State {
             .map(|id| (id.clone(), UserInteractionType::Positive))
             .collect_vec();
 
-        update_interactions(&self.storage, &self.coi, user, &interactions)
-            .await
-            .map_err(Into::into)
+        update_interactions(
+            &self.storage,
+            &self.coi,
+            user,
+            &interactions,
+            self.personalization.store_user_history,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn personalize(

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -77,6 +77,9 @@ pub(crate) struct PersonalizationConfig {
 
     /// Weighting of user interests vs document tags. Must be in the interval `[0, 1]`.
     pub(crate) interest_tag_bias: f32,
+
+    /// Whether to store the history of user interactions.
+    pub(crate) store_user_history: bool,
 }
 
 impl Default for PersonalizationConfig {
@@ -87,6 +90,7 @@ impl Default for PersonalizationConfig {
             // FIXME: what is a default value we know works well with how we do knn?
             max_cois_for_knn: 10,
             interest_tag_bias: 0.8,
+            store_user_history: true,
         }
     }
 }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -123,6 +123,7 @@ pub(crate) async fn update_interactions(
         storage,
         user_id,
         &document_ids,
+        store_user_history,
         |context| {
             match document_id_to_interaction_type[&context.document.id] {
                 UserInteractionType::Positive => {
@@ -139,7 +140,6 @@ pub(crate) async fn update_interactions(
                 }
             }
         },
-        store_user_history,
     )
     .await?;
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -88,7 +88,14 @@ async fn interactions(
                 .map(|document_id| (document_id, data.interaction_type))
         })
         .try_collect::<_, Vec<_>, _>()?;
-    update_interactions(&state.storage, &state.coi, &user_id, &interactions).await?;
+    update_interactions(
+        &state.storage,
+        &state.coi,
+        &user_id,
+        &interactions,
+        state.config.personalization.store_user_history,
+    )
+    .await?;
 
     Ok(HttpResponse::NoContent())
 }
@@ -98,6 +105,7 @@ pub(crate) async fn update_interactions(
     coi: &CoiSystem,
     user_id: &UserId,
     interactions: &[(DocumentId, UserInteractionType)],
+    store_user_history: bool,
 ) -> Result<(), Error> {
     storage::Interaction::user_seen(storage, user_id).await?;
 
@@ -111,19 +119,28 @@ pub(crate) async fn update_interactions(
         .iter()
         .map(|(document_id, _)| document_id)
         .collect_vec();
-    storage::Interaction::update_interactions(storage, user_id, &document_ids, |context| {
-        match document_id_to_interaction_type[&context.document.id] {
-            UserInteractionType::Positive => {
-                for tag in &context.document.tags {
-                    *context.tag_weight_diff
+    storage::Interaction::update_interactions(
+        storage,
+        user_id,
+        &document_ids,
+        |context| {
+            match document_id_to_interaction_type[&context.document.id] {
+                UserInteractionType::Positive => {
+                    for tag in &context.document.tags {
+                        *context.tag_weight_diff
                             .get_mut(tag)
                             .unwrap(/* update_interactions assures all tags are given */) += 1;
-                }
-                coi.log_positive_user_reaction(context.positive_cois, &context.document.embedding)
+                    }
+                    coi.log_positive_user_reaction(
+                        context.positive_cois,
+                        &context.document.embedding,
+                    )
                     .clone()
+                }
             }
-        }
-    })
+        },
+        store_user_history,
+    )
     .await?;
 
     Ok(())
@@ -234,12 +251,14 @@ fn compute_coi_weights(cois: &[PositiveCoi], horizon: Duration) -> Vec<f32> {
 }
 
 /// Performs an approximate knn search for documents similar to the positive user interests.
+#[allow(clippy::too_many_arguments)]
 async fn search_knn_documents(
     storage: &(impl storage::Document + storage::Interaction),
     user_id: &UserId,
     cois: &[PositiveCoi],
     horizon: Duration,
     max_cois: usize,
+    store_user_history: bool,
     count: usize,
     published_after: Option<DateTime<Utc>>,
 ) -> Result<Vec<PersonalizedDocument>, Error> {
@@ -253,7 +272,11 @@ async fn search_knn_documents(
     let cois = &cois[..max_cois.min(cois.len())];
     let weights_sum = cois.iter().map(|(_, w)| w).sum::<f32>();
 
-    let excluded = storage::Interaction::get(storage, user_id).await?;
+    let excluded = if store_user_history {
+        storage::Interaction::get(storage, user_id).await?
+    } else {
+        Vec::new()
+    };
 
     let mut document_futures = cois
         .iter()
@@ -351,6 +374,7 @@ pub(crate) async fn personalize_documents_by(
                 &cois.positive,
                 coi.config().horizon(),
                 personalization.max_cois_for_knn,
+                personalization.store_user_history,
                 count,
                 published_after,
             )
@@ -433,6 +457,7 @@ mod tests {
             &[],
             CoiConfig::default().horizon(),
             PersonalizationConfig::default().max_cois_for_knn,
+            PersonalizationConfig::default().store_user_history,
             10,
             None,
         )

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -147,8 +147,8 @@ pub(crate) trait Interaction {
         &self,
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
-        update_logic: F,
         store_user_history: bool,
+        update_logic: F,
     ) -> Result<(), Error>
     where
         F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Send + Sync;

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -148,6 +148,7 @@ pub(crate) trait Interaction {
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
         update_logic: F,
+        store_user_history: bool,
     ) -> Result<(), Error>
     where
         F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Send + Sync;

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -524,8 +524,8 @@ impl storage::Interaction for Storage {
         &self,
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
-        mut update_logic: F,
         store_user_history: bool,
+        mut update_logic: F,
     ) -> Result<(), Error>
     where
         F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Send + Sync,
@@ -697,13 +697,13 @@ mod tests {
             &storage,
             &user_id,
             &[&document_id],
+            true,
             |context| {
                 *context.tag_weight_diff.get_mut(&tags[0]).unwrap() += 10;
                 let pcoi = PositiveCoi::new(CoiId::new(), [0.2, 9.4, 1.2].try_into().unwrap());
                 context.positive_cois.push(pcoi.clone());
                 pcoi
             },
-            true,
         )
         .await
         .unwrap();

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -467,8 +467,8 @@ impl storage::Interaction for Storage {
         &self,
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
-        mut update_logic: F,
         store_user_history: bool,
+        mut update_logic: F,
     ) -> Result<(), Error>
     where
         F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Send + Sync,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -42,7 +42,8 @@ stdout = """
     "max_number_documents": 100,
     "default_number_documents": 10,
     "max_cois_for_knn": 10,
-    "interest_tag_bias": 0.8
+    "interest_tag_bias": 0.8,
+    "store_user_history": true
   }
 }
 """


### PR DESCRIPTION
**Reference**

- [ET-3957]

**Summary**

- add `store_user_history` flag to the `PersonalizationConfig`, defaults to `true`
- `interactions` endpoint: only store the user history in the `interaction` table if the flag is set
- `personalized_documents` endpoint: only fetch the user history from the `interaction` table (for the excluded docs list) if the flag is set (otherwise no docs are excluded)


[ET-3957]: https://xainag.atlassian.net/browse/ET-3957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ