### PR TITLE
[Merged by Bors] - ET-3884 personalization of semantic search

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Back Office API
-  version: 1.0.0-rc9
+  version: 1.0.0-rc10
   description: |-
     # Back Office
     The back office is typically used within server-side apps.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -171,7 +171,9 @@ paths:
             default: 0
         - name: personalize_for
           in: query
-          description: A user for whom the documents will be personalized for.
+          description:  |-
+            A user for whom the documents will be personalized for.
+            If that user doesn't have enough interactions in the system, then the documents are returned unpersonalized.
           required: false
           schema:
             $ref: './schemas/user.yml#/UserId'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Front Office API
-  version: 1.0.0-rc9
+  version: 1.0.0-rc10
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.
@@ -169,6 +169,12 @@ paths:
             minimum: 0
             maximum: 1
             default: 0
+        - name: personalize_for
+          in: query
+          description: A user for whom the documents will be personalized for.
+          required: false
+          schema:
+            $ref: './schemas/user.yml#/UserId'
       responses:
         '200':
           description: successful operation

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -82,8 +82,9 @@ pub(crate) struct PersonalizationConfig {
     /// Max number of positive cois to use in knn search.
     pub(crate) max_cois_for_knn: usize,
 
-    /// Weighting of user interests vs document tags. Must be in the interval `[0, 1]`.
-    pub(crate) interest_tag_bias: f32,
+    /// Weights for reranking of the scores. Each weight is in `[0, 1]` and they add up to `1`. The
+    /// order is `[interest_weight, tag_weight, elasticsearch_weight]`.
+    pub(crate) score_weights: [f32; 3],
 
     /// Whether to store the history of user interactions.
     pub(crate) store_user_history: bool,
@@ -99,7 +100,7 @@ impl Default for PersonalizationConfig {
             default_number_documents: 10,
             // FIXME: what is a default value we know works well with how we do knn?
             max_cois_for_knn: 10,
-            interest_tag_bias: 0.5,
+            score_weights: [0.5, 0.5, 0.0],
             store_user_history: true,
             max_stateless_history_size: 20,
         }
@@ -111,8 +112,13 @@ impl Default for PersonalizationConfig {
 pub(crate) struct SemanticSearchConfig {
     /// Max number of documents to return.
     pub(crate) max_number_documents: usize,
+
     /// Default number of documents to return.
     pub(crate) default_number_documents: usize,
+
+    /// Weights for reranking of the scores. Each weight is in `[0, 1]` and they add up to `1`. The
+    /// order is `[interest_weight, tag_weight, elasticsearch_weight]`.
+    pub(crate) score_weights: [f32; 3],
 }
 
 impl Default for SemanticSearchConfig {
@@ -120,6 +126,7 @@ impl Default for SemanticSearchConfig {
         Self {
             max_number_documents: 100,
             default_number_documents: 10,
+            score_weights: [0.4, 0.4, 0.2],
         }
     }
 }

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -23,10 +23,10 @@ use crate::models::{DocumentId, DocumentTag, PersonalizedDocument};
 pub(super) fn rerank_by_interest(
     coi_system: &CoiSystem,
     documents: &[PersonalizedDocument],
-    interest: &UserInterests,
+    interests: &UserInterests,
     time: DateTime<Utc>,
 ) -> HashMap<DocumentId, f32> {
-    let scores = coi_system.score(documents, interest, time);
+    let scores = coi_system.score(documents, interests, time);
     rank_keys_by_score(
         izip!(documents.iter().map(|doc| doc.id.clone()), scores),
         nan_safe_f32_cmp_desc,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -42,13 +42,22 @@ stdout = """
     "max_number_documents": 100,
     "default_number_documents": 10,
     "max_cois_for_knn": 10,
-    "interest_tag_bias": 0.5,
+    "score_weights": [
+      0.5,
+      0.5,
+      0.0
+    ],
     "store_user_history": true,
     "max_stateless_history_size": 20
   },
   "semantic_search": {
     "max_number_documents": 100,
-    "default_number_documents": 10
+    "default_number_documents": 10,
+    "score_weights": [
+      0.4,
+      0.4,
+      0.2
+    ]
   }
 }
 """


### PR DESCRIPTION
After finding similar documents (during which `min_similarity` is applied) does an additional personalization step.

Following should be done:

- [x] run similarity search normally (use `min_similarity` there) to get documents and get rank by similarity
- [x] code for resolving/parsing new query parameters
- [x]  get tag weights for documents and rank by tag weight 
- [x]  get cois and rank by interest
- [x] combine all ranks with a weighting
      - the ratio between similarity and interest+tag is `personalize_ratio`
      - the ratio between interest and tag is configured with the same config as it is for normal document personalization
- [x] set a new score based on the combined ranks 
- [ ]  ???~only apply the personlization on the top X found similar documents~???
- [x] update the openapi spec
     - [x] `personalize_for`
     - [x] `personalize_ratio`
     - [ ] ???~`personalization_count`~???
- [ ] decide what to do in case of not enough user interaction (fail or just as if `ratio == 0`?)
- [x] potentially update to combine scores instead of ranks

---

**References:**

- based on: #799 , #792 , #810
- issue: ET-3884
- story: ET-3877