### PR TITLE
[Merged by Bors] - ET-3960 integration tests for store_user_history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "toml 0.7.2",
  "tracing",
  "tracing-subscriber",
  "trycmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,24 +1554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integration-tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "once_cell",
- "regex",
- "reqwest",
- "scopeguard",
- "serde",
- "serde_json",
- "tokio",
- "toml 0.7.2",
- "xayn-ai-test-utils",
- "xayn-web-api",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4133,7 +4115,7 @@ dependencies = [
  "thiserror",
  "tokenizers",
  "tract-onnx",
- "xayn-ai-test-utils",
+ "xayn-test-utils",
 ]
 
 [[package]]
@@ -4155,11 +4137,29 @@ dependencies = [
  "tracing",
  "uuid",
  "xayn-ai-bert",
- "xayn-ai-test-utils",
+ "xayn-test-utils",
 ]
 
 [[package]]
-name = "xayn-ai-test-utils"
+name = "xayn-integration-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "once_cell",
+ "regex",
+ "reqwest",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 0.7.2",
+ "xayn-test-utils",
+ "xayn-web-api",
+]
+
+[[package]]
+name = "xayn-test-utils"
 version = "0.1.0"
 dependencies = [
  "float-cmp",
@@ -4211,7 +4211,7 @@ dependencies = [
  "uuid",
  "xayn-ai-bert",
  "xayn-ai-coi",
- "xayn-ai-test-utils",
+ "xayn-test-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,6 +4211,7 @@ dependencies = [
  "uuid",
  "xayn-ai-bert",
  "xayn-ai-coi",
+ "xayn-integration-tests",
  "xayn-test-utils",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0.92"
 sqlx = { version = "0.6.2", features = ["postgres", "runtime-tokio-rustls"] }
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", default-features = false }
+toml = "0.7.2"
 tracing = "0.1.37"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -18,7 +18,7 @@ sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokenizers = { version = "0.13.2", default-features = false, features = ["onig"] }
 tract-onnx = "0.18.5"
-xayn-ai-test-utils = { path = "../test-utils" }
+xayn-test-utils = { path = "../test-utils" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -16,7 +16,7 @@ use std::{hint::black_box, path::Path};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use xayn_ai_bert::{tokenizer::bert::Tokenizer, Config, NonePooler};
-use xayn_ai_test_utils::asset::smbert;
+use xayn_test_utils::asset::smbert;
 
 const TOKEN_SIZE: usize = 64;
 const SEQUENCE: &str = "This is a sequence.";

--- a/bert/examples/bert.rs
+++ b/bert/examples/bert.rs
@@ -15,7 +15,7 @@
 //! Run as `cargo run --example bert
 
 use xayn_ai_bert::{tokenizer::bert::Tokenizer, Config, FirstPooler};
-use xayn_ai_test_utils::asset::smbert;
+use xayn_test_utils::asset::smbert;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pipeline = Config::new(smbert()?)?

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -120,7 +120,7 @@ impl Model {
 mod tests {
     use ndarray::Array2;
     use tract_onnx::prelude::DatumType;
-    use xayn_ai_test_utils::asset::smbert_mocked;
+    use xayn_test_utils::asset::smbert_mocked;
 
     use super::*;
 

--- a/bert/src/pipeline.rs
+++ b/bert/src/pipeline.rs
@@ -98,7 +98,7 @@ impl<T, P> Pipeline<T, P> {
 
 #[cfg(test)]
 mod tests {
-    use xayn_ai_test_utils::asset::smbert_mocked;
+    use xayn_test_utils::asset::smbert_mocked;
 
     use super::*;
     use crate::{

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -31,7 +31,7 @@ use sqlx::{
 };
 use thiserror::Error;
 use tract_onnx::prelude::TractError;
-use xayn_ai_test_utils::ApproxEqIter;
+use xayn_test_utils::ApproxEqIter;
 
 use crate::{model::Prediction, tokenizer::AttentionMask};
 
@@ -277,7 +277,7 @@ mod tests {
 
     use ndarray::{arr2, arr3};
     use tract_onnx::prelude::IntoArcTensor;
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/bert/src/tokenizer/bert.rs
+++ b/bert/src/tokenizer/bert.rs
@@ -164,7 +164,7 @@ impl Tokenize for Tokenizer {
 #[cfg(test)]
 mod tests {
     use ndarray::ArrayView;
-    use xayn_ai_test_utils::asset::{sjbert, smbert_mocked};
+    use xayn_test_utils::asset::{sjbert, smbert_mocked};
 
     use super::*;
 

--- a/bert/src/tokenizer/roberta.rs
+++ b/bert/src/tokenizer/roberta.rs
@@ -126,7 +126,7 @@ impl Tokenize for Tokenizer {
 
 #[cfg(test)]
 mod tests {
-    use xayn_ai_test_utils::asset::smroberta;
+    use xayn_test_utils::asset::smroberta;
 
     use super::*;
 

--- a/coi/Cargo.toml
+++ b/coi/Cargo.toml
@@ -23,7 +23,7 @@ criterion = { workspace = true }
 rand = { workspace = true }
 rand_distr = "0.4.3"
 serde_json = { workspace = true }
-xayn-ai-test-utils = { path = "../test-utils" }
+xayn-test-utils = { path = "../test-utils" }
 
 [[bench]]
 name = "benches"

--- a/coi/src/context.rs
+++ b/coi/src/context.rs
@@ -108,7 +108,7 @@ impl UserInterests {
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
     use crate::point::tests::{create_neg_cois, create_pos_cois};

--- a/coi/src/document.rs
+++ b/coi/src/document.rs
@@ -29,7 +29,7 @@ pub trait Document {
 pub(crate) mod tests {
     use derive_more::Display;
     use uuid::Uuid;
-    use xayn_ai_test_utils::uuid::mock_uuid;
+    use xayn_test_utils::uuid::mock_uuid;
 
     use super::*;
 

--- a/coi/src/id.rs
+++ b/coi/src/id.rs
@@ -32,7 +32,7 @@ impl CoiId {
 
 #[cfg(test)]
 mod tests {
-    use xayn_ai_test_utils::uuid::mock_uuid;
+    use xayn_test_utils::uuid::mock_uuid;
 
     use super::*;
 

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -136,7 +136,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/coi/src/stats.rs
+++ b/coi/src/stats.rs
@@ -152,7 +152,7 @@ pub fn compute_coi_weights(
 
 #[cfg(test)]
 mod tests {
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
     use crate::{config::Config, point::tests::create_pos_cois};

--- a/coi/src/system.rs
+++ b/coi/src/system.rs
@@ -106,7 +106,7 @@ impl System {
 
 #[cfg(test)]
 mod tests {
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
     use crate::{

--- a/coi/src/utils.rs
+++ b/coi/src/utils.rs
@@ -95,7 +95,7 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
     use serde_json::{from_str, to_string};
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "integration-tests"
+name = "xayn-integration-tests"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -17,5 +17,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 toml = "0.7.2"
-xayn-ai-test-utils = { path = "../test-utils" }
+xayn-test-utils = { path = "../test-utils" }
 xayn-web-api = { path = "../web-api" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,6 +16,6 @@ scopeguard =  "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-toml = "0.7.2"
+toml = { workspace = true }
 xayn-test-utils = { path = "../test-utils" }
 xayn-web-api = { path = "../web-api" }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -35,7 +35,7 @@ use reqwest::{Client, Request, Response, StatusCode, Url};
 use scopeguard::{guard_on_success, OnSuccess, ScopeGuard};
 use serde::de::DeserializeOwned;
 use toml::Table;
-use xayn_ai_test_utils::{env::clear_env, error::Panic};
+use xayn_test_utils::{env::clear_env, error::Panic};
 use xayn_web_api::{config, start, AppHandle, Application};
 
 /// Absolute path to the root of the project as determined by `just`.
@@ -105,7 +105,7 @@ where
 /// Works with both `Table` and `&mut Table`.
 ///
 /// ```
-/// # use integration_tests::set_config_option;
+/// # use xayn_integration_tests::set_config_option;
 /// # use toml::{toml, Table};
 ///
 /// let mut config = Table::default();

--- a/integration-tests/tests/ingestion.rs
+++ b/integration-tests/tests/ingestion.rs
@@ -12,9 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use integration_tests::{send_assert, test_app};
 use reqwest::StatusCode;
 use serde_json::json;
+use xayn_integration_tests::{send_assert, test_app};
 use xayn_web_api::Ingestion;
 
 #[tokio::test]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xayn-ai-test-utils"
+name = "xayn-test-utils"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/test-utils/src/approx_eq.rs
+++ b/test-utils/src/approx_eq.rs
@@ -24,14 +24,14 @@ use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix};
 /// This can be used to compare two floating point numbers:
 ///
 /// ```
-/// use xayn_ai_test_utils::assert_approx_eq;
+/// use xayn_test_utils::assert_approx_eq;
 /// assert_approx_eq!(f32, 0.150_391_55, 0.150_391_6, ulps = 3);
 /// ```
 ///
 /// Or containers of such:
 ///
 /// ```
-/// use xayn_ai_test_utils::assert_approx_eq;
+/// use xayn_test_utils::assert_approx_eq;
 /// assert_approx_eq!(f32, &[[1., 2.], [3., 4.]], vec![[1., 2.], [3., 4.]])
 /// ```
 ///
@@ -39,7 +39,7 @@ use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix};
 ///
 /// ```
 /// use ndarray::arr2;
-/// use xayn_ai_test_utils::assert_approx_eq;
+/// use xayn_test_utils::assert_approx_eq;
 /// assert_approx_eq!(
 ///     f32,
 ///     arr2(&[[1., 2.], [3., 4.]]),

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -49,5 +49,5 @@ ouroboros = "0.15.5"
 tokio = { workspace = true, features = ["sync"] }
 toml = { workspace = true }
 trycmd = "0.14.11"
-xayn-test-utils = { path = "../test-utils" }
 xayn-integration-tests = { path = "../integration-tests" }
+xayn-test-utils = { path = "../test-utils" }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -47,6 +47,7 @@ instant-distance = { version = "0.6.0", features = ["with-serde"] }
 npyz = "0.7.4"
 ouroboros = "0.15.5"
 tokio = { workspace = true, features = ["sync"] }
+toml = { workspace = true }
 trycmd = "0.14.11"
 xayn-test-utils = { path = "../test-utils" }
 xayn-integration-tests = { path = "../integration-tests" }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -48,4 +48,4 @@ npyz = "0.7.4"
 ouroboros = "0.15.5"
 tokio = { workspace = true, features = ["sync"] }
 trycmd = "0.14.11"
-xayn-ai-test-utils = { path = "../test-utils" }
+xayn-test-utils = { path = "../test-utils" }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -49,3 +49,4 @@ ouroboros = "0.15.5"
 tokio = { workspace = true, features = ["sync"] }
 trycmd = "0.14.11"
 xayn-test-utils = { path = "../test-utils" }
+xayn-integration-tests = { path = "../integration-tests" }

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -606,7 +606,7 @@ impl Storage {
 mod tests {
     use itertools::Itertools;
     use xayn_ai_coi::{CoiId, CoiPoint};
-    use xayn_ai_test_utils::assert_approx_eq;
+    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
 

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -10,6 +10,7 @@
 // GNU Affero General Public License for more details.
 //
 // You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
     collections::HashMap,

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -18,7 +18,7 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps};
+use xayn_integration_tests::{extend_config, send_assert, send_assert_json, test_two_apps};
 use xayn_web_api::{Ingestion, Personalization};
 
 #[derive(Deserialize)]
@@ -35,10 +35,13 @@ async fn store_user_history(enabled: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         |_| {},
         |config| {
-            config.extend(toml! {
-                [personalization]
-                store_user_history = enabled
-            });
+            extend_config(
+                config,
+                toml! {
+                    [personalization]
+                    store_user_history = enabled
+                },
+            );
         },
         |client, ingestion, personalization, _| async move {
             send_assert(

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use xayn_integration_tests::{send_assert, send_assert_json, set_config_option, test_two_apps};
+use xayn_web_api::{Ingestion, Personalization};
+
+#[derive(Deserialize)]
+struct PersonalizedDocumentData {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct PersonalizedDocumentsResponse {
+    documents: Vec<PersonalizedDocumentData>,
+}
+
+async fn store_user_history(enabled: bool) {
+    test_two_apps::<Ingestion, Personalization, _>(
+        |_| {},
+        |config| {
+            set_config_option! { for config =>
+                [personalization]
+                store_user_history = enabled;
+            }
+        },
+        |client, ingestion, personalization, _| async move {
+            send_assert(
+                &client,
+                client
+                    .post(ingestion.join("/documents").unwrap())
+                    .json(&json!({ "documents": [
+                { "id": "1", "snippet": "a" },
+                { "id": "2", "snippet": "b" },
+                { "id": "3", "snippet": "c" },
+                { "id": "4", "snippet": "d" },
+                { "id": "5", "snippet": "e" }
+            ] }))
+                    .build()?,
+                StatusCode::CREATED,
+            )
+            .await;
+
+            send_assert(
+                &client,
+                client
+                    .patch(personalization.join("/users/u0/interactions").unwrap())
+                    .json(&json!({ "documents": [
+                        { "id": "2", "type": "Positive" },
+                        { "id": "5", "type": "Positive" },
+                    ] }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+            )
+            .await;
+
+            let documents = send_assert_json::<PersonalizedDocumentsResponse>(
+                &client,
+                client
+                    .get(
+                        personalization
+                            .join("/users/u0/personalized_documents")
+                            .unwrap(),
+                    )
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+            let documents = documents
+                .documents
+                .iter()
+                .map(|document| document.id.as_str())
+                .collect::<HashSet<_>>();
+            if enabled {
+                assert_eq!(documents, ["1", "3", "4"].into());
+            } else {
+                assert_eq!(documents, ["1", "2", "3", "4", "5"].into());
+            }
+
+            Ok(())
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_store_user_history_enabled() {
+    store_user_history(true).await;
+}
+
+#[tokio::test]
+async fn test_store_user_history_disabled() {
+    store_user_history(false).await;
+}

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -17,7 +17,8 @@ use std::collections::HashSet;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::json;
-use xayn_integration_tests::{send_assert, send_assert_json, set_config_option, test_two_apps};
+use toml::toml;
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps};
 use xayn_web_api::{Ingestion, Personalization};
 
 #[derive(Deserialize)]
@@ -34,10 +35,10 @@ async fn store_user_history(enabled: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         |_| {},
         |config| {
-            set_config_option! { for config =>
+            config.extend(toml! {
                 [personalization]
-                store_user_history = enabled;
-            }
+                store_user_history = enabled
+            });
         },
         |client, ingestion, personalization, _| async move {
             send_assert(

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -44,14 +44,16 @@ async fn store_user_history(enabled: bool) {
             send_assert(
                 &client,
                 client
-                    .post(ingestion.join("/documents").unwrap())
-                    .json(&json!({ "documents": [
-                { "id": "1", "snippet": "a" },
-                { "id": "2", "snippet": "b" },
-                { "id": "3", "snippet": "c" },
-                { "id": "4", "snippet": "d" },
-                { "id": "5", "snippet": "e" }
-            ] }))
+                    .post(ingestion.join("/documents")?)
+                    .json(&json!({
+                        "documents": [
+                            { "id": "1", "snippet": "a" },
+                            { "id": "2", "snippet": "b" },
+                            { "id": "3", "snippet": "c" },
+                            { "id": "4", "snippet": "d" },
+                            { "id": "5", "snippet": "e" }
+                        ]
+                    }))
                     .build()?,
                 StatusCode::CREATED,
             )
@@ -60,11 +62,13 @@ async fn store_user_history(enabled: bool) {
             send_assert(
                 &client,
                 client
-                    .patch(personalization.join("/users/u0/interactions").unwrap())
-                    .json(&json!({ "documents": [
-                        { "id": "2", "type": "Positive" },
-                        { "id": "5", "type": "Positive" },
-                    ] }))
+                    .patch(personalization.join("/users/u0/interactions")?)
+                    .json(&json!({
+                        "documents": [
+                            { "id": "2", "type": "Positive" },
+                            { "id": "5", "type": "Positive" }
+                        ]
+                    }))
                     .build()?,
                 StatusCode::NO_CONTENT,
             )
@@ -73,11 +77,7 @@ async fn store_user_history(enabled: bool) {
             let documents = send_assert_json::<PersonalizedDocumentsResponse>(
                 &client,
                 client
-                    .get(
-                        personalization
-                            .join("/users/u0/personalized_documents")
-                            .unwrap(),
-                    )
+                    .get(personalization.join("/users/u0/personalized_documents")?)
                     .build()?,
                 StatusCode::OK,
             )


### PR DESCRIPTION
**Reference**

- [ET-3960]

**Summary**

- add integration tests with and without `store_user_history`
- fix test crates naming: renamed `integration-tests` to `xayn-integration-tests` and `xayn-ai-test-utils` to `xayn-test-utils`
- simplify `set_config_option!` usage: there is no need to maintain this additional code, in cases where we create and edit a new config like `let mut config = Table::default(); set_config_option! { for config => ...}` we can simplify this to `let mut config = toml! { ... };`, and in cases where we modify an existing config like `|config| set_config_option! { for config => ... }` we can use `|config| config.extend(toml! { ... })`, otherwise we also need to take care of type export/import which are used in the macro but not available when the macro is called in another crate, additionally we can know use valid toml syntax ie no trailing semicolons


[ET-3960]: https://xainag.atlassian.net/browse/ET-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ