### PR TITLE
[Merged by Bors] - make ci more robust

### DIFF
--- a/web-api/compose.db.yml
+++ b/web-api/compose.db.yml
@@ -47,9 +47,22 @@ services:
     restart: "no"
     command: http://elasticsearch:9200/test_index
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     networks:
       - internal
+
+  db_ready:
+    image: debian:bookworm-slim
+    command: echo dummy
+    restart: "no"
+    depends_on:
+      create_es_index:
+        condition: service_completed_successfully
+      elasticsearch:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
   # kibana:
   #   image: kibana:8.4.0

--- a/web-api/compose.ingestion.yml
+++ b/web-api/compose.ingestion.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - "${HOST_PORT_SCOPE:-30}30:3030"
     depends_on:
-      - elasticsearch
-      - postgres
+      db_ready:
+        condition: service_completed_successfully
     networks:
       - internal
       - publisher

--- a/web-api/compose.personalization.yml
+++ b/web-api/compose.personalization.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - "${HOST_PORT_SCOPE:-30}31:3031"
     depends_on:
-      - elasticsearch
-      - postgres
+      db_ready:
+        condition: service_completed_successfully
     networks:
       - internal
       - public


### PR DESCRIPTION

- Make sure `just web-dev-up` only returns after all db services are healthy and oneshots completed.
- Remove podman support this uses a feature which podman-compose does not yet support