### PR TITLE
[Merged by Bors] - ET-XXXX-only-bind-to-single-loopback-address

### DIFF
--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -38,10 +38,10 @@ jobs:
       image: xaynetci/yellow:v10
     timeout-minutes: 20
     env:
-      XAYN_INGESTION__NET__BIND_TO: "127.0.1.1:3030"
-      INGESTION_URI: "http://127.0.1.1:3030"
-      XAYN_PERSONALIZATION__NET__BIND_TO: "127.0.1.1:3031"
-      PERSONALIZATION_URI: "http://127.0.1.1:3031"
+      XAYN_INGESTION__NET__BIND_TO: "127.0.0.1:3030"
+      INGESTION_URI: "http://127.0.0.1:3030"
+      XAYN_PERSONALIZATION__NET__BIND_TO: "127.0.0.1:3031"
+      PERSONALIZATION_URI: "http://127.0.0.1:3031"
     services:
       elasticsearch:
         image: elasticsearch:8.5.3


### PR DESCRIPTION
Due to how github/docker setups namespaces binding to other addresses might not always work as expected.