### PR TITLE
[Merged by Bors] - ET-4093  no oneOf in spec

### DIFF
--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -7,7 +7,7 @@ InputUser:
   description: |
     Information about a user provided as input for an search
 
-    Currently this can either be the users `id` oder a users `history`.
+    Currently this can _either_ be the users `id` oder a users `history`.
   type: object
   properties:
     id:

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -8,18 +8,9 @@ InputUser:
     Information about a user provided as input for an search
 
     Currently this can either be the users `id` oder a users `history`.
-  oneOf:
-    - $ref: "#/InputUserById"
-    - $ref: "#/InputUserWithHistory"
-
-InputUserById:
   type: object
   properties:
     id:
       $ref: '#/UserId'
-
-InputUserWithHistory:
-  type: object
-  properties:
     history:
       $ref: './document.yml#/History'

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -7,7 +7,7 @@ InputUser:
   description: |
     Information about a user provided as input for an search
 
-    Currently this can _either_ be the users `id` oder a users `history`.
+    Currently this can _either_ be the user's `id` or a user's `history`.
   type: object
   properties:
     id:


### PR DESCRIPTION
Our current code generated falls over when `oneOf` is used.

For now we will only document the constraint but not encode it in openapi.

**References:**

- issue: [ET-4093]
- story: [ET-4092]

[ET-4093]: https://xainag.atlassian.net/browse/ET-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4092]: https://xainag.atlassian.net/browse/ET-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ