### PR TITLE
[Merged by Bors] - Don't index properties fields

### DIFF
--- a/web-api/elastic-search/mapping.json
+++ b/web-api/elastic-search/mapping.json
@@ -11,6 +11,7 @@
                 "similarity": "dot_product"
             },
             "properties": {
+                "dynamic": false,
                 "properties": {
                     "publication_date": {
                         "type": "date"


### PR DESCRIPTION
Avoid that ElasticSearch index new fields in properties.