### PR TITLE
[Merged by Bors] - ET-4011 allow to select interaction time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
 name = "xayn-ai-coi"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "criterion",
  "derive_more",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.67.0"
 anyhow = "1.0.69"
 criterion = "0.4.0"
 csv = "1.1.6"
-chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4.23", default-features = false, features = ["clock", "serde", "std"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "display", "from", "into"] }
 displaydoc = "0.2.3"
 figment = "0.10.8"

--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -12,9 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::path::Path;
+use std::{hint::black_box, path::Path};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use xayn_ai_bert::{tokenizer::bert::Tokenizer, Config, NonePooler};
 use xayn_ai_test_utils::asset::smbert;
 
@@ -31,7 +31,7 @@ fn bench_tract_bert(manager: &mut Criterion, name: &str, dir: &Path) {
         .build()
         .unwrap();
     manager.bench_function(name, |bencher| {
-        bencher.iter(|| pipeline.run(black_box(SEQUENCE)).unwrap())
+        bencher.iter(|| black_box(pipeline.run(black_box(SEQUENCE)).unwrap()))
     });
 }
 

--- a/coi/Cargo.toml
+++ b/coi/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = { workspace = true }
 license = "AGPL-3.0-only"
 
 [dependencies]
+chrono = { workspace = true }
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 itertools = { workspace = true }

--- a/coi/benches/benches.rs
+++ b/coi/benches/benches.rs
@@ -12,10 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use chrono::Utc;
-use criterion::{black_box, criterion_group, BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 use itertools::Itertools;
 use rand::Rng;
 use rand_distr::Uniform;
@@ -44,7 +44,13 @@ fn bench_compute_coi_decay_factor(c: &mut Criterion) {
     let last_view = now - chrono::Duration::seconds(60 * 60);
 
     c.bench_function("compute_coi_decay_factor", |b| {
-        b.iter(|| black_box(compute_coi_decay_factor(horizon, now, last_view)))
+        b.iter(|| {
+            black_box(compute_coi_decay_factor(
+                black_box(horizon),
+                black_box(now),
+                black_box(last_view),
+            ))
+        })
     });
 }
 
@@ -65,7 +71,13 @@ fn bench_compute_coi_relevance(c: &mut Criterion) {
         c.bench_function(&format!("compute_coi_relevance_{base_name}"), |b| {
             b.iter_batched(
                 || black_box(positive_cois),
-                |cois| black_box(compute_coi_relevances(cois, horizon, now)),
+                |cois| {
+                    black_box(compute_coi_relevances(
+                        black_box(cois),
+                        black_box(horizon),
+                        black_box(now),
+                    ))
+                },
                 BatchSize::SmallInput,
             );
         });

--- a/coi/benches/benches.rs
+++ b/coi/benches/benches.rs
@@ -23,6 +23,7 @@ use xayn_ai_coi::{compute_coi_decay_factor, compute_coi_relevances, CoiId, CoiPo
 
 fn create_positive_coi(n: usize, embedding_size: usize) -> Vec<PositiveCoi> {
     let range = Uniform::new(-1., 1.);
+    let now = Utc::now();
 
     (0..n)
         .map(|_| {
@@ -32,7 +33,7 @@ fn create_positive_coi(n: usize, embedding_size: usize) -> Vec<PositiveCoi> {
                 .collect_vec()
                 .try_into()
                 .unwrap();
-            PositiveCoi::new(CoiId::new(), point)
+            PositiveCoi::new(CoiId::new(), point, now)
         })
         .collect()
 }

--- a/coi/src/lib.rs
+++ b/coi/src/lib.rs
@@ -48,5 +48,5 @@ pub use crate::{
     point::{CoiPoint, NegativeCoi, PositiveCoi},
     stats::{compute_coi_decay_factor, compute_coi_relevances, CoiStats},
     system::System as CoiSystem,
-    utils::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc, system_time_now},
+    utils::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc},
 };

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -12,17 +12,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::SystemTime;
-
+use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use xayn_ai_bert::{InvalidEmbedding, NormalizedEmbedding};
 
-use crate::{
-    id::CoiId,
-    stats::CoiStats,
-    utils::{nan_safe_f32_cmp_desc, system_time_now},
-};
+use crate::{id::CoiId, stats::CoiStats, utils::nan_safe_f32_cmp_desc};
 
 /// A positive `CoI`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -37,7 +32,7 @@ pub struct PositiveCoi {
 pub struct NegativeCoi {
     pub id: CoiId,
     pub point: NormalizedEmbedding,
-    pub last_view: SystemTime,
+    pub last_view: DateTime<Utc>,
 }
 
 /// Common `CoI` properties and functionality.
@@ -96,7 +91,7 @@ macro_rules! impl_coi_point {
 
 impl_coi_point! {
     PositiveCoi { stats: CoiStats::new() },
-    NegativeCoi { last_view: system_time_now() },
+    NegativeCoi { last_view: Utc::now() },
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.

--- a/coi/src/stats.rs
+++ b/coi/src/stats.rs
@@ -180,12 +180,9 @@ mod tests {
     #[test]
     fn test_compute_relevances_last() {
         let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
-        cois[0].stats.last_view -=
-            chrono::Duration::from_std(Duration::from_secs_f32(0.5 * SECONDS_PER_DAY_F32)).unwrap();
-        cois[1].stats.last_view -=
-            chrono::Duration::from_std(Duration::from_secs_f32(1.5 * SECONDS_PER_DAY_F32)).unwrap();
-        cois[2].stats.last_view -=
-            chrono::Duration::from_std(Duration::from_secs_f32(2.5 * SECONDS_PER_DAY_F32)).unwrap();
+        cois[0].stats.last_view -= chrono::Duration::hours(12);
+        cois[1].stats.last_view -= chrono::Duration::hours(36);
+        cois[2].stats.last_view -= chrono::Duration::hours(60);
         let config =
             Config::default().with_horizon(Duration::from_secs_f32(2. * SECONDS_PER_DAY_F32));
 
@@ -206,9 +203,7 @@ mod tests {
         let factor = compute_coi_decay_factor(horizon, now, now);
         assert_approx_eq!(f32, factor, 1.);
 
-        let last = now
-            - chrono::Duration::from_std(Duration::from_secs_f32(5. * SECONDS_PER_DAY_F32))
-                .unwrap();
+        let last = now - chrono::Duration::days(5);
         let factor = compute_coi_decay_factor(horizon, now, last);
         assert_approx_eq!(f32, factor, 0.585_914_55, epsilon = 1e-6);
 

--- a/coi/src/system.rs
+++ b/coi/src/system.rs
@@ -14,6 +14,7 @@
 
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use tracing::instrument;
 use xayn_ai_bert::NormalizedEmbedding;
 
@@ -52,6 +53,7 @@ impl System {
         &self,
         cois: &'a mut Vec<PositiveCoi>,
         embedding: &NormalizedEmbedding,
+        time: DateTime<Utc>,
     ) -> &'a PositiveCoi {
         // If the given embedding's similarity to the CoI is above the threshold,
         // we adjust the position of the nearest CoI
@@ -59,14 +61,14 @@ impl System {
             if similarity >= self.config.threshold() {
                 // normalization of the shifted coi is almost always possible
                 if let Ok(coi) = cois[index].shift_point(embedding, self.config.shift_factor()) {
-                    coi.log_reaction();
+                    coi.log_reaction(time);
                     return &cois[index];
                 }
             }
         }
 
         // If the embedding is too dissimilar, we create a new CoI instead
-        cois.push(PositiveCoi::new(CoiId::new(), embedding.clone()));
+        cois.push(PositiveCoi::new(CoiId::new(), embedding.clone(), time));
         &cois[cois.len() - 1]
     }
 
@@ -75,17 +77,18 @@ impl System {
         &self,
         cois: &mut Vec<NegativeCoi>,
         embedding: &NormalizedEmbedding,
+        time: DateTime<Utc>,
     ) {
         if let Some((coi, similarity)) = find_closest_coi_mut(cois, embedding) {
             if similarity >= self.config.threshold() {
                 if let Ok(coi) = coi.shift_point(embedding, self.config.shift_factor()) {
-                    coi.log_reaction();
+                    coi.log_reaction(time);
                     return;
                 }
             }
         }
 
-        cois.push(NegativeCoi::new(CoiId::new(), embedding.clone()));
+        cois.push(NegativeCoi::new(CoiId::new(), embedding.clone(), time));
     }
 
     /// Ranks the documents wrt the user interests.
@@ -93,11 +96,11 @@ impl System {
     /// The documents are sorted decreasingly by a score computed from the cois. If the cois are
     /// empty, then the original order of the documents is kept.
     #[instrument(skip_all)]
-    pub fn rank<D>(&self, documents: &mut [D], cois: &UserInterests)
+    pub fn rank<D>(&self, documents: &mut [D], cois: &UserInterests, time: DateTime<Utc>)
     where
         D: Document,
     {
-        if let Some(scores) = cois.compute_scores_for_docs(documents, &self.config) {
+        if let Some(scores) = cois.compute_scores_for_docs(documents, &self.config, time) {
             documents
                 .sort_unstable_by(|a, b| nan_safe_f32_cmp_desc(&scores[a.id()], &scores[b.id()]));
         }
@@ -121,7 +124,7 @@ mod tests {
         let system = Config::default().build();
 
         let before = cois.clone();
-        system.log_positive_user_reaction(&mut cois, &embedding);
+        system.log_positive_user_reaction(&mut cois, &embedding, Utc::now());
 
         assert_eq!(cois.len(), 3);
         assert_approx_eq!(
@@ -142,7 +145,7 @@ mod tests {
         let embedding = [1., 0.].try_into().unwrap();
         let system = Config::default().build();
 
-        system.log_positive_user_reaction(&mut cois, &embedding);
+        system.log_positive_user_reaction(&mut cois, &embedding, Utc::now());
 
         assert_eq!(cois.len(), 2);
         assert_approx_eq!(f32, cois[0].point, [0., 1.,]);
@@ -156,7 +159,7 @@ mod tests {
         let system = Config::default().build();
 
         let last_view = cois[0].last_view;
-        system.log_negative_user_reaction(&mut cois, &embedding);
+        system.log_negative_user_reaction(&mut cois, &embedding, Utc::now());
 
         assert_eq!(cois.len(), 1);
         assert!(cois[0].last_view > last_view);
@@ -193,7 +196,9 @@ mod tests {
             positive: create_pos_cois([[1., 0., 0.], [4., 12., 2.]]),
             negative: create_neg_cois([[-100., -10., 0.]]),
         };
-        Config::default().build().rank(&mut documents, &cois);
+        Config::default()
+            .build()
+            .rank(&mut documents, &cois, Utc::now());
         assert_eq!(documents[0].id, DocumentId::mocked(1));
         assert_eq!(documents[1].id, DocumentId::mocked(3));
         assert_eq!(documents[2].id, DocumentId::mocked(2));
@@ -208,7 +213,9 @@ mod tests {
             TestDocument::new(2, [0., 0., 0.].try_into().unwrap()),
         ];
         let cois = UserInterests::default();
-        Config::default().build().rank(&mut documents, &cois);
+        Config::default()
+            .build()
+            .rank(&mut documents, &cois, Utc::now());
         assert_eq!(documents[0].id, DocumentId::mocked(0));
         assert_eq!(documents[1].id, DocumentId::mocked(1));
         assert_eq!(documents[2].id, DocumentId::mocked(2));

--- a/coi/src/utils.rs
+++ b/coi/src/utils.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, time::SystemTime};
+use std::cmp::Ordering;
 
 /// Pretend that f32 has a total ordering.
 ///
@@ -66,12 +66,6 @@ pub(crate) const SECONDS_PER_DAY_F32: f32 = 86400.;
 
 /// The number of seconds per day (without leap seconds).
 pub(crate) const SECONDS_PER_DAY_U64: u64 = 86400;
-
-/// Gets the current system time depending on the target architecture.
-#[inline]
-pub fn system_time_now() -> SystemTime {
-    SystemTime::now()
-}
 
 pub(crate) mod serde_duration_as_days {
     use std::time::Duration;

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -11,7 +11,7 @@ actix-cors = "0.6.4"
 actix-web = { version = "4.3.0", default-features = false, features = ["compress-gzip", "compress-zstd"] }
 anyhow = { workspace = true }
 async-trait = "0.1.64"
-chrono = { workspace = true, features = ["serde"] }
+chrono = { workspace = true }
 clap = { version = "4.1.4", features = ["derive"] }
 csv = { workspace = true }
 derive_more = { workspace = true }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -26,13 +26,7 @@ use futures_util::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::error;
-use xayn_ai_coi::{
-    compute_coi_relevances,
-    nan_safe_f32_cmp,
-    system_time_now,
-    CoiSystem,
-    PositiveCoi,
-};
+use xayn_ai_coi::{compute_coi_relevances, nan_safe_f32_cmp, CoiSystem, PositiveCoi};
 
 use super::{AppState, PersonalizationConfig, SemanticSearchConfig};
 use crate::{
@@ -233,7 +227,7 @@ pub(crate) enum PersonalizedDocumentsError {
 
 /// Computes [`PositiveCoi`]s weights used to determine how many documents to fetch using each center's embedding.
 fn compute_coi_weights(cois: &[PositiveCoi], horizon: Duration) -> Vec<f32> {
-    let relevances = compute_coi_relevances(cois, horizon, system_time_now())
+    let relevances = compute_coi_relevances(cois, horizon, Utc::now())
         .into_iter()
         .map(|rel| 1.0 - (-3.0 * rel).exp())
         .collect_vec();

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -52,6 +52,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) num_candidates: usize,
     pub(crate) published_after: Option<DateTime<Utc>>,
     pub(crate) min_similarity: Option<f32>,
+    pub(crate) time: DateTime<Utc>,
 }
 
 #[derive(Debug, Error, From)]
@@ -138,19 +139,21 @@ pub(crate) struct InteractionUpdateContext<'s, 'l> {
     pub(crate) document: &'s InteractedDocument,
     pub(crate) tag_weight_diff: &'s mut HashMap<&'l DocumentTag, i32>,
     pub(crate) positive_cois: &'s mut Vec<PositiveCoi>,
+    pub(crate) time: DateTime<Utc>,
 }
 
 #[async_trait]
 pub(crate) trait Interaction {
     async fn get(&self, user_id: &UserId) -> Result<Vec<DocumentId>, Error>;
 
-    async fn user_seen(&self, id: &UserId) -> Result<(), Error>;
+    async fn user_seen(&self, id: &UserId, time: DateTime<Utc>) -> Result<(), Error>;
 
     async fn update_interactions<F>(
         &self,
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
         store_user_history: bool,
+        time: DateTime<Utc>,
         update_logic: F,
     ) -> Result<(), Error>
     where

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -411,16 +411,17 @@ impl storage::Document for Storage {
         let excluded_ids = json!({
             "values": params.excluded.iter().map(AsRef::as_ref).collect_vec()
         });
+        let time = params.time.to_rfc3339();
 
         let filter = if let Some(published_after) = params.published_after {
-            // published_after != null && published_after <= publication_date <= now
+            // published_after != null && published_after <= publication_date <= time
             json!({
                 "bool": {
                     "filter": {
                         "range": {
                             "properties.publication_date": {
                                 "gte": published_after.to_rfc3339(),
-                                "lte": "now"
+                                "lte": time
                             }
                         }
                     },
@@ -430,7 +431,7 @@ impl storage::Document for Storage {
                 }
             })
         } else {
-            // published_after == null || published_after <= now
+            // published_after == null || published_after <= time
             json!({
                 "bool": {
                     "must_not": [
@@ -440,7 +441,7 @@ impl storage::Document for Storage {
                         {
                             "range": {
                                 "properties.publication_date": {
-                                    "gt": "now"
+                                    "gt": time
                                 }
                             }
                         }

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -27,7 +27,7 @@ use std::{
 
 use async_trait::async_trait;
 use bincode::{deserialize, serialize};
-use chrono::{DateTime, Local, NaiveDateTime, Utc};
+use chrono::{Local, NaiveDateTime};
 use derive_more::{AsRef, Deref};
 use instant_distance::{Builder as HnswBuilder, HnswMap, Point, Search};
 use ouroboros::self_referencing;
@@ -557,10 +557,7 @@ impl storage::Interaction for Storage {
                 positive_cois,
             });
             if store_user_history {
-                interactions.insert((
-                    document.id.clone(),
-                    DateTime::<Utc>::from(updated.stats.last_view).naive_utc(),
-                ));
+                interactions.insert((document.id.clone(), updated.stats.last_view.naive_utc()));
             }
         }
 

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -265,7 +265,7 @@ impl Database {
                 stats: CoiStats {
                     view_count: coi.view_count as usize,
                     view_time: Duration::from_millis(coi.view_time_ms as u64),
-                    last_view: coi.last_view.into(),
+                    last_view: coi.last_view,
                 },
             })
             .collect_vec();
@@ -275,7 +275,7 @@ impl Database {
             .map(|coi| NegativeCoi {
                 id: coi.coi_id,
                 point: coi.embedding,
-                last_view: coi.last_view.into(),
+                last_view: coi.last_view,
             })
             .collect_vec();
 

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -319,7 +319,7 @@ impl Database {
                         .push_bind(update.point.to_vec())
                         .push_bind(update.stats.view_count as i32)
                         .push_bind(update.stats.view_time.as_millis() as i64)
-                        .push_bind(time);
+                        .push_bind(time.to_rfc3339());
                 })
                 .push(
                     " ON CONFLICT (coi_id) DO UPDATE SET
@@ -357,7 +357,7 @@ impl Database {
                     builder
                         .push_bind(document_id)
                         .push_bind(user_id)
-                        .push_bind(time)
+                        .push_bind(time.to_rfc3339())
                         .push_bind(*interaction as i16);
                 })
                 .push(
@@ -461,7 +461,7 @@ impl storage::Interaction for Storage {
             DO UPDATE SET last_seen = EXCLUDED.last_seen;",
         )
         .bind(id)
-        .bind(time)
+        .bind(time.to_rfc3339())
         .execute(&self.postgres.pool)
         .await?;
 

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -319,7 +319,7 @@ impl Database {
                         .push_bind(update.point.to_vec())
                         .push_bind(update.stats.view_count as i32)
                         .push_bind(update.stats.view_time.as_millis() as i64)
-                        .push_bind(time.to_rfc3339());
+                        .push_bind(time);
                 })
                 .push(
                     " ON CONFLICT (coi_id) DO UPDATE SET
@@ -357,7 +357,7 @@ impl Database {
                     builder
                         .push_bind(document_id)
                         .push_bind(user_id)
-                        .push_bind(time.to_rfc3339())
+                        .push_bind(time)
                         .push_bind(*interaction as i16);
                 })
                 .push(
@@ -461,7 +461,7 @@ impl storage::Interaction for Storage {
             DO UPDATE SET last_seen = EXCLUDED.last_seen;",
         )
         .bind(id)
-        .bind(time.to_rfc3339())
+        .bind(time)
         .execute(&self.postgres.pool)
         .await?;
 

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -292,7 +292,7 @@ impl Database {
     async fn upsert_cois(
         tx: &mut Transaction<'_, Postgres>,
         user_id: &UserId,
-        now: DateTime<Utc>,
+        time: DateTime<Utc>,
         cois: &HashMap<CoiId, PositiveCoi>,
     ) -> Result<(), Error> {
         let mut builder = QueryBuilder::new(
@@ -319,7 +319,7 @@ impl Database {
                         .push_bind(update.point.to_vec())
                         .push_bind(update.stats.view_count as i32)
                         .push_bind(update.stats.view_time.as_millis() as i64)
-                        .push_bind(now);
+                        .push_bind(time);
                 })
                 .push(
                     " ON CONFLICT (coi_id) DO UPDATE SET
@@ -339,7 +339,7 @@ impl Database {
     async fn upsert_interactions(
         tx: &mut Transaction<'_, Postgres>,
         user_id: &UserId,
-        now: DateTime<Utc>,
+        time: DateTime<Utc>,
         interactions: &HashMap<&DocumentId, (&InteractedDocument, UserInteractionType)>,
     ) -> Result<(), Error> {
         //FIXME micro benchmark and chunking+persist abstraction
@@ -357,7 +357,7 @@ impl Database {
                     builder
                         .push_bind(document_id)
                         .push_bind(user_id)
-                        .push_bind(now)
+                        .push_bind(time)
                         .push_bind(*interaction as i16);
                 })
                 .push(
@@ -453,14 +453,15 @@ impl storage::Interaction for Storage {
         Ok(documents.into_iter().map_into().collect())
     }
 
-    async fn user_seen(&self, id: &UserId) -> Result<(), Error> {
+    async fn user_seen(&self, id: &UserId, time: DateTime<Utc>) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO users (user_id, last_seen)
-            VALUES ($1, Now())
+            VALUES ($1, $2)
             ON CONFLICT (user_id)
             DO UPDATE SET last_seen = EXCLUDED.last_seen;",
         )
         .bind(id)
+        .bind(time)
         .execute(&self.postgres.pool)
         .await?;
 
@@ -472,6 +473,7 @@ impl storage::Interaction for Storage {
         user_id: &UserId,
         updated_document_ids: &[&DocumentId],
         store_user_history: bool,
+        time: DateTime<Utc>,
         mut update_logic: F,
     ) -> Result<(), Error>
     where
@@ -501,6 +503,7 @@ impl storage::Interaction for Storage {
                     document,
                     tag_weight_diff: &mut tag_weight_diff,
                     positive_cois: &mut interests.positive,
+                    time,
                 });
                 // We might update the same coi min `interests` multiple times,
                 // if we do we only want to keep the latest update.
@@ -510,10 +513,9 @@ impl storage::Interaction for Storage {
             }
         }
 
-        let now = Utc::now();
-        Database::upsert_cois(&mut tx, user_id, now, &updates).await?;
+        Database::upsert_cois(&mut tx, user_id, time, &updates).await?;
         if store_user_history {
-            Database::upsert_interactions(&mut tx, user_id, now, &document_map).await?;
+            Database::upsert_interactions(&mut tx, user_id, time, &document_map).await?;
         }
         Database::upsert_tag_weights(&mut tx, user_id, &tag_weight_diff).await?;
 


### PR DESCRIPTION
**Reference**

- [ET-4011]
- [ET-3952]

**Summary**

- replace `SystemTime` with `DateTime<Utc>`: `Utc::now()` anyway internally uses `SystemTime::now()`, but `DateTime` is also easily constructable for fixed values in contrast to `SystemTime`
- use `DateTime<Utc>` instead of `NaiveDateTime` for the in-memory storage to match it with the elastic/postgres storage
- expose the `time` argument in the internal apis up to the logic of the web-api routes, but not in the routes themselves, the routes & tests remain unchanged as they call the apis with `Utc::now()` for the time argument


[ET-4011]: https://xainag.atlassian.net/browse/ET-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-3952]: https://xainag.atlassian.net/browse/ET-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ