### PR TITLE
[Merged by Bors] - ET-4220 bm25/BERTknn hybrid search

### DIFF
--- a/web-api/src/mind.rs
+++ b/web-api/src/mind.rs
@@ -77,10 +77,7 @@ async fn run_persona_benchmark() -> Result<(), Panic> {
             let personalised_documents = state
                 .personalize(
                     user_id,
-                    PersonalizeBy::KnnSearch {
-                        count: benchmark_config.ndocuments,
-                        published_after: None,
-                    },
+                    PersonalizeBy::knn_search(benchmark_config.ndocuments),
                     state.time,
                 )
                 .await?
@@ -233,10 +230,7 @@ async fn run_saturation_benchmark() -> Result<(), Panic> {
             let personalised_documents = state
                 .personalize(
                     &user_id,
-                    PersonalizeBy::KnnSearch {
-                        count: benchmark_config.ndocuments,
-                        published_after: None,
-                    },
+                    PersonalizeBy::knn_search(benchmark_config.ndocuments),
                     state.time,
                 )
                 .await?
@@ -329,10 +323,7 @@ async fn run_persona_hot_news_benchmark() -> Result<(), Panic> {
             let personalised_documents = state
                 .personalize(
                     user_id,
-                    PersonalizeBy::KnnSearch {
-                        count: benchmark_config.ndocuments,
-                        published_after: None,
-                    },
+                    PersonalizeBy::knn_search(benchmark_config.ndocuments),
                     state.time,
                 )
                 .await?
@@ -405,10 +396,7 @@ async fn grid_search_for_best_parameters() -> Result<(), Panic> {
                 let personalised_documents = state
                     .personalize(
                         user_id,
-                        PersonalizeBy::KnnSearch {
-                            count: grid_search_config.ndocuments,
-                            published_after: None,
-                        },
+                        PersonalizeBy::knn_search(grid_search_config.ndocuments),
                         state.time,
                     )
                     .await?

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use xayn_ai_coi::CoiConfig;
 use xayn_test_utils::error::Panic;
 
-use crate::personalization::PersonalizationConfig;
+use crate::personalization::{routes::PersonalizeBy, PersonalizationConfig};
 
 #[derive(Debug, Serialize)]
 pub(super) struct StateConfig {
@@ -129,6 +129,16 @@ impl Default for SaturationConfig {
             click_probability: 0.2,
             ndocuments: 30,
             iterations: 10,
+        }
+    }
+}
+
+impl PersonalizeBy<'_> {
+    pub(super) fn knn_search(count: usize) -> Self {
+        Self::KnnSearch {
+            count,
+            published_after: None,
+            query: None,
         }
     }
 }

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -86,10 +86,11 @@ where
                         KnnSearchParams {
                             excluded: excluded.clone(),
                             embedding: &coi.point,
-                            k_neighbors,
+                            count: k_neighbors,
                             num_candidates: self.count,
                             published_after: self.published_after,
                             min_similarity: None,
+                            query: None,
                             time: self.time,
                         },
                     )

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -28,17 +28,18 @@ use crate::{
 };
 
 /// KNN search based on Centers of Interest.
-pub(super) struct CoiSearch<I, J> {
+pub(super) struct CoiSearch<'a, I, J> {
     pub(super) interests: I,
     pub(super) excluded: J,
     pub(super) horizon: Duration,
     pub(super) max_cois: usize,
     pub(super) count: usize,
     pub(super) published_after: Option<DateTime<Utc>>,
+    pub(super) query: Option<&'a str>,
     pub(super) time: DateTime<Utc>,
 }
 
-impl<'a, I, J> CoiSearch<I, J>
+impl<'a, I, J> CoiSearch<'a, I, J>
 where
     I: IntoIterator,
     <I as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a PositiveCoi>,
@@ -90,7 +91,7 @@ where
                             num_candidates: self.count,
                             published_after: self.published_after,
                             min_similarity: None,
-                            query: None,
+                            query: self.query,
                             time: self.time,
                         },
                     )
@@ -156,6 +157,7 @@ mod tests {
             max_cois: PersonalizationConfig::default().max_cois_for_knn,
             count: 10,
             published_after: None,
+            query: None,
             time: Utc::now(),
         }
         .run_on(&storage)

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -74,10 +74,10 @@ where
                 // fine as number of neighbors is small enough
                 clippy::cast_possible_truncation
             )]
-                let k_neighbors = (weight * self.count as f32).ceil() as usize;
+                let count = (weight * self.count as f32).ceil() as usize;
 
-                if k_neighbors == 0 {
-                    // using k_neighbors 0 in a KNN-search would cause storage to throw.
+                if count == 0 {
+                    // using count 0 in a KNN-search would cause storage to throw.
                     // since the value is 0, we anyway can safely return an empty result set.
                     Ok(Vec::new())
                 } else {
@@ -86,7 +86,7 @@ where
                         KnnSearchParams {
                             excluded: excluded.clone(),
                             embedding: &coi.point,
-                            count: k_neighbors,
+                            count,
                             num_candidates: self.count,
                             published_after: self.published_after,
                             min_similarity: None,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -67,17 +67,17 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
 }
 
 /// Represents user interaction request body.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 struct UpdateInteractions {
     documents: Vec<UserInteractionData>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 struct UserInteractionData {
     #[serde(rename = "id")]
-    pub(crate) document_id: String,
+    document_id: String,
     #[serde(rename = "type")]
-    pub(crate) interaction_type: UserInteractionType,
+    interaction_type: UserInteractionType,
 }
 
 async fn interactions(
@@ -148,11 +148,13 @@ pub(crate) async fn update_interactions(
 
     Ok(())
 }
+
 /// Represents personalized documents query params.
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct PersonalizedDocumentsQuery {
-    pub(crate) count: Option<usize>,
-    pub(crate) published_after: Option<DateTime<Utc>>,
+#[derive(Debug, Deserialize)]
+struct PersonalizedDocumentsQuery {
+    count: Option<usize>,
+    published_after: Option<DateTime<Utc>>,
+    query: Option<String>,
 }
 
 impl PersonalizedDocumentsQuery {
@@ -168,7 +170,7 @@ impl PersonalizedDocumentsQuery {
 async fn personalized_documents(
     state: Data<AppState>,
     user_id: Path<String>,
-    options: Query<PersonalizedDocumentsQuery>,
+    params: Query<PersonalizedDocumentsQuery>,
 ) -> Result<impl Responder, Error> {
     personalize_documents_by(
         &state.storage,
@@ -176,8 +178,9 @@ async fn personalized_documents(
         &user_id.into_inner().try_into()?,
         &state.config.personalization,
         PersonalizeBy::KnnSearch {
-            count: options.document_count(state.config.as_ref())?,
-            published_after: options.published_after,
+            count: params.document_count(state.config.as_ref())?,
+            published_after: params.published_after,
+            query: params.query.as_deref(),
         },
         Utc::now(),
     )
@@ -223,7 +226,7 @@ struct PersonalizedDocumentsResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind")]
-pub(crate) enum PersonalizedDocumentsError {
+enum PersonalizedDocumentsError {
     NotEnoughInteractions,
 }
 
@@ -231,8 +234,9 @@ pub(crate) enum PersonalizeBy<'a> {
     KnnSearch {
         count: usize,
         published_after: Option<DateTime<Utc>>,
+        query: Option<&'a str>,
     },
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     Documents(&'a [&'a DocumentId]),
 }
 
@@ -262,6 +266,7 @@ pub(crate) async fn personalize_documents_by(
         PersonalizeBy::KnnSearch {
             count,
             published_after,
+            query,
         } => {
             knn::CoiSearch {
                 interests: &interests.positive,
@@ -270,11 +275,13 @@ pub(crate) async fn personalize_documents_by(
                 max_cois: personalization.max_cois_for_knn,
                 count,
                 published_after,
+                query,
                 time,
             }
             .run_on(storage)
             .await?
         }
+        #[cfg(test)]
         PersonalizeBy::Documents(documents) => {
             storage::Document::get_personalized(storage, documents.iter().copied()).await?
         }
@@ -291,6 +298,7 @@ pub(crate) async fn personalize_documents_by(
         time,
     );
 
+    #[cfg_attr(not(test), allow(irrefutable_let_patterns))]
     if let PersonalizeBy::KnnSearch { count, .. } = by {
         // due to ceil-ing the number of documents we fetch per COI
         // we might end up with more documents then we want
@@ -300,8 +308,7 @@ pub(crate) async fn personalize_documents_by(
     Ok(Some(documents))
 }
 
-#[derive(Default, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Deserialize)]
 struct UnvalidatedInputUser {
     id: Option<String>,
     history: Option<Vec<UnvalidatedHistoryEntry>>,
@@ -333,16 +340,12 @@ impl UnvalidatedInputUser {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct UnvalidatedSemanticSearchQuery {
     document: UnvalidatedInputDocument,
-    #[serde(default)]
     count: Option<usize>,
-    #[serde(default)]
     min_similarity: Option<f32>,
-    #[serde(default)]
     published_after: Option<DateTime<Utc>>,
-    #[serde(default)]
     personalize: Option<UnvalidatedPersonalize>,
 }
 
@@ -376,7 +379,7 @@ impl UnvalidatedSemanticSearchQuery {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct UnvalidatedInputDocument {
     id: Option<String>,
     query: Option<String>,
@@ -398,7 +401,7 @@ impl UnvalidatedInputDocument {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct UnvalidatedPersonalize {
     #[serde(default = "true_fn")]
     exclude_seen: bool,

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -28,7 +28,7 @@ use crate::{
     Error,
 };
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub(super) struct UnvalidatedHistoryEntry {
     id: String,
     #[serde(default)]

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -48,7 +48,7 @@ pub(crate) struct KnnSearchParams<'a, I> {
     pub(crate) embedding: &'a NormalizedEmbedding,
     /// The number of documents which will be returned if there are enough fitting documents.
     pub(crate) count: usize,
-    // must be >= k_neighbors
+    // must be >= count
     pub(crate) num_candidates: usize,
     pub(crate) published_after: Option<DateTime<Utc>>,
     pub(crate) min_similarity: Option<f32>,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -46,11 +46,14 @@ use crate::{
 pub(crate) struct KnnSearchParams<'a, I> {
     pub(crate) excluded: I,
     pub(crate) embedding: &'a NormalizedEmbedding,
-    pub(crate) k_neighbors: usize,
+    /// The number of documents which will be returned if there are enough fitting documents.
+    pub(crate) count: usize,
     // must be >= k_neighbors
     pub(crate) num_candidates: usize,
     pub(crate) published_after: Option<DateTime<Utc>>,
     pub(crate) min_similarity: Option<f32>,
+    /// An additional query which will be run in parallel with the KNN search.
+    pub(super) query: Option<&'a str>,
     pub(crate) time: DateTime<Utc>,
 }
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -320,12 +320,12 @@ impl Client {
         }
         if let Some(query) = params.query {
             let mut filter: Value = filter;
-            //TODO better abstraction outside of PoC
+            //TODO better abstraction/implementation outside of PoC
             let filter_mut = filter.as_object_mut().unwrap()["bool"]
                 .as_object_mut()
                 .unwrap();
-            debug_assert!(!filter_mut.contains_key("match"));
-            filter_mut.insert("match".into(), json!({ "snippet": query }));
+            debug_assert!(!filter_mut.contains_key("must"));
+            filter_mut.insert("must".into(), json!({ "match": { "snippet": query }}));
             let body_mut = body.as_object_mut()
                 .unwrap(/* we just created it as object */);
             debug_assert!(!body_mut.contains_key("bool"));

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -262,12 +262,14 @@ impl Client {
         // the existing documents are not filtered in the query to avoid too much work for a cold
         // path, filtering them afterwards can occasionally lead to less than k results though
         let excluded_ids = json!({
-            "values": params.excluded.into_iter().collect_vec()
+            "ids": {
+                "values": params.excluded.into_iter().collect_vec()
+            }
         });
-        let filter = if let Some(published_after) = params.published_after {
-            // published_after != null && published_after <= publication_date <= time
-            json!({
-                "bool": {
+        let Value::Object(mut filter) = (
+            if let Some(published_after) = params.published_after {
+                // published_after != null && published_after <= publication_date <= time
+                json!({
                     "filter": {
                         "range": {
                             "properties.publication_date": {
@@ -276,19 +278,13 @@ impl Client {
                             }
                         }
                     },
-                    "must_not": {
-                        "ids": excluded_ids
-                    }
-                }
-            })
-        } else {
-            // published_after == null || published_after <= time
-            json!({
-                "bool": {
+                    "must_not": excluded_ids
+                })
+            } else {
+                // published_after == null || published_after <= time
+                json!({
                     "must_not": [
-                        {
-                            "ids": excluded_ids
-                        },
+                        excluded_ids,
                         {
                             "range": {
                                 "properties.publication_date": {
@@ -297,39 +293,34 @@ impl Client {
                             }
                         }
                     ]
-                }
-            })
+                })
+            }
+        ) else {
+            unreachable!(/* filter is a json object */);
         };
 
         // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn
-        let mut body = json!({
+        let Value::Object(mut body) = json!({
             "knn": {
                 "field": "embedding",
                 "query_vector": params.embedding,
                 "k": params.count,
                 "num_candidates": params.num_candidates,
-                "filter": filter
+                "filter": {
+                    "bool": filter
+                }
             },
             "size": params.count,
             "_source": false
-        });
+        }) else {
+            unreachable!(/* body is a json object */);
+        };
         if let Some(min_similarity) = params.min_similarity {
-            body.as_object_mut()
-                .unwrap(/* we just created it as object */)
-                .insert("min_score".into(), min_similarity.into());
+            body.insert("min_score".to_string(), json!(min_similarity));
         }
         if let Some(query) = params.query {
-            let mut filter: Value = filter;
-            //TODO better abstraction/implementation outside of PoC
-            let filter_mut = filter.as_object_mut().unwrap()["bool"]
-                .as_object_mut()
-                .unwrap();
-            debug_assert!(!filter_mut.contains_key("must"));
-            filter_mut.insert("must".into(), json!({ "match": { "snippet": query }}));
-            let body_mut = body.as_object_mut()
-                .unwrap(/* we just created it as object */);
-            debug_assert!(!body_mut.contains_key("bool"));
-            body_mut.insert("query".into(), filter);
+            filter.insert("must".to_string(), json!({ "match": { "snippet": query }}));
+            body.insert("query".to_string(), json!({ "bool": filter }));
         }
 
         Ok(self

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -316,7 +316,7 @@ impl storage::Document for Storage {
                     })
                 }
             })
-            .take(params.k_neighbors)
+            .take(params.count)
             .collect();
 
         Ok(documents)
@@ -668,10 +668,11 @@ mod tests {
             KnnSearchParams {
                 excluded: [],
                 embedding,
-                k_neighbors: 2,
+                count: 2,
                 num_candidates: 2,
                 published_after: None,
                 min_similarity: None,
+                query: None,
                 time: Utc::now(),
             },
         )
@@ -687,10 +688,11 @@ mod tests {
             KnnSearchParams {
                 excluded: [&ids[1]],
                 embedding,
-                k_neighbors: 3,
+                count: 3,
                 num_candidates: 3,
                 published_after: None,
                 min_similarity: None,
+                query: None,
                 time: Utc::now(),
             },
         )

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -62,7 +62,7 @@ async fn test_semantic_search() {
     test_two_apps::<Ingestion, Personalization, _>(
         unchanged_config,
         unchanged_config,
-        |client, ingestion_url, personalization_url, _services| async move {
+        |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,
                 &ingestion_url,
@@ -119,7 +119,7 @@ async fn test_semantic_search_min_similarity() {
     test_two_apps::<Ingestion, Personalization, _>(
         unchanged_config,
         unchanged_config,
-        |client, ingestion_url, personalization_url, _services| async move {
+        |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,
                 &ingestion_url,
@@ -174,7 +174,7 @@ async fn test_semantic_search_with_query() {
     test_two_apps::<Ingestion, Personalization, _>(
         unchanged_config,
         unchanged_config,
-        |client, ingestion_url, personalization_url, _services| async move {
+        |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,
                 &ingestion_url,


### PR DESCRIPTION
**Reference**

- [ET-4086]
- [ET-4220]

**Summary**

- use hybrid search for `/semantic_search` if a query instead of a document id is used
- similarly for `/users/{id}/personalized_documents` but the `query` parameter is undocumented

[ET-4086]: https://xainag.atlassian.net/browse/ET-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-4220]: https://xainag.atlassian.net/browse/ET-4220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ