### PR TITLE
[Merged by Bors] - ET-4106 set document candidates

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -14,9 +14,9 @@ module.exports = {
       then: {
         function: enumCaseConvention,
         functionOptions: {
-          type: 'pascal'
-        }
-      }
+          type: 'pascal',
+        },
+      },
     },
     'operation-id-case-convention': {
       description: 'Operation ids must be pascal case',
@@ -27,9 +27,9 @@ module.exports = {
       then: {
         function: enumCaseConvention,
         functionOptions: {
-          type: 'pascal'
-        }
-      }
+          type: 'pascal',
+        },
+      },
     },
     'major-version-in-path': 'off',
     'schema-description': 'off',
@@ -39,8 +39,18 @@ module.exports = {
     'delete-body': 'off',
     'prohibit-summary-sentence-style': 'off',
     'collection-array-property': 'off',
-    // the rule set wants to enforce a specific erorr schema
+    // the rule set wants to enforce a specific error schema
     'response-error-response-schema': 'off',
     'patch-request-content-type': 'off',
-  }
+  },
+  overrides: [
+    {
+      files: [
+        "web-api/openapi/back_office.yaml#/components/schemas/DocumentCandidatesRequest",
+      ],
+      rules: {
+        "array-boundary": "off",
+      },
+    },
+  ],
 };

--- a/web-api/migrations/20230302133700_document.sql
+++ b/web-api/migrations/20230302133700_document.sql
@@ -14,3 +14,7 @@
 
 ALTER TABLE document
     ADD COLUMN is_candidate BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_document_is_candidate
+    ON document (document_id)
+    WHERE is_candidate;

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -93,6 +93,25 @@ paths:
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
+  /documents/candidates:
+    put:
+      tags:
+        - back office
+      summary: Set the documents considerred for recommendations.
+      description: Set the documents considerred for recommendations.
+      operationId: replaceDocumentCandidates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentCandidatesRequest'
+      responses:
+        '204':
+          description: successful operation
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
+
   /documents/{document_id}:
     parameters:
       - $ref: './parameters/path/document_id.yml'
@@ -307,3 +326,19 @@ components:
           maxItems: 1000
           items:
             $ref: './schemas/document.yml#/DocumentId'
+    DocumentCandidate:
+      type: object
+      required: [id]
+      properties:
+        id:
+          $ref: './schemas/document.yml#/DocumentId'
+    DocumentCandidatesRequest:
+      type: object
+      required: [documents]
+      properties:
+        documents:
+          type: array
+          minItems: 0
+          maxItems: 1e+6
+          items:
+            $ref: '#/components/schemas/DocumentCandidate'

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -97,8 +97,8 @@ paths:
     put:
       tags:
         - back office
-      summary: Set the documents considerred for recommendations.
-      description: Set the documents considerred for recommendations.
+      summary: Set the documents considered for recommendations.
+      description: Set the documents considered for recommendations.
       operationId: replaceDocumentCandidates
       requestBody:
         required: true
@@ -339,6 +339,5 @@ components:
         documents:
           type: array
           minItems: 0
-          maxItems: 1e+6
           items:
             $ref: '#/components/schemas/DocumentCandidate'

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -79,7 +79,7 @@ pub(crate) struct InvalidDocumentTag {
 
 impl_application_error!(InvalidDocumentTag => BAD_REQUEST);
 
-/// Failed to delete some documents
+/// Failed to delete some documents.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct FailedToDeleteSomeDocuments {
     pub(crate) errors: Vec<DocumentIdAsObject>,
@@ -94,6 +94,16 @@ pub(crate) struct IngestingDocumentsFailed {
 }
 
 impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR);
+
+#[cfg(feature = "ET-4089")]
+/// Failed to set some document candidates.
+#[derive(Debug, Display, Error, Serialize)]
+pub(crate) struct FailedToSetSomeDocumentCandidates {
+    pub(crate) documents: Vec<DocumentIdAsObject>,
+}
+
+#[cfg(feature = "ET-4089")]
+impl_application_error!(FailedToSetSomeDocumentCandidates => BAD_REQUEST);
 
 /// The requested document was not found.
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -107,6 +107,16 @@ pub(crate) trait Document {
     ) -> Result<Warning<DocumentId>, Error>;
 }
 
+#[cfg(feature = "ET-4089")]
+#[async_trait(?Send)]
+pub(crate) trait DocumentCandidate {
+    /// Sets the document candidates and reports failed ids.
+    async fn set(
+        &self,
+        ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+    ) -> Result<Warning<DocumentId>, Error>;
+}
+
 #[async_trait]
 pub(crate) trait DocumentProperties {
     async fn get(&self, id: &DocumentId) -> Result<Option<models::DocumentProperties>, Error>;

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -471,8 +471,9 @@ impl Database {
 
         let mut ingestable = ids.into_iter().collect::<HashSet<_>>();
         let unchanged = sqlx::query_as::<_, DocumentId>(
-            "UPDATE document SET
-            is_candidate = FALSE
+            "UPDATE document
+            SET is_candidate = FALSE
+            WHERE is_candidate
             RETURNING document_id;",
         )
         .fetch_all(&mut tx)


### PR DESCRIPTION
**Reference**

- [ET-4106]
- [ET-4107]
- [ET-4126]
- requires #837
- followed by #849

**Summary**

- define api spec for setting candidates
- impl setting candidates for storages & add route to the backoffice


[ET-4106]: https://xainag.atlassian.net/browse/ET-4106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4107]: https://xainag.atlassian.net/browse/ET-4107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4126]: https://xainag.atlassian.net/browse/ET-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ