### PR TITLE
[Merged by Bors] - ET-4004 Return bad request if document does not exists

### DIFF
--- a/discovery_engine_api_tests/tests/back_office/test_actions_with_documents.py
+++ b/discovery_engine_api_tests/tests/back_office/test_actions_with_documents.py
@@ -18,7 +18,6 @@ class TestActionsWithDocuments:
         au.assert_status_code_equals(request.status_code, 204)
 
     @allure.severity(allure.severity_level.NORMAL)
-    @pytest.mark.skip(reason="ET-4004")
     def test_delete_doc_negative(self):
         request = self.api_handler.delete_document(doc_id=tu.generate_random_alphanumerical(10))
         au.assert_status_code_equals(request.status_code, 400)

--- a/discovery_engine_api_tests/tests/test_back_office.py
+++ b/discovery_engine_api_tests/tests/test_back_office.py
@@ -18,7 +18,6 @@ class TestBackOfficeEndpoint:
         au.assert_status_code_equals(docs.status_code, 204)
 
     @allure.severity(allure.severity_level.NORMAL)
-    @pytest.mark.skip(reason="ET-4004")
     def test_delete_doc_negative(self):
         api_handler = ApiHandler()
         docs = api_handler.delete_document(su.generate_random_alphanumerical(10))

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -79,9 +79,7 @@ paths:
         - back office
       summary: Delete all listed documents.
       description: |-
-        Delete all documents listed in the request body. The endpoint is
-        idempotent. I.e. if the list contains one or multiple non-existing
-        documents, no error is produced.
+        Delete all documents listed in the request body.
       operationId: deleteDocuments
       requestBody:
         required: true
@@ -103,8 +101,7 @@ paths:
         - back office
       summary: Delete the document from the system.
       description: |-
-        Permanently deletes the document from the system. The endpoint is
-        idempotent. Deleting a non-existing document does not produce an error.
+        Permanently deletes the document from the system.
       operationId: deleteDocument
       responses:
         '204':

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -85,7 +85,7 @@ pub(crate) struct FailedToDeleteSomeDocuments {
     pub(crate) errors: Vec<DocumentIdAsObject>,
 }
 
-impl_application_error!(FailedToDeleteSomeDocuments => INTERNAL_SERVER_ERROR);
+impl_application_error!(FailedToDeleteSomeDocuments => BAD_REQUEST);
 
 /// The ingestion of some documents failed.
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -67,14 +67,10 @@ pub(crate) enum InsertionError {
 
 #[derive(Debug, From)]
 pub(crate) enum DeletionError {
+    #[from(types(sqlx::Error))]
     General(Error),
+    #[from]
     PartialFailure { errors: Vec<DocumentIdAsObject> },
-}
-
-impl From<sqlx::Error> for DeletionError {
-    fn from(e: sqlx::Error) -> Self {
-        DeletionError::General(e.into())
-    }
 }
 
 #[async_trait(?Send)]

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -71,6 +71,12 @@ pub(crate) enum DeletionError {
     PartialFailure { errors: Vec<DocumentIdAsObject> },
 }
 
+impl From<sqlx::Error> for DeletionError {
+    fn from(e: sqlx::Error) -> Self {
+        DeletionError::General(e.into())
+    }
+}
+
 #[async_trait(?Send)]
 pub(crate) trait Document {
     async fn get_interacted(&self, ids: &[&DocumentId]) -> Result<Vec<InteractedDocument>, Error>;


### PR DESCRIPTION
Return an error if some of the documents do not exist.
The documentation was mentioning that the endpoint does not return an error and then contradicts itself by stating that it could return 400. The part around the idempotency of the method was also wrong. Being idempotent does not mean that a method does not return an error if something does not exist.
The HTTP standard requires DELETE methods to be idempotent and it specify that it is in respect to the state of the server not the response. 
```
A request method is considered "idempotent" if the intended EFFECT ON THE SERVER of multiple identical requests with that method is the same as the effect for a single such request. Of the request methods defined by this specification, PUT, DELETE, and safe request methods are idempotent.
```

Returning an error makes `DELETE /documents/<id>` behaving like `GET /documents/<id>`  where we return 400 if the document does not exists.