### PR TITLE
[Merged by Bors] - ET-4108 get document candidates

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -47,6 +47,7 @@ module.exports = {
     {
       files: [
         "web-api/openapi/back_office.yaml#/components/schemas/DocumentCandidatesRequest",
+        "web-api/openapi/back_office.yaml#/components/schemas/DocumentCandidatesResponse",
       ],
       rules: {
         "array-boundary": "off",

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -94,6 +94,21 @@ paths:
           $ref: './responses/generic.yml#/BadRequest'
 
   /documents/candidates:
+    get:
+      tags:
+        - back office
+      summary: Get the documents considered for recommendations.
+      description: Get the documents considered for recommendations.
+      operationId: listDocumentCandidates
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCandidatesResponse'
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
     put:
       tags:
         - back office
@@ -341,3 +356,15 @@ components:
           minItems: 0
           items:
             $ref: '#/components/schemas/DocumentCandidate'
+    DocumentCandidatesResponse:
+      type: object
+      required: [documents]
+      properties:
+        documents:
+          type: array
+          minItems: 0
+          items:
+            $ref: './schemas/document.yml#/DocumentId'
+      example:
+        documents:
+          - 'document_id0'

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -110,6 +110,9 @@ pub(crate) trait Document {
 #[cfg(feature = "ET-4089")]
 #[async_trait(?Send)]
 pub(crate) trait DocumentCandidate {
+    /// Gets the document candidates.
+    async fn get(&self) -> Result<Vec<DocumentId>, Error>;
+
     /// Sets the document candidates and reports failed ids.
     async fn set(
         &self,

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -375,6 +375,19 @@ impl storage::Document for Storage {
 #[cfg(feature = "ET-4089")]
 #[async_trait(?Send)]
 impl storage::DocumentCandidate for Storage {
+    async fn get(&self) -> Result<Vec<DocumentId>, Error> {
+        let documents = self
+            .documents
+            .read()
+            .await
+            .0
+            .iter()
+            .filter_map(|(id, document)| document.is_candidate.then(|| id.clone()))
+            .collect();
+
+        Ok(documents)
+    }
+
     async fn set(
         &self,
         ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -826,6 +826,13 @@ impl storage::Document for Storage {
 #[cfg(feature = "ET-4089")]
 #[async_trait(?Send)]
 impl storage::DocumentCandidate for Storage {
+    async fn get(&self) -> Result<Vec<DocumentId>, Error> {
+        sqlx::query_as("SELECT document_id FROM document WHERE is_candidate;")
+            .fetch_all(&self.postgres.pool)
+            .await
+            .map_err(Into::into)
+    }
+
     async fn set(
         &self,
         ids: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,

--- a/web-api/tests/document_candidates.rs
+++ b/web-api/tests/document_candidates.rs
@@ -14,6 +14,8 @@
 
 #![cfg(feature = "ET-4089")]
 
+use std::collections::HashSet;
+
 use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
@@ -41,6 +43,24 @@ async fn ingest(client: &Client, url: &Url) -> Result<(), Panic> {
     Ok(())
 }
 
+#[derive(Deserialize)]
+struct DocumentCandidatesResponse {
+    documents: Vec<String>,
+}
+
+impl DocumentCandidatesResponse {
+    fn ids(&self) -> HashSet<&str> {
+        self.documents.iter().map(AsRef::as_ref).collect()
+    }
+}
+
+async fn get(client: &Client, url: &Url) -> Result<DocumentCandidatesResponse, Panic> {
+    let request = client.get(url.join("/documents/candidates")?).build()?;
+    let response = send_assert_json(client, request, StatusCode::OK).await;
+
+    Ok(response)
+}
+
 async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) -> Result<(), Panic> {
     let request = client
         .put(url.join("/documents/candidates")?)
@@ -54,8 +74,11 @@ async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) ->
 #[tokio::test]
 async fn test_candidates_all() {
     test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         set(&client, &url, ["d1", "d2", "d3"]).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         Ok(())
     })
     .await;
@@ -64,8 +87,11 @@ async fn test_candidates_all() {
 #[tokio::test]
 async fn test_candidates_some() {
     test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         set(&client, &url, ["d1", "d3"]).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d3"].into());
         Ok(())
     })
     .await;
@@ -74,8 +100,39 @@ async fn test_candidates_some() {
 #[tokio::test]
 async fn test_candidates_none() {
     test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         set(&client, &url, None).await?;
+        assert!(get(&client, &url).await?.ids().is_empty());
+        Ok(())
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_candidates_not_default() {
+    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        assert!(get(&client, &url).await?.ids().is_empty());
+        send_assert(
+            &client,
+            client
+                .post(url.join("/documents")?)
+                .json(&json!({
+                    "documents": [
+                        { "id": "d1", "snippet": "once in a spring" },
+                        { "id": "d2", "snippet": "there was a fall" },
+                        { "id": "d3", "snippet": "fall in a once", "is_candidate": false },
+                        { "id": "d4", "snippet": "once in a fall", "is_candidate": false }
+                    ]
+                }))
+                .build()?,
+            StatusCode::CREATED,
+        )
+        .await;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2"].into());
+        set(&client, &url, ["d2", "d3"]).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d2", "d3"].into());
         Ok(())
     })
     .await;
@@ -102,7 +159,9 @@ struct Error {
 #[tokio::test]
 async fn test_candidates_warning() {
     test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+        assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
+        assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         let error = send_assert_json::<Error>(
             &client,
             client
@@ -119,6 +178,7 @@ async fn test_candidates_warning() {
         .await;
         assert_eq!(error.kind, Kind::FailedToSetSomeDocumentCandidates);
         assert_eq!(error.details, Details::Set(json!([ { "id": "d4" } ])));
+        assert_eq!(get(&client, &url).await?.ids(), ["d1"].into());
         Ok(())
     })
     .await;


### PR DESCRIPTION
**Reference**

- [ET-4108]
- [ET-4109]
- [ET-4126]
- requires #845
- followed by #852

**Summary**

- define api spec for getting candidates
- impl getting candidates for storages & add route to the backoffice


[ET-4108]: https://xainag.atlassian.net/browse/ET-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4109]: https://xainag.atlassian.net/browse/ET-4109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4126]: https://xainag.atlassian.net/browse/ET-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ