### PR TITLE
ET-4104 input user history limits

### DIFF
--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -103,7 +103,7 @@ impl Default for PersonalizationConfig {
             max_cois_for_knn: 10,
             score_weights: [0.5, 0.5, 0.0],
             store_user_history: true,
-            max_stateless_history_size: 20,
+            max_stateless_history_size: 200,
         }
     }
 }

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -90,8 +90,11 @@ pub(crate) struct PersonalizationConfig {
     /// Whether to store the history of user interactions.
     pub(crate) store_user_history: bool,
 
-    /// The maximal size the history of the stateless personalization endpoint can have.
+    /// Them maximal number of history entries used as stateless user history.
     pub(crate) max_stateless_history_size: usize,
+
+    /// Them maximal number of history entries used when calculating CoIs from a stateless user history.
+    pub(crate) max_stateless_history_for_cois: usize,
 }
 
 impl Default for PersonalizationConfig {
@@ -104,6 +107,7 @@ impl Default for PersonalizationConfig {
             score_weights: [0.5, 0.5, 0.0],
             store_user_history: true,
             max_stateless_history_size: 200,
+            max_stateless_history_for_cois: 20,
         }
     }
 }

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -90,10 +90,10 @@ pub(crate) struct PersonalizationConfig {
     /// Whether to store the history of user interactions.
     pub(crate) store_user_history: bool,
 
-    /// Them maximal number of history entries used as stateless user history.
+    /// The maximal number of history entries used as stateless user history.
     pub(crate) max_stateless_history_size: usize,
 
-    /// Them maximal number of history entries used when calculating CoIs from a stateless user history.
+    /// The maximal number of history entries used when calculating CoIs from a stateless user history.
     pub(crate) max_stateless_history_for_cois: usize,
 }
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -31,6 +31,7 @@ use super::{
     stateless::{
         derive_interests_and_tag_weights,
         load_history,
+        trim_history,
         validate_history,
         HistoryEntry,
         UnvalidatedHistoryEntry,
@@ -194,8 +195,12 @@ async fn stateless_personalized_documents(
     let count = request.document_count(state.config.as_ref())?;
     let (history, time) = request.history_and_time(state.config.as_ref(), &mut warnings)?;
 
+    let excluded = history.iter().map(|entry| entry.id.clone()).collect_vec();
+    let history = trim_history(
+        history,
+        state.config.personalization.max_stateless_history_for_cois,
+    );
     let history = load_history(&state.storage, history).await?;
-
     let (interests, tag_weights) = derive_interests_and_tag_weights(&state.coi, &history);
 
     let mut documents = knn::CoiSearch {
@@ -592,14 +597,9 @@ async fn personalize_knn_search_result(
             storage::Interest::get(storage, &id).await?,
             storage::Tag::get(storage, &id).await?,
         ),
-        InputUser::Inline { mut history } => {
+        InputUser::Inline { history } => {
             let config: &PersonalizationConfig = config.as_ref();
-            if let Some(surplus) = history
-                .len()
-                .checked_sub(config.max_stateless_history_for_cois)
-            {
-                history.drain(..surplus);
-            }
+            let history = trim_history(history, config.max_stateless_history_for_cois);
             let history = load_history(storage, history).await?;
             derive_interests_and_tag_weights(coi_system, &history)
         }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -205,7 +205,7 @@ async fn stateless_personalized_documents(
 
     let mut documents = knn::CoiSearch {
         interests: &interests.positive,
-        excluded: history.iter().map(|entry| &entry.id),
+        excluded: &excluded,
         horizon: state.coi.config().horizon(),
         max_cois: state.config.personalization.max_cois_for_knn,
         count,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -582,7 +582,7 @@ async fn personalized_exclusions(
 
 async fn personalize_knn_search_result(
     storage: &(impl storage::Interest + storage::Tag + storage::Document),
-    config: &(impl AsRef<CoiConfig> + AsRef<SemanticSearchConfig>),
+    config: &(impl AsRef<CoiConfig> + AsRef<SemanticSearchConfig> + AsRef<PersonalizationConfig>),
     coi_system: &CoiSystem,
     personalize: Personalize,
     documents: &mut [PersonalizedDocument],
@@ -592,7 +592,14 @@ async fn personalize_knn_search_result(
             storage::Interest::get(storage, &id).await?,
             storage::Tag::get(storage, &id).await?,
         ),
-        InputUser::Inline { history } => {
+        InputUser::Inline { mut history } => {
+            let config: &PersonalizationConfig = config.as_ref();
+            if let Some(surplus) = history
+                .len()
+                .checked_sub(config.max_stateless_history_for_cois)
+            {
+                history.drain(..surplus);
+            }
             let history = load_history(storage, history).await?;
             derive_interests_and_tag_weights(coi_system, &history)
         }

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -48,7 +48,8 @@ stdout = """
       0.0
     ],
     "store_user_history": true,
-    "max_stateless_history_size": 20
+    "max_stateless_history_size": 200,
+    "max_stateless_history_for_cois": 20
   },
   "semantic_search": {
     "max_number_documents": 100,


### PR DESCRIPTION
- [x] bump history limit to 200
- a new limit for how much of the history is used for CoI computation
  - [x] add new config
  - [x] use new config
  
**References:**

- Issue: [ET-4104]
- Story: [Et-4092]
- Based On: #834 