### PR TITLE
[Merged by Bors] - ET-4093 openapi: semantic search with user history

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -239,7 +239,7 @@ components:
     SemanticSearchRequest:
       type: object
       properties:
-        document:
+        document_id:
           $ref: './schemas/document.yml#/DocumentId'
         count:
           $ref: '#/components/schemas/Count'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -246,15 +246,6 @@ components:
           $ref: '#/components/schemas/Count'
         published_after:
           $ref: './schemas/time.yml#/PublicationDate'
-        exclude_seen:
-          type: boolean
-          default: true
-          description: |
-            If true do not include documents the user has already seen as search candidate.
-
-            A trimmed version of the users history might be used for this filter.
-
-            This option is incompatible with not specifying a user.
         min_similarity:
           description: "Minimal similarity of a document to consider it as search candidate."
           type: number
@@ -262,8 +253,21 @@ components:
           minimum: 0
           maximum: 1
           default: 0
-        user:
-          $ref: './schemas/user.yml#/InputUser'
+        personalize:
+          description: Personalize the ranking of candidates based on a users preferences
+          type: object
+          properties:
+            exclude_seen:
+              type: boolean
+              default: true
+              description: |
+                If true do not include documents the user has already seen as search candidate.
+
+                A trimmed version of the users history might be used for this filter.
+
+                This option is incompatible with not specifying a user.
+            user:
+              $ref: './schemas/user.yml#/InputUser'
     SemanticSearchResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -157,8 +157,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SemanticSearchRequest'
-      parameters:
-        - $ref: './parameters/path/document_id.yml'
       responses:
         '200':
           description: successful operation

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -252,6 +252,8 @@ components:
           description: |
             If true do not include documents the user has already seen as search candidate.
 
+            A trimmed version of the users history might be used for this filter.
+
             This option is incompatible with not specifying a user.
         min_similarity:
           description: "Minimal similarity of a document to consider it as search candidate."

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -246,6 +246,13 @@ components:
           $ref: '#/components/schemas/Count'
         published_after:
           $ref: './schemas/time.yml#/PublicationDate'
+        exclude_seen:
+          type: bool
+          default: true
+          description: |
+            If true do not include documents the user has already seen as search candidate.
+
+            This option is incompatible with not specifying a user.
         min_similarity:
           description: "Minimal similarity of a document to consider it as search candidate."
           type: number

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -238,6 +238,7 @@ components:
               title: "News title"
     SemanticSearchRequest:
       type: object
+      required: [document_id]
       properties:
         document_id:
           $ref: './schemas/document.yml#/DocumentId'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -156,7 +156,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SimilaritySearchRequest'
+              $ref: '#/components/schemas/SemanticSearchRequest'
       parameters:
         - $ref: './parameters/path/document_id.yml'
       responses:
@@ -253,7 +253,7 @@ components:
           maximum: 1
           default: 0
         user:
-          $ref: InputUser
+          $ref: '#/components/schemas/InputUser'
     InputUser:
       description: "A user either specified by id or with they relevant data inlined directly"
       oneOf:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -253,16 +253,7 @@ components:
           maximum: 1
           default: 0
         user:
-          $ref: '#/components/schemas/InputUser'
-    InputUser:
-      description: "A user either specified by id or with they relevant data inlined directly"
-      oneOf:
-        - $ref: './schemas/document.yml#/DocumentId'
-        - type: object
-          required: [history]
-          properties:
-            history:
-              $ref: './schemas/document.yml#/History'
+          $ref: './schemas/user.yml#/InputUser'
     SemanticSearchResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -186,6 +186,32 @@ paths:
                 $ref: '#/components/schemas/SemanticSearchResponse'
         '400':
             $ref: './responses/generic.yml#/BadRequest'
+    post:
+      tags:
+        - front office
+      summary: Returns documents similar to the given document.
+      description: |-
+        Returns a list of documents that are semantically similar to the one given as input.
+        Each document contains the id, the score and the properties.
+        The score is a value between 0 and 1 where a higher value means that the document is more similar to the one in input
+      operationId: getSimilarDocuments2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimilaritySearchRequest'
+      parameters:
+        - $ref: './parameters/path/document_id.yml'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticSearchResponse'
+        '400':
+            $ref: './responses/generic.yml#/BadRequest'
 
 components:
   securitySchemes:
@@ -256,6 +282,31 @@ components:
             score: 0.87
             properties:
               title: "News title"
+    SemanticSearchRequest:
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/Count'
+        published_after:
+          $ref: './schemas/time.yml#/PublicationDate'
+        min_similarity:
+          description: "Minimal similarity of a document to consider it as search candidate."
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 0
+        user:
+          $ref: InputUser
+    InputUser:
+      description: "A user either specified by id or with they relevant data inlined directly"
+      oneOf:
+        - $ref: './schemas/document.yml#/DocumentId'
+        - type: object
+          required: [history]
+          properties:
+            history:
+              $ref: './schemas/document.yml#/History'
     SemanticSearchResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -142,50 +142,6 @@ paths:
                 $ref: '#/components/schemas/UserInteractionError'
 
   /semantic_search/{document_id}:
-    get:
-      tags:
-        - front office
-      summary: Returns documents similar to the given document.
-      description: |-
-        Returns a list of documents that are semantically similar to the one given as input.
-        Each document contains the id, the score and the properties.
-        The score is a value between 0 and 1 where a higher value means that the document is more similar to the one in input
-      operationId: getSimilarDocuments
-      parameters:
-        - $ref: './parameters/path/document_id.yml'
-        - name: count
-          in: query
-          description: Maximum number of semantic similar documents to return
-          required: false
-          schema:
-            $ref: '#/components/schemas/Count'
-        - name: min_similarity
-          in: query
-          description: Minimum similarity a document has to have to be included.
-          required: false
-          schema:
-            type: number
-            format: float
-            minimum: 0
-            maximum: 1
-            default: 0
-        - name: personalize_for
-          in: query
-          description:  |-
-            A user for whom the documents will be personalized for.
-            If that user doesn't have enough interactions in the system, then the documents are returned unpersonalized.
-          required: false
-          schema:
-            $ref: './schemas/user.yml#/UserId'
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SemanticSearchResponse'
-        '400':
-            $ref: './responses/generic.yml#/BadRequest'
     post:
       tags:
         - front office
@@ -194,7 +150,7 @@ paths:
         Returns a list of documents that are semantically similar to the one given as input.
         Each document contains the id, the score and the properties.
         The score is a value between 0 and 1 where a higher value means that the document is more similar to the one in input
-      operationId: getSimilarDocuments2
+      operationId: getSimilarDocuments
       requestBody:
         required: true
         content:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -256,6 +256,7 @@ components:
         personalize:
           description: Personalize the ranking of candidates based on a users preferences
           type: object
+          required: [user]
           properties:
             exclude_seen:
               type: boolean

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -141,7 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserInteractionError'
 
-  /semantic_search/{document_id}:
+  /semantic_search:
     post:
       tags:
         - front office
@@ -241,6 +241,8 @@ components:
     SemanticSearchRequest:
       type: object
       properties:
+        document:
+          $ref: './schemas/document.yml#/DocumentId'
         count:
           $ref: '#/components/schemas/Count'
         published_after:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -247,7 +247,7 @@ components:
         published_after:
           $ref: './schemas/time.yml#/PublicationDate'
         exclude_seen:
-          type: bool
+          type: boolean
           default: true
           description: |
             If true do not include documents the user has already seen as search candidate.

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -16,6 +16,6 @@ InputUser:
   type: object
   properties:
     id:
-      $ref: './schemas/user.yml#/UserId'
+      $ref: '#/UserId'
     history:
-      $ref: './schemas/document.yml#/History'
+      $ref: './document.yml#/History'

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -2,3 +2,20 @@ UserId:
   description: Id of a user.
   $ref: './id.yml#/Id'
   example: "user_id"
+
+InputUser:
+  summary: Information about a user provided as input for an search
+  description: |
+    Information about a user provided as input for an search
+
+    This can be anything from no user information, to a user id, to
+    part of the user data inlined.
+
+    Be aware that currently using the `id` in combination with any
+    other field is not allowed.
+  type: object
+  properties:
+    id:
+      $ref: './schemas/user.yml#/UserId'
+    history:
+      $ref: './schemas/document.yml#/History'

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -18,6 +18,7 @@ InputUser:
       $ref: '#/UserId'
     history:
       $ref: './document.yml#/History'
-  oneOf:
-    - required: [id]
-    - required: [history]
+  # Disabled as our linter can't handle that correctly
+  # oneOf:
+  #   - required: [id]
+  #   - required: [history]

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -4,7 +4,6 @@ UserId:
   example: "user_id"
 
 InputUser:
-  summary: Information about a user provided as input for an search
   description: |
     Information about a user provided as input for an search
 

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -7,18 +7,19 @@ InputUser:
   description: |
     Information about a user provided as input for an search
 
-    This can be anything from no user information, to a user id, to
-    part of the user data inlined.
+    Currently this can either be the users `id` oder a users `history`.
+  oneOf:
+    - $ref: "#/InputUserById"
+    - $ref: "#/InputUserWithHistory"
 
-    Be aware that currently using the `id` in combination with any
-    other field is not allowed.
+InputUserById:
   type: object
   properties:
     id:
       $ref: '#/UserId'
+
+InputUserWithHistory:
+  type: object
+  properties:
     history:
       $ref: './document.yml#/History'
-  # Disabled as our linter can't handle that correctly
-  # oneOf:
-  #   - required: [id]
-  #   - required: [history]

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -18,3 +18,6 @@ InputUser:
       $ref: '#/UserId'
     history:
       $ref: './document.yml#/History'
+  oneOf:
+    - required: [id]
+    - required: [history]


### PR DESCRIPTION
Adds a `POST` variant of `/semantic_search/{document_id}` which allows specifying users either by id or by in-lining the user object (for now limited to `history`).

**References:**

- issue: [ET-4093]
- story: [ET-4092]


[ET-4093]: https://xainag.atlassian.net/browse/ET-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4092]: https://xainag.atlassian.net/browse/ET-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ