### PR TITLE
[Merged by Bors] - ET-3898 get embeddings from postgres

### DIFF
--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -26,6 +26,7 @@ use sqlx::{
     Database,
     Decode,
     Encode,
+    FromRow,
     Postgres,
     Type,
 };
@@ -83,7 +84,7 @@ pub type Embedding1 = Embedding<Ix1>;
 /// A normalized embedding.
 #[derive(Clone, Debug, Deref, Deserialize, Serialize)]
 #[serde(transparent)]
-#[cfg_attr(feature = "sqlx", derive(Type), sqlx(transparent))]
+#[cfg_attr(feature = "sqlx", derive(FromRow, Type), sqlx(transparent))]
 pub struct NormalizedEmbedding(Embedding1);
 
 #[derive(Clone, Debug, Display, Error, Serialize)]

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -27,13 +27,7 @@ use crate::{
     Error,
 };
 
-pub(super) struct Search<'a, I, J>
-where
-    I: IntoIterator,
-    <I as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a PositiveCoi>,
-    J: IntoIterator,
-    <J as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a DocumentId>,
-{
+pub(super) struct Search<I, J> {
     pub(super) interests: I,
     pub(super) excluded: J,
     pub(super) horizon: Duration,
@@ -43,7 +37,7 @@ where
     pub(super) time: DateTime<Utc>,
 }
 
-impl<'a, I, J> Search<'a, I, J>
+impl<'a, I, J> Search<I, J>
 where
     I: IntoIterator,
     <I as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a PositiveCoi>,

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -38,7 +38,7 @@ where
         .collect()
 }
 
-pub(super) fn rerank_by_interest(
+fn rerank_by_interest(
     coi_system: &CoiSystem,
     documents: &[PersonalizedDocument],
     interests: &UserInterests,
@@ -51,7 +51,7 @@ pub(super) fn rerank_by_interest(
     )
 }
 
-pub(super) fn rerank_by_tag_weight(
+fn rerank_by_tag_weight(
     documents: &[PersonalizedDocument],
     tag_weights: &HashMap<DocumentTag, usize>,
 ) -> HashMap<DocumentId, f32> {

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -45,10 +45,7 @@ use crate::{
     Error,
 };
 
-pub(crate) struct KnnSearchParams<'a, I>
-where
-    I: IntoIterator<Item = &'a DocumentId>,
-{
+pub(crate) struct KnnSearchParams<'a, I> {
     pub(crate) excluded: I,
     pub(crate) embedding: &'a NormalizedEmbedding,
     pub(crate) k_neighbors: usize,
@@ -86,7 +83,7 @@ pub(crate) trait Document {
 
     async fn get_personalized(
         &self,
-        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -26,8 +26,11 @@ use reqwest::{
     Url,
 };
 use secrecy::{ExposeSecret, Secret};
+#[cfg(feature = "ET-3837")]
+use serde::Deserializer;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
+#[cfg(not(feature = "ET-3837"))]
 use sqlx::{Postgres, Transaction};
 use tracing::error;
 use xayn_ai_bert::NormalizedEmbedding;
@@ -215,12 +218,42 @@ impl Client {
 
         self.query_with_bytes(url, post_data).await
     }
+
+    #[cfg(feature = "ET-3837")]
+    async fn get_score(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<HashMap<DocumentId, f32>, Error> {
+        let ids = ids.into_iter();
+        if ids.len() == 0 {
+            return Ok(HashMap::new());
+        }
+
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
+        let body = Some(json!({
+            "query": {
+                "ids" : {
+                    "values": ids.into_iter().collect_vec()
+                }
+            },
+            "_source": false
+        }));
+        let response = self
+            .query_with_json::<_, SearchResponse<NoSource>>(
+                self.create_resource_path(["_search"], None),
+                body,
+            )
+            .await?;
+
+        Ok(response.map(Into::into).unwrap_or_default())
+    }
 }
 
 #[derive(Debug, Deserialize)]
 struct Hit<T> {
     #[serde(rename = "_id")]
     id: DocumentId,
+    #[cfg_attr(feature = "ET-3837", allow(dead_code))]
     #[serde(rename = "_source")]
     source: T,
     #[serde(rename = "_score")]
@@ -237,6 +270,36 @@ struct SearchResponse<T> {
     hits: Hits<T>,
 }
 
+#[cfg(feature = "ET-3837")]
+#[derive(Debug)]
+struct NoSource;
+
+#[cfg(feature = "ET-3837")]
+impl<'de> Deserialize<'de> for NoSource {
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self)
+    }
+}
+
+#[cfg(feature = "ET-3837")]
+impl<S> From<SearchResponse<NoSource>> for HashMap<DocumentId, f32, S>
+where
+    S: BuildHasher + Default,
+{
+    fn from(response: SearchResponse<NoSource>) -> Self {
+        response
+            .hits
+            .hits
+            .into_iter()
+            .map(|hit| (hit.id, hit.score))
+            .collect()
+    }
+}
+
+#[cfg(not(feature = "ET-3837"))]
 #[derive(Debug, Deserialize)]
 struct InteractedDocument {
     embedding: NormalizedEmbedding,
@@ -244,6 +307,7 @@ struct InteractedDocument {
     tags: Vec<DocumentTag>,
 }
 
+#[cfg(not(feature = "ET-3837"))]
 impl From<SearchResponse<InteractedDocument>> for Vec<models::InteractedDocument> {
     fn from(response: SearchResponse<InteractedDocument>) -> Self {
         response
@@ -259,11 +323,13 @@ impl From<SearchResponse<InteractedDocument>> for Vec<models::InteractedDocument
     }
 }
 
+#[cfg(not(feature = "ET-3837"))]
 #[derive(Debug, Deserialize)]
 struct SearchEmbedding {
     embedding: NormalizedEmbedding,
 }
 
+#[cfg(not(feature = "ET-3837"))]
 impl<S> From<SearchResponse<SearchEmbedding>> for HashMap<DocumentId, NormalizedEmbedding, S>
 where
     S: BuildHasher + Default,
@@ -278,6 +344,7 @@ where
     }
 }
 
+#[cfg(not(feature = "ET-3837"))]
 #[derive(Debug, Deserialize)]
 struct PersonalizedDocument {
     #[serde(default)]
@@ -287,6 +354,7 @@ struct PersonalizedDocument {
     tags: Vec<DocumentTag>,
 }
 
+#[cfg(not(feature = "ET-3837"))]
 impl From<SearchResponse<PersonalizedDocument>> for Vec<models::PersonalizedDocument> {
     fn from(response: SearchResponse<PersonalizedDocument>) -> Self {
         response
@@ -318,6 +386,7 @@ fn is_success_status(status: u16, allow_not_found: bool) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(not(feature = "ET-3837"))]
 impl Storage {
     pub(crate) async fn get_interacted_with_transaction(
         &self,
@@ -400,45 +469,70 @@ impl Storage {
 impl storage::Document for Storage {
     async fn get_interacted(
         &self,
-        ids: &[&DocumentId],
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<models::InteractedDocument>, Error> {
-        self.get_interacted_with_transaction(ids, None).await
+        #[cfg(not(feature = "ET-3837"))]
+        return self
+            .get_interacted_with_transaction(&ids.into_iter().collect_vec(), None)
+            .await;
+
+        #[cfg(feature = "ET-3837")]
+        self.get_interacted(ids).await
     }
 
     async fn get_personalized(
         &self,
-        ids: &[&DocumentId],
+        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<models::PersonalizedDocument>, Error> {
-        self.get_personalized_with_transaction(ids, None).await
+        #[cfg(not(feature = "ET-3837"))]
+        return self
+            .get_personalized_with_transaction(&ids.into_iter().collect_vec(), None)
+            .await;
+
+        #[cfg(feature = "ET-3837")]
+        {
+            let ids = ids.into_iter();
+            let scores = self.elastic.get_score(ids.clone()).await?;
+            self.get_personalized(ids, &scores).await
+        }
     }
 
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
-        #[derive(Deserialize)]
-        struct Response {
-            _source: Fields,
-        }
-        #[derive(Deserialize)]
-        struct Fields {
-            embedding: NormalizedEmbedding,
-        }
+        #[cfg(not(feature = "ET-3837"))]
+        return {
+            #[derive(Deserialize)]
+            struct Response {
+                _source: Fields,
+            }
+            #[derive(Deserialize)]
+            struct Fields {
+                embedding: NormalizedEmbedding,
+            }
 
-        self.elastic
-            .query_with_bytes::<Vec<u8>, Response>(
-                self.elastic
-                    .create_resource_path(["_doc", id.as_ref()], [("_source", Some("embedding"))]),
-                None,
-            )
-            .await
-            .map(|opt| opt.map(|resp| resp._source.embedding))
+            self.elastic
+                .query_with_bytes::<Vec<u8>, Response>(
+                    self.elastic.create_resource_path(
+                        ["_doc", id.as_ref()],
+                        [("_source", Some("embedding"))],
+                    ),
+                    None,
+                )
+                .await
+                .map(|opt| opt.map(|resp| resp._source.embedding))
+        };
+
+        #[cfg(feature = "ET-3837")]
+        self.get_embedding(id).await
     }
 
     async fn get_by_embedding<'a>(
         &self,
-        params: KnnSearchParams<'a>,
+        params: KnnSearchParams<'a, impl IntoIterator<Item = &'a DocumentId>>,
     ) -> Result<Vec<models::PersonalizedDocument>, Error> {
-        // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
+        // the existing documents are not filtered in the elastic query to avoid too much work for a
+        // cold path, filtering them afterwards can occasionally lead to less than k results though
         let excluded_ids = json!({
-            "values": params.excluded.iter().map(AsRef::as_ref).collect_vec()
+            "values": params.excluded.into_iter().collect_vec()
         });
         let time = params.time.to_rfc3339();
 
@@ -479,6 +573,11 @@ impl storage::Document for Storage {
             })
         };
 
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
+        #[cfg(not(feature = "ET-3837"))]
+        let source = ["properties", "embedding", "tags"];
+        #[cfg(feature = "ET-3837")]
+        let source = false;
         let mut body = json!({
             "size": params.k_neighbors,
             "knn": {
@@ -488,7 +587,7 @@ impl storage::Document for Storage {
                 "num_candidates": params.num_candidates,
                 "filter": filter
             },
-            "_source": ["properties", "embedding", "tags"]
+            "_source": source
         });
 
         if let Some(min_similarity) = params.min_similarity {
@@ -497,26 +596,42 @@ impl storage::Document for Storage {
                 .insert("min_score".into(), min_similarity.into());
         }
 
-        // the existing documents are not filtered in the elastic query to avoid too much work for a
-        // cold path, filtering them afterwards can occasionally lead to less than k results though
-        let mut documents = self
-            .elastic
-            .query_with_json::<_, SearchResponse<_>>(
-                self.elastic.create_resource_path(["_search"], None),
-                Some(body),
-            )
-            .await?
-            .map(<Vec<models::PersonalizedDocument>>::from)
-            .unwrap_or_default();
-        let ids = self
-            .postgres
-            .documents_exist(&documents.iter().map(|document| &document.id).collect_vec())
-            .await?
-            .into_iter()
-            .collect::<HashSet<_>>();
-        documents.retain(|document| ids.contains(&document.id));
+        #[cfg(not(feature = "ET-3837"))]
+        return {
+            let mut documents = self
+                .elastic
+                .query_with_json::<_, SearchResponse<_>>(
+                    self.elastic.create_resource_path(["_search"], None),
+                    Some(body),
+                )
+                .await?
+                .map(<Vec<models::PersonalizedDocument>>::from)
+                .unwrap_or_default();
+            let ids = self
+                .postgres
+                .documents_exist(&documents.iter().map(|document| &document.id).collect_vec())
+                .await?
+                .into_iter()
+                .collect::<HashSet<_>>();
+            documents.retain(|document| ids.contains(&document.id));
 
-        Ok(documents)
+            Ok(documents)
+        };
+
+        #[cfg(feature = "ET-3837")]
+        {
+            let scores = self
+                .elastic
+                .query_with_json::<_, SearchResponse<NoSource>>(
+                    self.elastic.create_resource_path(["_search"], None),
+                    Some(body),
+                )
+                .await?
+                .map(HashMap::from)
+                .unwrap_or_default();
+
+            self.get_personalized(scores.keys(), &scores).await
+        }
     }
 
     async fn insert(
@@ -589,47 +704,46 @@ impl storage::Document for Storage {
         }
     }
 
-    async fn delete(&self, documents: &[DocumentId]) -> Result<(), DeletionError> {
-        if documents.is_empty() {
+    async fn delete(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<(), DeletionError> {
+        let ids = ids.into_iter();
+        if ids.len() == 0 {
             return Ok(());
         }
 
-        self.postgres.delete_documents(documents).await?;
+        let mut failed_documents = match self.postgres.delete_documents(ids.clone()).await {
+            Ok(()) => Vec::new(),
+            Err(DeletionError::PartialFailure { errors }) => errors,
+            Err(error) => return Err(error),
+        };
 
         let response = self
             .elastic
-            .bulk_request(
-                documents
-                    .iter()
-                    .map(|document_id| Ok(BulkInstruction::Delete { id: document_id })),
-            )
+            .bulk_request(ids.map(|id| Ok(BulkInstruction::Delete { id })))
             .await?;
-        let failed_documents = response.errors.then(|| {
-            response
-                .items
-                .into_iter()
-                .filter_map(|mut response| {
-                    if let Some(response) = response.remove("delete") {
-                        if !is_success_status(response.status, true) {
-                            error!(
-                                document_id=%response.id,
-                                error=%response.error,
-                                "Elastic failed to delete document.",
-                            );
-                            return Some(response.id.into());
-                        }
-                    } else {
-                        error!("Bulk delete request contains non delete responses: {response:?}",);
+        if response.errors {
+            for mut response in response.items {
+                if let Some(response) = response.remove("delete") {
+                    if !is_success_status(response.status, true) {
+                        error!(
+                            document_id=%response.id,
+                            error=%response.error,
+                            "Elastic failed to delete document.",
+                        );
+                        failed_documents.push(response.id.into());
                     }
-                    None
-                })
-                .collect_vec()
-        });
+                } else {
+                    error!("Bulk delete request contains non delete responses: {response:?}");
+                }
+            }
+        }
 
-        if let Some(failed_documents) = failed_documents {
-            Err(failed_documents.into())
-        } else {
+        if failed_documents.is_empty() {
             Ok(())
+        } else {
+            Err(failed_documents.into())
         }
     }
 }

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -255,7 +255,7 @@ impl storage::Document for Storage {
 
     async fn get_personalized(
         &self,
-        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
         let documents = self.documents.read().await;
         let documents = ids

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -36,11 +36,13 @@ use sqlx::{
 };
 use tracing::{info, instrument, warn};
 use xayn_ai_bert::NormalizedEmbedding;
+#[cfg(feature = "ET-3837")]
+use xayn_ai_coi::nan_safe_f32_cmp_desc;
 use xayn_ai_coi::{CoiId, CoiStats, NegativeCoi, PositiveCoi, UserInterests};
 
 use super::InteractionUpdateContext;
 #[cfg(feature = "ET-3837")]
-use crate::models::IngestedDocument;
+use crate::models::{DocumentProperties, IngestedDocument, PersonalizedDocument};
 use crate::{
     error::common::DocumentIdAsObject,
     models::{DocumentId, DocumentTag, InteractedDocument, UserId, UserInteractionType},
@@ -140,6 +142,23 @@ pub(crate) struct Database {
     pool: Pool<Postgres>,
 }
 
+#[cfg(feature = "ET-3837")]
+#[derive(FromRow)]
+struct QueriedInteractedDocument {
+    document_id: DocumentId,
+    tags: Vec<DocumentTag>,
+    embedding: NormalizedEmbedding,
+}
+
+#[cfg(feature = "ET-3837")]
+#[derive(FromRow)]
+struct QueriedPersonalizedDocument {
+    document_id: DocumentId,
+    properties: Json<DocumentProperties>,
+    tags: Vec<DocumentTag>,
+    embedding: NormalizedEmbedding,
+}
+
 impl Database {
     // https://docs.rs/sqlx/latest/sqlx/struct.QueryBuilder.html#note-database-specific-limits
     const BIND_LIMIT: usize = 65_535;
@@ -214,35 +233,41 @@ impl Database {
         Ok(())
     }
 
-    pub(crate) async fn delete_documents(&self, ids: &[DocumentId]) -> Result<(), DeletionError> {
+    pub(super) async fn delete_documents(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<(), DeletionError> {
         let mut tx = self.pool.begin().await?;
 
-        let documents = self
-            .documents_exist_with_transaction(&ids.iter().collect_vec(), &mut tx)
-            .await?;
         let mut builder = QueryBuilder::new("DELETE FROM document WHERE document_id IN ");
-        for ids in ids.chunks(Self::BIND_LIMIT) {
-            builder
-                .reset()
-                .push_tuple(ids)
-                .build()
-                .persistent(false)
-                .execute(&mut tx)
-                .await?;
+        let all = ids.into_iter();
+        let mut deleted = Vec::with_capacity(all.len());
+        let mut ids = all.clone().peekable();
+        while ids.peek().is_some() {
+            deleted.extend(
+                builder
+                    .reset()
+                    .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
+                    .push(" RETURNING document_id;")
+                    .build()
+                    .persistent(false)
+                    .try_map(|row| DocumentId::from_row(&row))
+                    .fetch_all(&mut tx)
+                    .await?,
+            );
         }
 
         tx.commit().await?;
 
-        if documents.len() == ids.len() {
+        if deleted.len() == all.len() {
             Ok(())
         } else {
-            let errors = ids
-                .iter()
+            Err(all
                 .collect::<HashSet<_>>()
-                .difference(&documents.iter().collect::<HashSet<_>>())
+                .difference(&deleted.iter().collect::<HashSet<_>>())
                 .map(|id| DocumentIdAsObject { id: id.to_string() })
-                .collect_vec();
-            Err(DeletionError::PartialFailure { errors })
+                .collect_vec()
+                .into())
         }
     }
 
@@ -255,6 +280,7 @@ impl Database {
             .map_err(Into::into)
     }
 
+    #[cfg(not(feature = "ET-3837"))]
     pub(super) async fn documents_exist(
         &self,
         ids: &[&DocumentId],
@@ -265,6 +291,7 @@ impl Database {
         Ok(res)
     }
 
+    #[cfg(not(feature = "ET-3837"))]
     pub(super) async fn documents_exist_with_transaction(
         &self,
         ids: &[&DocumentId],
@@ -285,6 +312,94 @@ impl Database {
             }
         }
         Ok(existing_ids)
+    }
+
+    #[cfg(feature = "ET-3837")]
+    async fn get_interacted(
+        tx: &mut Transaction<'_, Postgres>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<Vec<InteractedDocument>, Error> {
+        let mut builder = QueryBuilder::new(
+            "SELECT document_id, tags, embedding
+            FROM document
+            WHERE document_id IN ",
+        );
+        let mut ids = ids.into_iter().peekable();
+        let mut documents = Vec::with_capacity(ids.len());
+        while ids.peek().is_some() {
+            documents.extend(
+                builder
+                    .reset()
+                    .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
+                    .build()
+                    .try_map(|row| {
+                        QueriedInteractedDocument::from_row(&row).map(|document| {
+                            InteractedDocument {
+                                id: document.document_id,
+                                embedding: document.embedding,
+                                tags: document.tags,
+                            }
+                        })
+                    })
+                    .fetch_all(&mut *tx)
+                    .await?,
+            );
+        }
+
+        Ok(documents)
+    }
+
+    #[cfg(feature = "ET-3837")]
+    async fn get_personalized(
+        tx: &mut Transaction<'_, Postgres>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        scores: &HashMap<DocumentId, f32>,
+    ) -> Result<Vec<PersonalizedDocument>, Error> {
+        let mut builder = QueryBuilder::new(
+            "SELECT document_id, properties, tags, embedding
+            FROM document
+            WHERE document_id IN ",
+        );
+        let ids = ids.into_iter();
+        let mut documents = Vec::with_capacity(ids.len());
+        let mut ids = ids.filter(|id| scores.contains_key(id)).peekable();
+        while ids.peek().is_some() {
+            documents.extend(
+                builder
+                    .reset()
+                    .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
+                    .build()
+                    .try_map(|row| {
+                        QueriedPersonalizedDocument::from_row(&row).map(|document| {
+                            let score = scores[&document.document_id];
+                            PersonalizedDocument {
+                                id: document.document_id,
+                                score,
+                                embedding: document.embedding,
+                                properties: document.properties.0,
+                                tags: document.tags,
+                            }
+                        })
+                    })
+                    .fetch_all(&mut *tx)
+                    .await?,
+            );
+        }
+        documents.sort_unstable_by(|a, b| nan_safe_f32_cmp_desc(&scores[&a.id], &scores[&b.id]));
+
+        Ok(documents)
+    }
+
+    #[cfg(feature = "ET-3837")]
+    async fn get_embedding(
+        tx: &mut Transaction<'_, Postgres>,
+        id: &DocumentId,
+    ) -> Result<Option<NormalizedEmbedding>, Error> {
+        sqlx::query_as("SELECT embedding FROM document WHERE document_id = $1;")
+            .bind(id)
+            .fetch_optional(tx)
+            .await
+            .map_err(Into::into)
     }
 
     async fn acquire_user_coi_lock(
@@ -468,6 +583,43 @@ impl Database {
     }
 }
 
+#[cfg(feature = "ET-3837")]
+impl Storage {
+    pub(super) async fn get_interacted(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<Vec<InteractedDocument>, Error> {
+        let mut tx = self.postgres.pool.begin().await?;
+        let documents = Database::get_interacted(&mut tx, ids).await?;
+        tx.commit().await?;
+
+        Ok(documents)
+    }
+
+    pub(super) async fn get_personalized(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        scores: &HashMap<DocumentId, f32>,
+    ) -> Result<Vec<PersonalizedDocument>, Error> {
+        let mut tx = self.postgres.pool.begin().await?;
+        let documents = Database::get_personalized(&mut tx, ids, scores).await?;
+        tx.commit().await?;
+
+        Ok(documents)
+    }
+
+    pub(super) async fn get_embedding(
+        &self,
+        id: &DocumentId,
+    ) -> Result<Option<NormalizedEmbedding>, Error> {
+        let mut tx = self.postgres.pool.begin().await?;
+        let embedding = Database::get_embedding(&mut tx, id).await?;
+        tx.commit().await?;
+
+        Ok(embedding)
+    }
+}
+
 #[derive(FromRow)]
 struct QueriedCoi {
     coi_id: CoiId,
@@ -533,23 +685,36 @@ impl storage::Interaction for Storage {
         Ok(())
     }
 
-    async fn update_interactions<F>(
+    async fn update_interactions(
         &self,
         user_id: &UserId,
-        updated_document_ids: &[&DocumentId],
+        interactions: impl IntoIterator<
+            IntoIter = impl Clone + ExactSizeIterator<Item = &(DocumentId, UserInteractionType)>,
+        >,
         store_user_history: bool,
         time: DateTime<Utc>,
-        mut update_logic: F,
-    ) -> Result<(), Error>
-    where
-        F: for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi + Sync,
-    {
+        mut update_logic: impl for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> PositiveCoi,
+    ) -> Result<(), Error> {
         let mut tx = self.postgres.pool.begin().await?;
         Database::acquire_user_coi_lock(&mut tx, user_id).await?;
 
+        let interactions = interactions.into_iter();
+        #[cfg(not(feature = "ET-3837"))]
         let documents = self
-            .get_interacted_with_transaction(updated_document_ids, Some(&mut tx))
+            .get_interacted_with_transaction(
+                &interactions
+                    .clone()
+                    .map(|(document_id, _)| document_id)
+                    .collect_vec(),
+                Some(&mut tx),
+            )
             .await?;
+        #[cfg(feature = "ET-3837")]
+        let documents = Database::get_interacted(
+            &mut tx,
+            interactions.clone().map(|(document_id, _)| document_id),
+        )
+        .await?;
         let document_map = documents
             .iter()
             .map(|document| (&document.id, (document, UserInteractionType::Positive)))
@@ -562,10 +727,11 @@ impl storage::Interaction for Storage {
 
         let mut interests = Database::get_user_interests(&mut tx, user_id).await?;
         let mut updates = HashMap::new();
-        for id in updated_document_ids {
-            if let Some((document, _)) = document_map.get(id) {
+        for &(ref document_id, interaction_type) in interactions {
+            if let Some((document, _)) = document_map.get(document_id) {
                 let updated_coi = update_logic(InteractionUpdateContext {
                     document,
+                    interaction_type,
                     tag_weight_diff: &mut tag_weight_diff,
                     positive_cois: &mut interests.positive,
                     time,
@@ -574,7 +740,7 @@ impl storage::Interaction for Storage {
                 // if we do we only want to keep the latest update.
                 updates.insert(updated_coi.id, updated_coi);
             } else {
-                warn!(%id, "interacted document doesn't exist");
+                warn!(%document_id, "interacted document doesn't exist");
             }
         }
 

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -12,28 +12,55 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use reqwest::StatusCode;
+use std::collections::HashMap;
+
+use reqwest::{Client, StatusCode, Url};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use xayn_integration_tests::{send_assert, test_app, unchanged_config};
+use xayn_integration_tests::{send_assert, send_assert_json, test_app, unchanged_config};
+use xayn_test_utils::error::Panic;
 use xayn_web_api::Ingestion;
+
+async fn ingest(client: &Client, url: &Url) -> Result<(), Panic> {
+    send_assert(
+        client,
+        client
+            .post(url.join("/documents")?)
+            .json(&json!({
+                "documents": [
+                    { "id": "d1", "snippet": "once in a spring there was a fall" },
+                    { "id": "d2", "snippet": "fall in a once" }
+                ]
+            }))
+            .build()?,
+        StatusCode::CREATED,
+    )
+    .await;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+enum Kind {
+    DocumentNotFound,
+    FailedToDeleteSomeDocuments,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+enum Details {
+    #[serde(rename = "errors")]
+    Deletion(Vec<HashMap<String, String>>),
+}
+
+#[derive(Deserialize)]
+struct Error {
+    kind: Kind,
+    details: Option<Details>,
+}
 
 #[tokio::test]
 async fn test_ingestion() {
     test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
-        send_assert(
-            &client,
-            client
-                .post(url.join("/documents")?)
-                .json(&json!({
-                    "documents": [
-                        { "id": "d1", "snippet": "once in a spring there was a fall" },
-                        { "id": "d2", "snippet": "fall in a once" }
-                    ]
-                }))
-                .build()?,
-            StatusCode::CREATED,
-        )
-        .await;
+        ingest(&client, &url).await?;
         send_assert(
             &client,
             client.get(url.join("/documents/d1/properties")?).build()?,
@@ -46,12 +73,43 @@ async fn test_ingestion() {
             StatusCode::OK,
         )
         .await;
-        send_assert(
+        let error = send_assert_json::<Error>(
             &client,
             client.get(url.join("/documents/d3/properties")?).build()?,
             StatusCode::BAD_REQUEST,
         )
         .await;
+        assert_eq!(error.kind, Kind::DocumentNotFound);
+        assert!(error.details.is_none());
+        Ok(())
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_deletion() {
+    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        ingest(&client, &url).await?;
+        send_assert(
+            &client,
+            client.delete(url.join("/documents/d1")?).build()?,
+            StatusCode::NO_CONTENT,
+        )
+        .await;
+        let error = send_assert_json::<Error>(
+            &client,
+            client
+                .delete(url.join("/documents")?)
+                .json(&json!({ "documents": ["d1", "d2"] }))
+                .build()?,
+            StatusCode::BAD_REQUEST,
+        )
+        .await;
+        assert_eq!(error.kind, Kind::FailedToDeleteSomeDocuments);
+        assert_eq!(
+            error.details.unwrap(),
+            Details::Deletion(vec![[("id".to_string(), "d1".to_string())].into()]),
+        );
         Ok(())
     })
     .await;

--- a/web-api/tests/stateless_personalization.rs
+++ b/web-api/tests/stateless_personalization.rs
@@ -35,7 +35,7 @@ struct StatelessPersonalizedDocumentsResponse {
 }
 
 #[tokio::test]
-async fn test_test_app() {
+async fn test_stateless_personalization() {
     test_two_apps::<Ingestion, Personalization, _>(
         unchanged_config,
         unchanged_config,


### PR DESCRIPTION
**References**

- [ET-3898]
- followed by #829

**Summary**

- get the documents including the embeddings from postgres, only the score comes from elasticsearch if a knn search is done
- use iterators with `&T` items instead of `&[&T]` slices for better ergonomics and less collecting/cloning of large vectors
- fix partial deletion error leftovers from elastic & add test

[ET-3898]: https://xainag.atlassian.net/browse/ET-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ