### PR TITLE
[Merged by Bors] - ET-4094 implement semantic search with inline user

### DIFF
--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -14,6 +14,7 @@
 mod knn;
 mod rerank;
 pub(crate) mod routes;
+mod stateless;
 
 use actix_web::web::ServiceConfig;
 use async_trait::async_trait;

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -27,7 +27,7 @@ use crate::{
     Error,
 };
 
-/// KNN search based on Centers of Interest;
+/// KNN search based on Centers of Interest.
 pub(super) struct CoiSearch<I, J> {
     pub(super) interests: I,
     pub(super) excluded: J,

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -27,7 +27,8 @@ use crate::{
     Error,
 };
 
-pub(super) struct Search<I, J> {
+/// KNN search based on Centers of Interest;
+pub(super) struct CoiSearch<I, J> {
     pub(super) interests: I,
     pub(super) excluded: J,
     pub(super) horizon: Duration,
@@ -37,7 +38,7 @@ pub(super) struct Search<I, J> {
     pub(super) time: DateTime<Utc>,
 }
 
-impl<'a, I, J> Search<I, J>
+impl<'a, I, J> CoiSearch<I, J>
 where
     I: IntoIterator,
     <I as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a PositiveCoi>,
@@ -141,7 +142,7 @@ mod tests {
     #[tokio::test]
     async fn test_search_knn_documents_for_empty_cois() {
         let storage = Storage::default();
-        let documents = Search {
+        let documents = CoiSearch {
             interests: &[],
             excluded: &[],
             horizon: CoiConfig::default().horizon(),

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -258,7 +258,7 @@ async fn stateless_personalized_documents(
         }
     }
 
-    let mut documents = knn::Search {
+    let mut documents = knn::CoiSearch {
         interests: &interests.positive,
         excluded: history.iter().map(|entry| &entry.id),
         horizon: state.coi.config().horizon(),
@@ -419,7 +419,7 @@ pub(crate) async fn personalize_documents_by(
             count,
             published_after,
         } => {
-            knn::Search {
+            knn::CoiSearch {
                 interests: &interests.positive,
                 excluded: &excluded,
                 horizon: coi_system.config().horizon(),

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -60,8 +60,8 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
             web::resource("personalized_documents")
                 .route(web::get().to(personalized_documents.error_with_request_id())),
         );
-    let semantic_search = web::resource("/semantic_search/{document_id}")
-        .route(web::get().to(semantic_search.error_with_request_id()));
+    let semantic_search = web::resource("/semantic_search")
+        .route(web::post().to(semantic_search.error_with_request_id()));
     let stateless = web::resource("personalized_documents")
         .route(web::post().to(stateless_personalized_documents.error_with_request_id()));
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -169,7 +169,7 @@ impl StatelessPersonalizationRequest {
         config: &PersonalizationConfig,
         warnings: &mut Vec<Warning>,
     ) -> Result<(Vec<HistoryEntry>, DateTime<Utc>), Error> {
-        let history = validate_history(self.history, config, warnings, Utc::now())?;
+        let history = validate_history(self.history, config, warnings, Utc::now(), false)?;
         let time = history.last().unwrap(/* history is checked to be not empty */).timestamp;
         Ok((history, time))
     }
@@ -403,7 +403,7 @@ impl UnvalidatedInputUser {
         Ok(match (self.id, self.history) {
             (Some(id), None) => InputUser::Ref { id: id.try_into()? },
             (None, Some(history)) => InputUser::Inline {
-                history: validate_history(history, config, warnings, Utc::now())?,
+                history: validate_history(history, config, warnings, Utc::now(), true)?,
             },
             _ => {
                 return Err(BadRequest::from(

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -33,7 +33,7 @@ use super::{
         load_history,
         validate_history,
         HistoryEntry,
-        InvalidatedHistoryEntry,
+        UnvalidatedHistoryEntry,
     },
     AppState,
     PersonalizationConfig,
@@ -160,7 +160,7 @@ struct StatelessPersonalizationRequest {
     count: Option<usize>,
     #[serde(default)]
     published_after: Option<DateTime<Utc>>,
-    history: Vec<InvalidatedHistoryEntry>,
+    history: Vec<UnvalidatedHistoryEntry>,
 }
 
 impl StatelessPersonalizationRequest {
@@ -383,10 +383,10 @@ pub(crate) async fn personalize_documents_by(
 
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum InvalidatedInputUser {
+enum UnvalidatedInputUser {
     Ref(String),
     Inline {
-        history: Vec<InvalidatedHistoryEntry>,
+        history: Vec<UnvalidatedHistoryEntry>,
     },
 }
 
@@ -395,7 +395,7 @@ enum InputUser {
     Inline { history: Vec<HistoryEntry> },
 }
 
-impl InvalidatedInputUser {
+impl UnvalidatedInputUser {
     fn validate(
         self,
         config: &PersonalizationConfig,
@@ -411,11 +411,11 @@ impl InvalidatedInputUser {
 }
 
 #[derive(Deserialize)]
-struct InvalidatedSemanticSearchQuery {
+struct UnvalidatedSemanticSearchQuery {
     document_id: String,
     count: Option<usize>,
     min_similarity: Option<f32>,
-    user: Option<InvalidatedInputUser>,
+    user: Option<UnvalidatedInputUser>,
 }
 
 struct SemanticSearchQuery {
@@ -425,7 +425,7 @@ struct SemanticSearchQuery {
     user: Option<InputUser>,
 }
 
-impl InvalidatedSemanticSearchQuery {
+impl UnvalidatedSemanticSearchQuery {
     fn validate_and_resolve_defaults(
         self,
         semantic_search_config: &SemanticSearchConfig,
@@ -469,7 +469,7 @@ struct SemanticSearchResponse {
 
 async fn semantic_search(
     state: Data<AppState>,
-    query: Json<InvalidatedSemanticSearchQuery>,
+    query: Json<UnvalidatedSemanticSearchQuery>,
 ) -> Result<impl Responder, Error> {
     let mut warnings = Vec::new();
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -164,6 +164,7 @@ struct StatelessPersonalizationRequest {
 }
 
 impl StatelessPersonalizationRequest {
+    /// Return the validated input history, it's expected to be ordered from oldest to newest.
     fn history_and_time(
         self,
         config: &PersonalizationConfig,
@@ -381,7 +382,6 @@ pub(crate) async fn personalize_documents_by(
     Ok(Some(documents))
 }
 
-#[derive(Deserialize)]
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct UnvalidatedInputUser {
@@ -514,9 +514,7 @@ async fn semantic_search(
         count,
         min_similarity,
         personalize,
-    } = query
-        .into_inner()
-        .validate_and_resolve_defaults(&state.config, &mut warnings)?;
+    } = query.validate_and_resolve_defaults(&state.config, &mut warnings)?;
 
     let embedding = storage::Document::get_embedding(&state.storage, &document_id)
         .await?

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -382,10 +382,10 @@ pub(crate) async fn personalize_documents_by(
 }
 
 #[derive(Deserialize)]
+#[derive(Default, Deserialize)]
+#[serde(default)]
 struct UnvalidatedInputUser {
-    #[serde(default)]
     id: Option<String>,
-    #[serde(default)]
     history: Option<Vec<UnvalidatedHistoryEntry>>,
 }
 
@@ -407,7 +407,7 @@ impl UnvalidatedInputUser {
             },
             _ => {
                 return Err(BadRequest::from(
-                    "personalize.user must haver _either_ an `id` or a `history` field",
+                    "personalize.user must have _either_ an `id` or a `history` field",
                 )
                 .into())
             }
@@ -505,7 +505,7 @@ struct SemanticSearchResponse {
 
 async fn semantic_search(
     state: Data<AppState>,
-    query: Json<UnvalidatedSemanticSearchQuery>,
+    Json(query): Json<UnvalidatedSemanticSearchQuery>,
 ) -> Result<impl Responder, Error> {
     let mut warnings = Vec::new();
 

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -46,6 +46,8 @@ pub(super) struct HistoryEntry {
 /// The history is expected to be ordered from oldest to
 /// newest entry, i.e. new entries are pushed to the end
 /// of the history vec.
+///
+/// The returned history is also ordered from oldest to newest.
 pub(super) fn validate_history(
     history: Vec<UnvalidatedHistoryEntry>,
     config: &PersonalizationConfig,
@@ -80,6 +82,7 @@ pub(super) fn validate_history(
     Ok(history)
 }
 
+/// Enriches the history with data loaded from the database.
 pub(super) async fn load_history(
     storage: &impl storage::Document,
     history: Vec<HistoryEntry>,
@@ -115,7 +118,7 @@ pub(super) struct LoadedHistoryEntry {
     pub(super) tags: Vec<DocumentTag>,
 }
 
-/// Given an iterator over the history from _newest_ to oldest calculates user interests and tag weights.
+/// Given an iterator over the history from oldest to newest calculates user interests and tag weights.
 pub(super) fn derive_interests_and_tag_weights<'a>(
     coi_system: &CoiSystem,
     history: impl IntoIterator<Item = &'a LoadedHistoryEntry>,

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -1,0 +1,144 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use serde::Deserialize;
+use xayn_ai_bert::NormalizedEmbedding;
+use xayn_ai_coi::{CoiSystem, UserInterests};
+
+use super::PersonalizationConfig;
+use crate::{
+    error::{common::HistoryTooSmall, warning::Warning},
+    models::{DocumentId, DocumentTag},
+    storage::{self, TagWeights},
+    Error,
+};
+
+/// Represents a Users history passed to an endpoint.
+///
+/// The history is expected to be ordered from oldest to
+/// newest entry, i.e. new entries are pushed to the end
+/// of the history vec.
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub(super) struct InvalidatedHistory(Vec<InvalidatedHistoryEntry>);
+
+#[derive(Deserialize)]
+struct InvalidatedHistoryEntry {
+    id: String,
+    timestamp: Option<DateTime<Utc>>,
+}
+
+impl InvalidatedHistory {
+    pub(super) async fn validate_and_load(
+        self,
+        storage: &impl storage::Document,
+        config: &PersonalizationConfig,
+        warnings: &mut Vec<Warning>,
+    ) -> Result<Vec<HistoryEntry>, Error> {
+        let history = self.validate(config, warnings, Utc::now())?;
+        Self::load(storage, history).await
+    }
+
+    fn validate(
+        self,
+        config: &PersonalizationConfig,
+        warnings: &mut Vec<Warning>,
+        time: DateTime<Utc>,
+    ) -> Result<Vec<(DocumentId, DateTime<Utc>)>, Error> {
+        if self.0.is_empty() {
+            return Err(HistoryTooSmall.into());
+        }
+        let max_history_len = config.max_stateless_history_size;
+        if self.0.len() > max_history_len {
+            warnings.push(format!("history truncated, max length is {max_history_len}").into());
+        }
+        let mut most_recent_time = Utc::now();
+        let mut history = self
+            .0
+            .into_iter()
+            .rev()
+            .take(max_history_len)
+            .map(|unchecked| {
+                let id = DocumentId::try_from(unchecked.id)?;
+                let timestamp = unchecked.timestamp.unwrap_or(most_recent_time);
+                if timestamp > most_recent_time {
+                    warnings
+                        .push(format!("inconsistent history ordering around document {id}").into());
+                }
+                most_recent_time = timestamp;
+                Ok((id, timestamp))
+            })
+            .try_collect::<_, Vec<_>, Error>()?;
+
+        history.reverse();
+        Ok(history)
+    }
+
+    async fn load(
+        storage: &impl storage::Document,
+        history: Vec<(DocumentId, DateTime<Utc>)>,
+    ) -> Result<Vec<HistoryEntry>, Error> {
+        let mut loaded =
+            storage::Document::get_interacted(storage, history.iter().map(|(id, _)| id))
+                .await?
+                .into_iter()
+                .map(|document| (document.id, (document.embedding, document.tags)))
+                .collect::<HashMap<_, _>>();
+
+        Ok(history
+            .into_iter()
+            // filter ignores documents which don't exist in our database (i.e. have
+            // been deleted)
+            .filter_map(|(id, timestamp)| {
+                loaded.remove(&id).map(|(embedding, tags)| HistoryEntry {
+                    id,
+                    timestamp,
+                    embedding,
+                    tags,
+                })
+            })
+            .collect())
+    }
+}
+
+pub(super) struct HistoryEntry {
+    pub(super) id: DocumentId,
+    pub(super) timestamp: DateTime<Utc>,
+    pub(super) embedding: NormalizedEmbedding,
+    pub(super) tags: Vec<DocumentTag>,
+}
+
+/// Given an iterator over the history from _newest_ to oldest calculates user interests and tag weights.
+pub(super) fn derive_interests_and_tag_weights<'a>(
+    coi_system: &CoiSystem,
+    history: impl IntoIterator<Item = &'a HistoryEntry>,
+) -> (UserInterests, TagWeights) {
+    let mut user_interests = UserInterests::default();
+    let mut tag_weights = TagWeights::default();
+    for entry in history {
+        coi_system.log_positive_user_reaction(
+            &mut user_interests.positive,
+            &entry.embedding,
+            entry.timestamp,
+        );
+        for tag in &entry.tags {
+            *tag_weights.entry(tag.clone()).or_default() += 1;
+        }
+    }
+    (user_interests, tag_weights)
+}

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -160,8 +160,10 @@ mod tests {
     #[test]
     fn test_validating_to_large_history_warns() -> Result<(), Panic> {
         let now = Utc.with_ymd_and_hms(2000, 10, 20, 3, 4, 5).unwrap();
-        let mut config = PersonalizationConfig::default();
-        config.max_stateless_history_size = 1;
+        let config = PersonalizationConfig {
+            max_stateless_history_size: 1,
+            ..Default::default()
+        };
         let mut warnings = Vec::new();
 
         validate_history(

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 #[derive(Deserialize)]
-pub(super) struct InvalidatedHistoryEntry {
+pub(super) struct UnvalidatedHistoryEntry {
     id: String,
     #[serde(default)]
     timestamp: Option<DateTime<Utc>>,
@@ -47,7 +47,7 @@ pub(super) struct HistoryEntry {
 /// newest entry, i.e. new entries are pushed to the end
 /// of the history vec.
 pub(super) fn validate_history(
-    history: Vec<InvalidatedHistoryEntry>,
+    history: Vec<UnvalidatedHistoryEntry>,
     config: &PersonalizationConfig,
     warnings: &mut Vec<Warning>,
     time: DateTime<Utc>,
@@ -161,7 +161,7 @@ mod tests {
         let mut warnings = Vec::new();
 
         validate_history(
-            vec![InvalidatedHistoryEntry {
+            vec![UnvalidatedHistoryEntry {
                 id: "doc-1".into(),
                 timestamp: Some(now - Duration::days(1)),
             }],
@@ -173,11 +173,11 @@ mod tests {
 
         let documents = validate_history(
             vec![
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-1".into(),
                     timestamp: Some(now - Duration::days(2)),
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-2".into(),
                     timestamp: Some(now - Duration::days(1)),
                 },
@@ -207,23 +207,23 @@ mod tests {
 
         let documents = validate_history(
             vec![
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-1".into(),
                     timestamp: Some(now - Duration::days(2)),
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-2".into(),
                     timestamp: None,
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-3".into(),
                     timestamp: None,
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-4".into(),
                     timestamp: Some(now - Duration::days(1)),
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-5".into(),
                     timestamp: None,
                 },
@@ -270,15 +270,15 @@ mod tests {
 
         validate_history(
             vec![
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-1".into(),
                     timestamp: Some(now + Duration::days(2)),
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-4".into(),
                     timestamp: Some(now + Duration::days(1)),
                 },
-                InvalidatedHistoryEntry {
+                UnvalidatedHistoryEntry {
                     id: "doc-5".into(),
                     timestamp: None,
                 },

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -51,8 +51,9 @@ pub(super) fn validate_history(
     config: &PersonalizationConfig,
     warnings: &mut Vec<Warning>,
     time: DateTime<Utc>,
+    allow_empty_history: bool,
 ) -> Result<Vec<HistoryEntry>, Error> {
-    if history.is_empty() {
+    if !allow_empty_history && history.is_empty() {
         return Err(HistoryTooSmall.into());
     }
     let max_history_len = config.max_stateless_history_size;
@@ -148,8 +149,11 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2000, 10, 20, 3, 4, 5).unwrap();
         let config = PersonalizationConfig::default();
         let mut warnings = Vec::new();
-        let res = validate_history(vec![], &config, &mut warnings, now);
+        let res = validate_history(vec![], &config, &mut warnings, now, false);
         assert!(res.is_err());
+        assert!(warnings.is_empty());
+        let res = validate_history(vec![], &config, &mut warnings, now, true);
+        assert!(res.is_ok());
         assert!(warnings.is_empty());
     }
 
@@ -168,6 +172,7 @@ mod tests {
             &config,
             &mut warnings,
             now,
+            true,
         )?;
         assert!(warnings.is_empty());
 
@@ -185,6 +190,7 @@ mod tests {
             &config,
             &mut warnings,
             now,
+            true,
         )?;
 
         assert_eq!(warnings.len(), 1);
@@ -231,6 +237,7 @@ mod tests {
             &config,
             &mut warnings,
             now,
+            true,
         )?;
 
         assert!(warnings.is_empty());
@@ -286,6 +293,7 @@ mod tests {
             &config,
             &mut warnings,
             now,
+            true,
         )?;
 
         assert_eq!(warnings.len(), 2);

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -170,7 +170,7 @@ pub(crate) trait Interaction {
     ) -> Result<(), Error>;
 }
 
-pub type TagWeights = HashMap<DocumentTag, usize>;
+pub(crate) type TagWeights = HashMap<DocumentTag, usize>;
 
 #[async_trait]
 pub(crate) trait Tag {

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -170,9 +170,11 @@ pub(crate) trait Interaction {
     ) -> Result<(), Error>;
 }
 
+pub type TagWeights = HashMap<DocumentTag, usize>;
+
 #[async_trait]
 pub(crate) trait Tag {
-    async fn get(&self, user_id: &UserId) -> Result<HashMap<DocumentTag, usize>, Error>;
+    async fn get(&self, user_id: &UserId) -> Result<TagWeights, Error>;
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -36,7 +36,7 @@ use tokio::sync::RwLock;
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{PositiveCoi, UserInterests};
 
-use super::{Document as _, InteractionUpdateContext};
+use super::{Document as _, InteractionUpdateContext, TagWeights};
 use crate::{
     error::{
         application::Error,
@@ -572,7 +572,7 @@ impl storage::Interaction for Storage {
 
 #[async_trait]
 impl storage::Tag for Storage {
-    async fn get(&self, id: &UserId) -> Result<HashMap<DocumentTag, usize>, Error> {
+    async fn get(&self, id: &UserId) -> Result<TagWeights, Error> {
         Ok(self.tags.read().await.get(id).cloned().unwrap_or_default())
     }
 }

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -40,7 +40,7 @@ use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::nan_safe_f32_cmp_desc;
 use xayn_ai_coi::{CoiId, CoiStats, NegativeCoi, PositiveCoi, UserInterests};
 
-use super::InteractionUpdateContext;
+use super::{InteractionUpdateContext, TagWeights};
 #[cfg(feature = "ET-3837")]
 use crate::models::{DocumentProperties, IngestedDocument, PersonalizedDocument};
 use crate::{
@@ -766,7 +766,7 @@ struct QueriedWeightedTag {
 
 #[async_trait]
 impl storage::Tag for Storage {
-    async fn get(&self, user_id: &UserId) -> Result<HashMap<DocumentTag, usize>, Error> {
+    async fn get(&self, user_id: &UserId) -> Result<TagWeights, Error> {
         let mut tx = self.postgres.pool.begin().await?;
 
         let tags = sqlx::query_as::<_, QueriedWeightedTag>(

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -113,8 +113,16 @@ async fn test_full_personalization() {
             let not_enough_interactions = send_assert_json::<SemanticSearchResponse>(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
-                    .query(&[("count", "5"), ("personalize_for", "u1")])
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1",
+                        "count": 5,
+                        "personalize": {
+                            "user": {
+                                "id": "u1"
+                            }
+                        }
+                    }))
                     .build()?,
                 StatusCode::OK,
             )
@@ -131,8 +139,11 @@ async fn test_full_personalization() {
             let not_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
-                    .query(&[("count", "5")])
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1",
+                        "count": 5
+                    }))
                     .build()?,
                 StatusCode::OK,
             )
@@ -147,8 +158,16 @@ async fn test_full_personalization() {
             let fully_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
-                    .query(&[("count", "5"), ("personalize_for", "u1")])
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1",
+                        "count": 5,
+                        "personalize": {
+                            "user": {
+                                "id": "u1"
+                            }
+                        }
+                    }))
                     .build()?,
                 StatusCode::OK,
             )
@@ -186,8 +205,16 @@ async fn test_subtle_personalization() {
             let subtle_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
-                    .query(&[("count", "5"), ("personalize_for", "u1")])
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1",
+                        "count": 5,
+                        "personalize": {
+                            "user": {
+                                "id": "u1"
+                            }
+                        }
+                    }))
                     .build()?,
                 StatusCode::OK,
             )

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -89,7 +89,10 @@ async fn test_semantic_search() {
             let SemanticSearchResponse { documents } = send_assert_json(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1"
+                    }))
                     .build()?,
                 StatusCode::OK,
             )
@@ -143,8 +146,11 @@ async fn test_semantic_search_min_similarity() {
             let SemanticSearchResponse { documents } = send_assert_json(
                 &client,
                 client
-                    .get(personalization_url.join("/semantic_search/d1")?)
-                    .query(&[("min_similarity", "0.6")])
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document_id": "d1",
+                        "min_similarity": 0.6
+                    }))
                     .build()?,
                 StatusCode::OK,
             )


### PR DESCRIPTION
Implement the updated semantic search which can accept the user data inline instead of an user id.

The option to toggle exuding seen documents is in a follow up PR.

# References

- issue: [ET-4094]
- story: [ET-4092]
- based on: #831


[ET-4094]: https://xainag.atlassian.net/browse/ET-4094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4092]: https://xainag.atlassian.net/browse/ET-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ