### PR TITLE
ET-XXXX-make-document-id-required

### DIFF
--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -64,6 +64,7 @@ InputDocument:
 
     Currently this can _only_ be the user's `id`, more options will be added in the future.
   type: object
+  required: [id]
   properties:
     id:
       $ref: '#/DocumentId'


### PR DESCRIPTION
When the text search is added we can no longer mark it as required as the way to mark either required will make our tooling fall over.

But until then we can mark `id` as required.