### PR TITLE
[Merged by Bors] - ET-4013/ET-4015 stateless personalization impl

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -95,6 +95,12 @@ pub(crate) struct IngestingDocumentsFailed {
 
 impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR);
 
+/// The requested document was not found.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct HistoryTooSmall;
+
+impl_application_error!(HistoryTooSmall => BAD_REQUEST);
+
 /// Custom error for 400 Bad Request status code.
 #[derive(Debug, Error, Display, Serialize, From)]
 pub(crate) struct BadRequest {

--- a/web-api/src/error/warning.rs
+++ b/web-api/src/error/warning.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Xayn AG
+// Copyright 2023 Xayn AG
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -12,7 +12,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod application;
-pub(crate) mod common;
-pub(crate) mod json_error;
-pub(crate) mod warning;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(transparent)]
+pub(crate) struct Warning {
+    message: String,
+}
+
+impl From<&'_ str> for Warning {
+    fn from(message: &'_ str) -> Self {
+        Warning {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<String> for Warning {
+    fn from(message: String) -> Self {
+        Warning { message }
+    }
+}

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -87,6 +87,9 @@ pub(crate) struct PersonalizationConfig {
 
     /// Whether to store the history of user interactions.
     pub(crate) store_user_history: bool,
+
+    /// The maximal size the history of the stateless personalization endpoint can have.
+    pub(crate) max_stateless_history_size: usize,
 }
 
 impl Default for PersonalizationConfig {
@@ -98,6 +101,7 @@ impl Default for PersonalizationConfig {
             max_cois_for_knn: 10,
             interest_tag_bias: 0.5,
             store_user_history: true,
+            max_stateless_history_size: 20,
         }
     }
 }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -274,7 +274,7 @@ async fn stateless_personalized_documents(
         }
     }
 
-    let mut documents = personalized_knn::Search {
+    let mut documents = knn::Search {
         interests: &interests.positive,
         excluded: &[],
         horizon: state.coi.config().horizon(),

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -249,7 +249,8 @@ async fn stateless_personalized_documents(
     let ids = history.iter().map(|document| &document.id).collect_vec();
     let time = history
         .last()
-        .unwrap(/* history has been checked */);
+        .unwrap(/* history has been checked */)
+        .timestamp;
 
     let documents_from_history = storage::Document::get_interacted(&state.storage, &ids).await?;
     let documents_from_history = documents_from_history

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -169,7 +169,10 @@ pub(crate) async fn update_interactions(
 
 #[derive(Deserialize)]
 struct StatelessPersonalizationRequest {
+    #[serde(default)]
     count: Option<usize>,
+    #[serde(default)]
+    published_after: Option<DateTime<Utc>>,
     history: Vec<UncheckedHistoryEntry>,
 }
 
@@ -232,6 +235,7 @@ async fn stateless_personalize_documents(
     Json(request): Json<StatelessPersonalizationRequest>,
 ) -> Result<impl Responder, Error> {
     let mut warnings = vec![];
+    let published_after = request.published_after;
     let count = request.document_count(state.config.as_ref())?;
     let history = request.resolved_history(&mut warnings)?;
     let ids = history.iter().map(|document| &document.id).collect_vec();
@@ -254,7 +258,7 @@ async fn stateless_personalize_documents(
         horizon: state.coi.config().horizon(),
         max_cois: state.config.personalization.max_cois_for_knn,
         count,
-        published_after: None,
+        published_after,
     }
     .run_on(&state.storage)
     .await?;

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -177,8 +177,12 @@ struct StatelessPersonalizationRequest {
 }
 
 impl StatelessPersonalizationRequest {
-    fn resolved_history(self, warnings: &mut Vec<Warning>) -> Result<Vec<HistoryEntry>, Error> {
-        let max_history_len = 100 /*TODO config*/;
+    fn resolved_history(
+        self,
+        config: &PersonalizationConfig,
+        warnings: &mut Vec<Warning>,
+    ) -> Result<Vec<HistoryEntry>, Error> {
+        let max_history_len = config.max_stateless_history_size;
         if self.history.len() > max_history_len {
             warnings.push(format!("history truncated, max length is {max_history_len}").into());
         }
@@ -237,7 +241,7 @@ async fn stateless_personalize_documents(
     let mut warnings = vec![];
     let published_after = request.published_after;
     let count = request.document_count(state.config.as_ref())?;
-    let history = request.resolved_history(&mut warnings)?;
+    let history = request.resolved_history(state.config.as_ref(), &mut warnings)?;
     let ids = history.iter().map(|document| &document.id).collect_vec();
 
     let documents_from_history = storage::Document::get_interacted(&state.storage, &ids).await?;

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -257,9 +257,8 @@ async fn stateless_personalize_documents(
             state.coi.log_positive_user_reaction(
                 &mut interests.positive,
                 &document.embedding,
-                /* TODO after rebase: entry.timestamp, */
+                entry.timestamp,
             );
-            let _ = entry.timestamp;
         } else {
             let msg = format!("document {id} does not exist");
             warn!("{}", msg);

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -80,11 +80,6 @@ pub(crate) trait Document {
         ids: &[&DocumentId],
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
-    async fn get_embeddings(
-        &self,
-        ids: &[&DocumentId],
-    ) -> Result<HashMap<DocumentId, NormalizedEmbedding>, Error>;
-
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;
 
     async fn get_by_embedding<'a>(

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -80,6 +80,11 @@ pub(crate) trait Document {
         ids: &[&DocumentId],
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
+    async fn get_embeddings(
+        &self,
+        ids: &[&DocumentId],
+    ) -> Result<HashMap<DocumentId, NormalizedEmbedding>, Error>;
+
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;
 
     async fn get_by_embedding<'a>(

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -412,35 +412,6 @@ impl storage::Document for Storage {
         self.get_personalized_with_transaction(ids, None).await
     }
 
-    async fn get_embeddings(
-        &self,
-        ids: &[&DocumentId],
-    ) -> Result<HashMap<DocumentId, NormalizedEmbedding>, Error> {
-        if ids.is_empty() {
-            return Ok(HashMap::default());
-        }
-
-        // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
-        let body = Some(json!({
-            "query": {
-                "ids" : {
-                    "values": ids
-                }
-            },
-            "_source": [ "embedding" ]
-        }));
-
-        Ok(self
-            .elastic
-            .query_with_json::<_, SearchResponse<SearchEmbedding>>(
-                self.elastic.create_resource_path(["_search"], None),
-                body,
-            )
-            .await?
-            .map(Into::into)
-            .unwrap_or_default())
-    }
-
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
         #[derive(Deserialize)]
         struct Response {

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -284,6 +284,21 @@ impl storage::Document for Storage {
         Ok(documents)
     }
 
+    async fn get_embeddings(
+        &self,
+        ids: &[&DocumentId],
+    ) -> Result<HashMap<DocumentId, NormalizedEmbedding>, Error> {
+        let guard = self.documents.read().await;
+        let map = guard.1.borrow_map();
+        Ok(ids
+            .iter()
+            .filter_map(|&id| {
+                let embedding = map.get(id)?;
+                Some((id.clone(), embedding.clone()))
+            })
+            .collect())
+    }
+
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
         Ok(self.documents.read().await.1.borrow_map().get(id).cloned())
     }

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -284,21 +284,6 @@ impl storage::Document for Storage {
         Ok(documents)
     }
 
-    async fn get_embeddings(
-        &self,
-        ids: &[&DocumentId],
-    ) -> Result<HashMap<DocumentId, NormalizedEmbedding>, Error> {
-        let guard = self.documents.read().await;
-        let map = guard.1.borrow_map();
-        Ok(ids
-            .iter()
-            .filter_map(|&id| {
-                let embedding = map.get(id)?;
-                Some((id.clone(), embedding.clone()))
-            })
-            .collect())
-    }
-
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
         Ok(self.documents.read().await.1.borrow_map().get(id).cloned())
     }

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -43,7 +43,8 @@ stdout = """
     "default_number_documents": 10,
     "max_cois_for_knn": 10,
     "interest_tag_bias": 0.5,
-    "store_user_history": true
+    "store_user_history": true,
+    "max_stateless_history_size": 20
   },
   "semantic_search": {
     "max_number_documents": 100,

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -14,30 +14,27 @@
 
 use reqwest::StatusCode;
 use serde_json::json;
-use xayn_integration_tests::{send_assert, test_app};
+use xayn_integration_tests::{send_assert, test_app, unchanged_config};
 use xayn_web_api::Ingestion;
 
 #[tokio::test]
 async fn test_ingestion() {
-    test_app::<Ingestion, _>(
-        |_config| {},
-        |client, url, _service| async move {
-            send_assert(
-                &client,
-                client
-                    .post(url.join("/documents")?)
-                    .json(&json!({
-                        "documents": [
-                            { "id": "d1", "snippet": "once in a spring there was a fall" },
-                            { "id": "d2", "snippet": "fall in a once" },
-                        ]
-                    }))
-                    .build()?,
-                StatusCode::CREATED,
-            )
-            .await;
-            Ok(())
-        },
-    )
+    test_app::<Ingestion, _>(unchanged_config, |client, url, _service| async move {
+        send_assert(
+            &client,
+            client
+                .post(url.join("/documents")?)
+                .json(&json!({
+                    "documents": [
+                        { "id": "d1", "snippet": "once in a spring there was a fall" },
+                        { "id": "d2", "snippet": "fall in a once" },
+                    ]
+                }))
+                .build()?,
+            StatusCode::CREATED,
+        )
+        .await;
+        Ok(())
+    })
     .await;
 }

--- a/web-api/tests/stateless_personalization.rs
+++ b/web-api/tests/stateless_personalization.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use chrono::Utc;
+use itertools::Itertools;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, unchanged_config};
+use xayn_web_api::{Ingestion, Personalization};
+
+#[derive(Debug, Deserialize)]
+struct PersonalizedDocumentData {
+    id: String,
+    #[allow(dead_code)]
+    score: f32,
+    #[allow(dead_code)]
+    properties: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct StatelessPersonalizedDocumentsResponse {
+    documents: Vec<PersonalizedDocumentData>,
+}
+
+#[tokio::test]
+async fn test_test_app() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        unchanged_config,
+        unchanged_config,
+        |client, ingestion_url, personalization_url, _services| async move {
+            send_assert(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents")?)
+                    .json(&json!({
+                        "documents": [
+                            { "id": "d1", "snippet": "Computer", "properties": { "publication_date": "2023-01-12T20:20:20Z" } },
+                            { "id": "d2", "snippet": "Technology", "properties": { "publication_date": "2023-01-12T20:20:20Z" } },
+                            { "id": "d3", "snippet": "Politic", "properties": { "publication_date": "2023-01-12T20:20:20Z" } },
+                            { "id": "d4", "snippet": "Laptop", "properties": { "publication_date": "2023-01-12T20:20:20Z" } },
+                            { "id": "d5", "snippet": "Smartphone", "properties": { "publication_date": "2023-01-12T20:20:20Z" } },
+                            { "id": "d6", "snippet": "Computer", "properties": { "publication_date": "2021-05-12T20:20:20Z" } },
+                        ]
+                    }))
+                    .build()?,
+                StatusCode::CREATED,
+            )
+            .await;
+
+            let StatelessPersonalizedDocumentsResponse {documents} = send_assert_json(
+                &client,
+                client
+                    .post(personalization_url.join("/personalized_documents")?)
+                    .json(&json!({
+                        "published_after": "2022-05-12T20:20:20Z",
+                        "history": [
+                            { "id": "d1", "timestamp": Utc::now().to_rfc3339() },
+                            { "id": "d4" },
+                            { "id": "d5", "timestamp": null }
+                        ]
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+
+            let found_ids = documents.iter().map(|document| &document.id).collect_vec();
+            assert_eq!(found_ids, &["d2", "d3"], "unexpected documents {documents:?}");
+            Ok(())
+        },
+    )
+    .await;
+}

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -18,7 +18,13 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{extend_config, send_assert, send_assert_json, test_two_apps};
+use xayn_integration_tests::{
+    extend_config,
+    send_assert,
+    send_assert_json,
+    test_two_apps,
+    unchanged_config,
+};
 use xayn_web_api::{Ingestion, Personalization};
 
 #[derive(Deserialize)]
@@ -33,7 +39,7 @@ struct PersonalizedDocumentsResponse {
 
 async fn store_user_history(enabled: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
-        |_| {},
+        unchanged_config,
         |config| {
             extend_config(
                 config,


### PR DESCRIPTION
Implement the (user-)stateless `/personalized_documents` endpoint.

**References:**

- based on #809
- task: [ET-4015]
- story: [ET-4010]


[ET-4015]: https://xainag.atlassian.net/browse/ET-4015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4010]: https://xainag.atlassian.net/browse/ET-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ