### PR TITLE
Modularize mind code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.69"
 criterion = "0.4.0"
 csv = "1.1.6"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "serde", "std"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "display", "from", "into"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "deref", "deref_mut", "display", "from", "into"] }
 displaydoc = "0.2.3"
 figment = "0.10.8"
 itertools = "0.10.5"

--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -28,13 +28,7 @@ use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
 use crate::{
     mind::{
-        config::{
-            create_grid_search_configs,
-            GridSearchConfig,
-            PersonaBasedConfig,
-            SaturationConfig,
-            StateConfig,
-        },
+        config::{GridSearchConfig, PersonaBasedConfig, SaturationConfig, StateConfig},
         data::{
             read,
             score_documents,
@@ -61,7 +55,7 @@ async fn run_persona_benchmark() -> Result<(), Error> {
     let state = State::new(Storage::default(), StateConfig::default()).unwrap();
     // load documents from document provider to state
     state
-        .insert(document_provider.documents.values().cloned().collect_vec())
+        .insert(document_provider.values().cloned().collect_vec())
         .await
         .unwrap();
     let benchmark_config = PersonaBasedConfig::default();
@@ -240,7 +234,7 @@ async fn run_saturation_benchmark() -> Result<(), Error> {
     let state = State::new(Storage::default(), StateConfig::default()).unwrap();
     // load documents from document provider to state
     state
-        .insert(document_provider.documents.values().cloned().collect_vec())
+        .insert(document_provider.values().cloned().collect_vec())
         .await
         .unwrap();
     let benchmark_config = SaturationConfig::default();
@@ -310,12 +304,12 @@ async fn run_saturation_benchmark() -> Result<(), Error> {
                 .unwrap();
 
             // add results to the topic result
-            topic_result.iterations.push(SaturationIteration {
+            topic_result.push(SaturationIteration {
                 shown_documents: personalised_documents,
                 clicked_documents: to_be_clicked,
             });
         }
-        results.topics.push(topic_result);
+        results.push(topic_result);
     }
     //save results to json file
     let file = File::create("saturation_results.json")?;
@@ -332,7 +326,7 @@ async fn run_persona_hot_news_benchmark() -> Result<(), Error> {
     let state = State::new(Storage::default(), StateConfig::default()).unwrap();
     // load documents from document provider to state
     state
-        .insert(document_provider.documents.values().cloned().collect_vec())
+        .insert(document_provider.values().cloned().collect_vec())
         .await
         .unwrap();
     let benchmark_config = PersonaBasedConfig::default();
@@ -430,7 +424,7 @@ async fn grid_search_for_best_parameters() -> Result<(), Error> {
     let users_interests = Users::new("user_categories_sample.json")?;
     let document_provider = DocumentProvider::new("news.tsv")?;
     let grid_search_config = GridSearchConfig::default();
-    let configs = create_grid_search_configs(&grid_search_config);
+    let configs = grid_search_config.create_state_configs();
     let mut state = State::new(Storage::default(), StateConfig::default()).unwrap();
     state
         .insert(document_provider.to_documents())

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -18,7 +18,7 @@ use xayn_ai_coi::CoiConfig;
 
 use crate::personalization::PersonalizationConfig;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Debug, Serialize)]
 pub(super) struct StateConfig {
     pub(super) coi: CoiConfig,
     pub(super) personalization: PersonalizationConfig,
@@ -35,6 +35,7 @@ impl Default for StateConfig {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct GridSearchConfig {
     pub(super) thresholds: Vec<f32>,
     pub(super) shifts: Vec<f32>,
@@ -61,37 +62,34 @@ impl Default for GridSearchConfig {
     }
 }
 
-pub(super) fn create_grid_search_configs(
-    grid_search_config: &GridSearchConfig,
-) -> Vec<StateConfig> {
-    let mut configs = Vec::with_capacity(
-        grid_search_config.thresholds.len()
-            * grid_search_config.shifts.len()
-            * grid_search_config.min_pos_cois.len(),
-    );
+impl GridSearchConfig {
+    pub(super) fn create_state_configs(&self) -> Vec<StateConfig> {
+        let mut configs =
+            Vec::with_capacity(self.thresholds.len() * self.shifts.len() * self.min_pos_cois.len());
+        let start_time = Utc::now();
 
-    let start_time = Utc::now();
-
-    for t in &grid_search_config.thresholds {
-        for s in &grid_search_config.shifts {
-            for m in &grid_search_config.min_pos_cois {
-                configs.push(StateConfig {
-                    coi: {
-                        CoiConfig::default()
-                            .with_shift_factor(*s)
-                            .unwrap()
-                            .with_threshold(*t)
-                            .unwrap()
-                            .with_min_positive_cois(*m)
-                            .unwrap()
-                    },
-                    personalization: PersonalizationConfig::default(),
-                    time: start_time,
-                });
+        for &threshold in &self.thresholds {
+            for &shift_factor in &self.shifts {
+                for &min_positive_cois in &self.min_pos_cois {
+                    configs.push(StateConfig {
+                        coi: {
+                            CoiConfig::default()
+                                .with_shift_factor(shift_factor)
+                                .unwrap()
+                                .with_threshold(threshold)
+                                .unwrap()
+                                .with_min_positive_cois(min_positive_cois)
+                                .unwrap()
+                        },
+                        personalization: PersonalizationConfig::default(),
+                        time: start_time,
+                    });
+                }
             }
         }
+
+        configs
     }
-    configs
 }
 
 /// The config of hyperparameters for the persona based benchmark.

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -15,6 +15,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use xayn_ai_coi::CoiConfig;
+use xayn_test_utils::error::Panic;
 
 use crate::personalization::PersonalizationConfig;
 
@@ -63,7 +64,7 @@ impl Default for GridSearchConfig {
 }
 
 impl GridSearchConfig {
-    pub(super) fn create_state_configs(&self) -> Vec<StateConfig> {
+    pub(super) fn create_state_configs(&self) -> Result<Vec<StateConfig>, Panic> {
         let mut configs =
             Vec::with_capacity(self.thresholds.len() * self.shifts.len() * self.min_pos_cois.len());
         let start_time = Utc::now();
@@ -74,12 +75,9 @@ impl GridSearchConfig {
                     configs.push(StateConfig {
                         coi: {
                             CoiConfig::default()
-                                .with_shift_factor(shift_factor)
-                                .unwrap()
-                                .with_threshold(threshold)
-                                .unwrap()
-                                .with_min_positive_cois(min_positive_cois)
-                                .unwrap()
+                                .with_shift_factor(shift_factor)?
+                                .with_threshold(threshold)?
+                                .with_min_positive_cois(min_positive_cois)?
                         },
                         personalization: PersonalizationConfig::default(),
                         time: start_time,
@@ -88,7 +86,7 @@ impl GridSearchConfig {
             }
         }
 
-        configs
+        Ok(configs)
     }
 }
 

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -1,0 +1,138 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use xayn_ai_coi::CoiConfig;
+
+use crate::personalization::PersonalizationConfig;
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct StateConfig {
+    pub(super) coi: CoiConfig,
+    pub(super) personalization: PersonalizationConfig,
+    pub(super) time: DateTime<Utc>,
+}
+
+impl Default for StateConfig {
+    fn default() -> Self {
+        Self {
+            coi: CoiConfig::default(),
+            personalization: PersonalizationConfig::default(),
+            time: Utc::now(),
+        }
+    }
+}
+
+pub(super) struct GridSearchConfig {
+    pub(super) thresholds: Vec<f32>,
+    pub(super) shifts: Vec<f32>,
+    pub(super) min_pos_cois: Vec<usize>,
+    pub(super) click_probability: f64,
+    pub(super) ndocuments: usize,
+    pub(super) iterations: usize,
+    pub(super) nranks: Vec<usize>,
+    pub(super) is_semi_interesting: bool,
+}
+
+impl Default for GridSearchConfig {
+    fn default() -> Self {
+        Self {
+            thresholds: vec![0.67, 0.7, 0.75, 0.8, 0.85, 0.9],
+            shifts: vec![0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4],
+            min_pos_cois: vec![1],
+            click_probability: 0.2,
+            ndocuments: 100,
+            iterations: 10,
+            nranks: vec![3, 5],
+            is_semi_interesting: false,
+        }
+    }
+}
+
+pub(super) fn create_grid_search_configs(
+    grid_search_config: &GridSearchConfig,
+) -> Vec<StateConfig> {
+    let mut configs = Vec::with_capacity(
+        grid_search_config.thresholds.len()
+            * grid_search_config.shifts.len()
+            * grid_search_config.min_pos_cois.len(),
+    );
+
+    let start_time = Utc::now();
+
+    for t in &grid_search_config.thresholds {
+        for s in &grid_search_config.shifts {
+            for m in &grid_search_config.min_pos_cois {
+                configs.push(StateConfig {
+                    coi: {
+                        CoiConfig::default()
+                            .with_shift_factor(*s)
+                            .unwrap()
+                            .with_threshold(*t)
+                            .unwrap()
+                            .with_min_positive_cois(*m)
+                            .unwrap()
+                    },
+                    personalization: PersonalizationConfig::default(),
+                    time: start_time,
+                });
+            }
+        }
+    }
+    configs
+}
+
+/// The config of hyperparameters for the persona based benchmark.
+#[derive(Debug, Deserialize)]
+pub(super) struct PersonaBasedConfig {
+    pub(super) click_probability: f64,
+    pub(super) ndocuments: usize,
+    pub(super) iterations: usize,
+    pub(super) amount_of_doc_used_to_prepare: usize,
+    pub(super) nranks: Vec<usize>,
+    pub(super) ndocuments_hot_news: usize,
+    pub(super) is_semi_interesting: bool,
+}
+
+impl Default for PersonaBasedConfig {
+    fn default() -> Self {
+        Self {
+            click_probability: 0.2,
+            ndocuments: 100,
+            iterations: 10,
+            amount_of_doc_used_to_prepare: 1,
+            nranks: vec![3, 5],
+            ndocuments_hot_news: 15,
+            is_semi_interesting: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct SaturationConfig {
+    pub(super) click_probability: f64,
+    pub(super) ndocuments: usize,
+    pub(super) iterations: usize,
+}
+
+impl Default for SaturationConfig {
+    fn default() -> Self {
+        Self {
+            click_probability: 0.2,
+            ndocuments: 30,
+            iterations: 10,
+        }
+    }
+}

--- a/web-api/src/mind/data.rs
+++ b/web-api/src/mind/data.rs
@@ -1,0 +1,252 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, fs::File, io, io::Write, path::Path};
+
+use anyhow::Error;
+use csv::{DeserializeRecordsIntoIter, Reader, ReaderBuilder};
+use derive_more::Deref;
+use itertools::Itertools;
+use ndarray::{ArrayBase, Data, Dimension};
+use npyz::{AutoSerialize, WriterBuilder};
+use rand::{rngs::StdRng, seq::IteratorRandom, SeedableRng};
+use serde::{de, Deserialize, Deserializer};
+
+use crate::models::{DocumentId, DocumentTag, UserId};
+
+pub(super) fn deserialize_clicked_documents<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<DocumentId>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)?
+        .as_ref()
+        .map(|m| {
+            m.split(' ')
+                .map(|document| DocumentId::new(document).map_err(de::Error::custom))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ViewedDocument {
+    pub(super) document_id: DocumentId,
+    pub(super) was_clicked: bool,
+}
+
+pub(super) fn deserialize_viewed_documents<'de, D>(
+    deserializer: D,
+) -> Result<Vec<ViewedDocument>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?
+        .split(' ')
+        .map(|viewed_document| {
+            viewed_document
+                .split_once('-')
+                .ok_or_else(|| de::Error::custom("missing document id"))
+                .and_then(|(document_id, was_clicked)| {
+                    let document_id = DocumentId::new(document_id).map_err(de::Error::custom)?;
+                    let was_clicked = match was_clicked {
+                        "0" => Ok(false),
+                        "1" => Ok(true),
+                        _ => Err(de::Error::custom("invalid was_clicked")),
+                    }?;
+                    Ok(ViewedDocument {
+                        document_id,
+                        was_clicked,
+                    })
+                })
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct Impression {
+    #[allow(dead_code)]
+    id: String,
+    pub(super) user_id: String,
+    #[allow(dead_code)]
+    time: String,
+    #[serde(deserialize_with = "deserialize_clicked_documents")]
+    pub(super) clicks: Option<Vec<DocumentId>>,
+    #[serde(deserialize_with = "deserialize_viewed_documents")]
+    pub(super) news: Vec<ViewedDocument>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct Document {
+    pub(super) id: DocumentId,
+    pub(super) category: DocumentTag,
+    pub(super) subcategory: DocumentTag,
+    #[allow(dead_code)]
+    title: String,
+    pub(super) snippet: String,
+    #[allow(dead_code)]
+    url: String,
+}
+
+impl Document {
+    /// Checks if the document is of interest to the user.
+    pub(super) fn is_interesting(&self, user_interests: &[String]) -> bool {
+        user_interests.iter().any(|interest| {
+            let (main_category, sub_category) = interest.split_once('/').unwrap();
+            self.category.as_ref() == main_category || self.subcategory.as_ref() == sub_category
+        })
+    }
+
+    /// Checks if only the main category is matching user's interests
+    pub(super) fn is_semi_interesting(&self, user_interests: &[String]) -> bool {
+        user_interests.iter().any(|interest| {
+            let (main_category, sub_category) = interest.split_once('/').unwrap();
+            self.category.as_ref() == main_category || self.subcategory.as_ref() != sub_category
+        })
+    }
+}
+
+/// Assigns a score to a vector of documents based on the user's interests.
+///
+/// The score is equal to 2 if the document is of interest to the user, 0 otherwise.
+/// if the flag is set to true, the score is equal to 1 if the document is semi interesting to the user, 0 otherwise
+pub(super) fn score_documents(
+    documents: &[&Document],
+    user_interests: &[String],
+    is_semi_interesting: bool,
+) -> Vec<f32> {
+    documents
+        .iter()
+        .map(|document| {
+            if document.is_interesting(user_interests) {
+                2.0
+            } else if is_semi_interesting && document.is_semi_interesting(user_interests) {
+                1.0
+            } else {
+                0.0
+            }
+        })
+        .collect_vec()
+}
+
+fn read_from_tsv<P>(path: P) -> Result<Reader<File>, Error>
+where
+    P: AsRef<Path>,
+{
+    ReaderBuilder::new()
+        .delimiter(b'\t')
+        .has_headers(false)
+        .flexible(true)
+        .from_path(path)
+        .map_err(Into::into)
+}
+
+pub(super) fn read<T>(path: &str) -> Result<DeserializeRecordsIntoIter<File, T>, Error>
+where
+    for<'de> T: Deserialize<'de>,
+{
+    Ok(read_from_tsv(path)?.into_deserialize())
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct DocumentProvider {
+    pub(super) documents: HashMap<DocumentId, Document>,
+}
+
+impl DocumentProvider {
+    pub(super) fn new(path: &str) -> Result<Self, Error> {
+        let documents = read::<Document>(path)?
+            .map(|document| document.map(|document| (document.id.clone(), document)))
+            .try_collect()?;
+        Ok(Self { documents })
+    }
+
+    pub(super) fn sample(&self, n: usize) -> Vec<&Document> {
+        self.documents
+            .values()
+            .choose_multiple(&mut StdRng::seed_from_u64(42), n)
+    }
+
+    pub(super) fn get(&self, id: &DocumentId) -> Option<&Document> {
+        self.documents.get(id)
+    }
+
+    pub(super) fn to_documents(&self) -> Vec<Document> {
+        self.documents.values().cloned().collect()
+    }
+
+    /// Gets all documents that matches user's interest.
+    pub(super) fn get_all_interest(&self, interests: &[String]) -> Vec<&Document> {
+        self.documents
+            .values()
+            .filter(|doc| doc.is_interesting(interests))
+            .collect()
+    }
+}
+
+#[derive(Debug, Deref, Deserialize)]
+pub(super) struct SpecificTopics(Vec<String>);
+
+impl SpecificTopics {
+    pub(super) fn new(path: &str) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let topics = serde_json::from_reader::<_, Vec<String>>(file)?;
+        Ok(Self(topics))
+    }
+}
+
+#[derive(Debug, Deref, Deserialize)]
+pub(super) struct Users(HashMap<UserId, Vec<String>>);
+
+impl Users {
+    /// Reads the users interests from a json file.
+    pub(super) fn new(path: &str) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        let json = serde_json::from_reader::<_, serde_json::Value>(file)?;
+        let map = json.as_object().unwrap();
+        // iterate over map and create a map of user ids and their interests
+        Ok(Users(
+            map.iter()
+                .map(|(user_id, interests)| {
+                    let interests = interests
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|interest| interest.as_str().unwrap().to_string())
+                        .collect();
+                    (UserId::new(user_id).unwrap(), interests)
+                })
+                .collect(),
+        ))
+    }
+}
+
+pub(super) fn write_array<T, S, D>(writer: impl Write, array: &ArrayBase<S, D>) -> io::Result<()>
+where
+    T: Clone + AutoSerialize,
+    S: Data<Elem = T>,
+    D: Dimension,
+{
+    let shape = array.shape().iter().map(|&x| x as u64).collect_vec();
+    let c_order_items = array.iter();
+
+    let mut writer = npyz::WriteOptions::new()
+        .default_dtype()
+        .shape(&shape)
+        .writer(writer)
+        .begin_nd()?;
+    writer.extend(c_order_items)?;
+    writer.finish()
+}

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -1,0 +1,228 @@
+// Copyright 2022 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use anyhow::Error;
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use serde::Serialize;
+use xayn_ai_bert::NormalizedEmbedding;
+use xayn_ai_coi::{nan_safe_f32_cmp_desc, CoiConfig, CoiSystem};
+
+use crate::{
+    embedding::{self, Embedder},
+    mind::{config::StateConfig, data::Document},
+    models::{DocumentId, DocumentProperties, IngestedDocument, UserId, UserInteractionType},
+    personalization::{
+        routes::{personalize_documents_by, update_interactions, PersonalizeBy},
+        PersonalizationConfig,
+    },
+    storage::{self, memory::Storage},
+};
+
+pub(super) struct State {
+    storage: Storage,
+    embedder: Embedder,
+    pub(super) coi: CoiSystem,
+    personalization: PersonalizationConfig,
+    pub(super) time: DateTime<Utc>,
+}
+
+impl State {
+    pub(super) fn new(storage: Storage, config: StateConfig) -> Result<Self, Error> {
+        let embedder = Embedder::load(&embedding::Config {
+            directory: "../assets/smbert_v0003".into(),
+            ..embedding::Config::default()
+        })?;
+
+        let coi = config.coi.build();
+        let personalization = config.personalization;
+        let time = config.time;
+
+        Ok(Self {
+            storage,
+            embedder,
+            coi,
+            personalization,
+            time,
+        })
+    }
+
+    pub(super) fn with_coi_config(&mut self, config: CoiConfig) {
+        self.coi = config.build();
+    }
+
+    pub(super) async fn insert(&self, documents: Vec<Document>) -> Result<(), Error> {
+        let documents = documents
+            .into_iter()
+            .map(|document| {
+                let document = IngestedDocument {
+                    id: document.id,
+                    snippet: document.snippet,
+                    properties: DocumentProperties::default(),
+                    tags: vec![document.category, document.subcategory],
+                };
+                let embedding = self.embedder.run(&document.snippet)?;
+
+                Ok((document, embedding))
+            })
+            .try_collect::<_, _, Error>()?;
+
+        storage::Document::insert(&self.storage, documents)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[allow(dead_code)]
+    pub(super) async fn update(
+        &self,
+        embeddings: Vec<(DocumentId, NormalizedEmbedding)>,
+    ) -> Result<(), Error> {
+        let mut documents =
+            storage::Document::get_personalized(&self.storage, embeddings.iter().map(|(id, _)| id))
+                .await?
+                .into_iter()
+                .map(|document| (document.id.clone(), document))
+                .collect::<HashMap<_, _>>();
+        let documents = embeddings
+            .into_iter()
+            .map(|(id, embedding)| {
+                let document = documents.remove(&id).unwrap(/* document must already exist */);
+                let document = IngestedDocument {
+                    id,
+                    snippet: String::new(/* unused for in-memory db */),
+                    properties: document.properties,
+                    tags: document.tags,
+                };
+                (document, embedding)
+            })
+            .collect_vec();
+        storage::Document::insert(&self.storage, documents).await?;
+
+        Ok(())
+    }
+
+    pub(super) async fn interact(
+        &self,
+        user: &UserId,
+        documents: impl IntoIterator<Item = (&DocumentId, DateTime<Utc>)>,
+    ) -> Result<(), Error> {
+        for (id, time) in documents {
+            update_interactions(
+                &self.storage,
+                &self.coi,
+                user,
+                [&(id.clone(), UserInteractionType::Positive)],
+                self.personalization.store_user_history,
+                time,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) async fn personalize(
+        &self,
+        user: &UserId,
+        by: PersonalizeBy<'_>,
+        time: DateTime<Utc>,
+    ) -> Result<Option<Vec<DocumentId>>, Error> {
+        personalize_documents_by(
+            &self.storage,
+            &self.coi,
+            user,
+            &self.personalization,
+            by,
+            time,
+        )
+        .await
+        .map(|documents| {
+            documents.map(|documents| documents.into_iter().map(|document| document.id).collect())
+        })
+        .map_err(Into::into)
+    }
+}
+
+/// The results of iteration of the saturation benchmark
+#[derive(Debug, Default, Serialize)]
+pub(super) struct SaturationIteration {
+    pub(super) shown_documents: Vec<DocumentId>,
+    pub(super) clicked_documents: Vec<DocumentId>,
+}
+
+/// The results of the saturation benchmark for one topic
+#[derive(Debug, Default, Serialize)]
+pub(super) struct SaturationTopicResult {
+    pub(super) topic: String,
+    pub(super) iterations: Vec<SaturationIteration>,
+}
+
+impl SaturationTopicResult {
+    pub(super) fn new(topic: &str, iterations: usize) -> Self {
+        Self {
+            topic: topic.to_owned(),
+            iterations: Vec::with_capacity(iterations),
+        }
+    }
+}
+
+/// The results of the saturation benchmark
+#[derive(Debug, Default, Serialize)]
+pub(super) struct SaturationResult {
+    pub(super) topics: Vec<SaturationTopicResult>,
+}
+
+impl SaturationResult {
+    pub(super) fn new(topics: usize) -> Self {
+        Self {
+            topics: Vec::with_capacity(topics),
+        }
+    }
+}
+
+pub(super) fn ndcg(relevance: &[f32], k: &[usize]) -> Vec<f32> {
+    let mut optimal_order = relevance.to_owned();
+    optimal_order.sort_by(nan_safe_f32_cmp_desc);
+    let last = k
+        .iter()
+        .max()
+        .copied()
+        .map_or_else(|| relevance.len(), |k| k.min(relevance.len()));
+
+    let ndcgs = relevance
+        .iter()
+        .zip(optimal_order)
+        .take(last)
+        .scan(
+            (1_f32, 0., 0.),
+            |(i, dcg, ideal_dcg), (relevance, optimal_order)| {
+                *i += 1.;
+                let log_i = (*i).log2();
+                *dcg += (2_f32.powf(*relevance) - 1.) / log_i;
+                *ideal_dcg += (2_f32.powf(optimal_order) - 1.) / log_i;
+                Some(*dcg / (*ideal_dcg + 0.00001))
+            },
+        )
+        .collect::<Vec<_>>();
+
+    k.iter()
+        .map(|nrank| match ndcgs.get(*nrank - 1) {
+            Some(i) => i,
+            None => ndcgs.last().unwrap(),
+        })
+        .copied()
+        .collect::<Vec<_>>()
+}

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
 use serde::Serialize;
 use xayn_ai_bert::NormalizedEmbedding;
@@ -156,33 +157,35 @@ impl State {
     }
 }
 
-/// The results of iteration of the saturation benchmark
+/// The results of iteration of the saturation benchmark.
 #[derive(Debug, Default, Serialize)]
 pub(super) struct SaturationIteration {
     pub(super) shown_documents: Vec<DocumentId>,
     pub(super) clicked_documents: Vec<DocumentId>,
 }
 
-/// The results of the saturation benchmark for one topic
-#[derive(Debug, Default, Serialize)]
+/// The results of the saturation benchmark for one topic.
+#[derive(Debug, Default, Deref, DerefMut, Serialize)]
 pub(super) struct SaturationTopicResult {
-    pub(super) topic: String,
-    pub(super) iterations: Vec<SaturationIteration>,
+    topic: String,
+    #[deref]
+    #[deref_mut]
+    iterations: Vec<SaturationIteration>,
 }
 
 impl SaturationTopicResult {
     pub(super) fn new(topic: &str, iterations: usize) -> Self {
         Self {
-            topic: topic.to_owned(),
+            topic: topic.to_string(),
             iterations: Vec::with_capacity(iterations),
         }
     }
 }
 
-/// The results of the saturation benchmark
-#[derive(Debug, Default, Serialize)]
+/// The results of the saturation benchmark.
+#[derive(Debug, Default, Deref, DerefMut, Serialize)]
 pub(super) struct SaturationResult {
-    pub(super) topics: Vec<SaturationTopicResult>,
+    topics: Vec<SaturationTopicResult>,
 }
 
 impl SaturationResult {


### PR DESCRIPTION
**Summary**

- split the mind code into submodules: `config`, `data` & `state`, the benchmarks themselves remain in the main module
- move some free functions into their type impls & improve caller ergonomics
- use `Panic` instead of `anyhow::Error` such that `.unwrap()`s  can be replaced with `?`
