### PR TITLE
[Merged by Bors] - ET-4165 future prove document input for semantic search

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -238,10 +238,10 @@ components:
               title: "News title"
     SemanticSearchRequest:
       type: object
-      required: [document_id]
+      required: [document]
       properties:
-        document_id:
-          $ref: './schemas/document.yml#/DocumentId'
+        document:
+          $ref: './schemas/document.yml#/InputDocument'
         count:
           $ref: '#/components/schemas/Count'
         published_after:

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -57,3 +57,13 @@ HistoryEntry:
       $ref: '#/DocumentId'
     timestamp:
       $ref: './time.yml#/Timestamp'
+
+InputDocument:
+  description: |
+    Information about a document provided as input for an search.
+
+    Currently this can _only_ be the user's `id`, more options will be added in the future.
+  type: object
+  properties:
+    id:
+      $ref: '#/Document'

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -66,4 +66,4 @@ InputDocument:
   type: object
   properties:
     id:
-      $ref: '#/Document'
+      $ref: '#/DocumentId'

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -115,7 +115,7 @@ async fn test_full_personalization() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5,
                         "personalize": {
                             "user": {
@@ -141,7 +141,7 @@ async fn test_full_personalization() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5
                     }))
                     .build()?,
@@ -160,7 +160,7 @@ async fn test_full_personalization() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5,
                         "personalize": {
                             "user": {
@@ -207,7 +207,7 @@ async fn test_subtle_personalization() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5,
                         "personalize": {
                             "user": {
@@ -253,7 +253,7 @@ async fn test_full_personalization_with_inline_history() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5,
                         "personalize": {
                             "user": {
@@ -277,7 +277,7 @@ async fn test_full_personalization_with_inline_history() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5
                     }))
                     .build()?,
@@ -296,7 +296,7 @@ async fn test_full_personalization_with_inline_history() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "count": 5,
                         "personalize": {
                             "user": {

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -91,7 +91,7 @@ async fn test_semantic_search() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1"
+                        "document": { "id": "d1" },
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -148,7 +148,7 @@ async fn test_semantic_search_min_similarity() {
                 client
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
-                        "document_id": "d1",
+                        "document": { "id": "d1" },
                         "min_similarity": 0.6
                     }))
                     .build()?,


### PR DESCRIPTION
Change `document_id: ..` to `document: { id: ... }` so that we later can also have `document: { text: ... }`.

**References:**

- Issue: [ET-4092]
- Story: [ET-4165]


[ET-4092]: https://xainag.atlassian.net/browse/ET-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4165]: https://xainag.atlassian.net/browse/ET-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ