### PR TITLE
[Merged by Bors] - ET-4101 Update tract for newer opset version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1314,7 +1323,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1508,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2463,6 +2472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2796,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
 ]
 
 [[package]]
@@ -3174,6 +3207,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.11.2",
+ "serde",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea181f44fa0f02e234e52ff010f40eaadf96aff76566bcac2685c476adabfbe1"
+checksum = "0c69c1bfa4618066fb4ded8b4284f36b18752cd57cfd4bec35aa17cd97706698"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -3574,6 +3624,7 @@ dependencies = [
  "ndarray",
  "num-integer",
  "num-traits",
+ "rustfft",
  "smallvec",
  "tract-data",
  "tract-linalg",
@@ -3581,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b83088c06a20933275ee79b98288ef8e3af8f87688a78b7523d427e6f6861de"
+checksum = "6bde5d77f61f46a1b9bd5680d7b12f6dac865c52662cd3a467c300ae71a2d4f3"
 dependencies = [
  "anyhow",
  "educe",
@@ -3592,18 +3643,20 @@ dependencies = [
  "lazy_static",
  "maplit",
  "ndarray",
+ "nom",
  "num-complex",
  "num-integer",
  "num-traits",
  "scan_fmt",
  "smallvec",
+ "string-interner",
 ]
 
 [[package]]
 name = "tract-hir"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276a8a313f44a54f65efeb3a7179921b6f1a853958c373198030d84edf13293"
+checksum = "24e20a89a3c565be9fafc776236eaeaef66eb61d86d06823061e89fcd9ebbf67"
 dependencies = [
  "derive-new",
  "educe",
@@ -3613,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55be8006b7b8f5ac85d51f4994edcfc0edf3c6df952dad594ab7c8faa74d93ed"
+checksum = "72e32a12274f50e71b9ce6d2bf6f83496994ff30351325ce069d104df2132e38"
 dependencies = [
  "cc",
  "derive-new",
@@ -3637,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfd2f5ed54894e7adc33ac541d3436a95ab51b5f87df6ce26c140a541d07fbc"
+checksum = "be9d9b431456713a1d2b4546c6c8d79fe7d1f902847c6cd01bac97f71ac32014"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3652,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6974d2450e3b918ab2733eeba8f6222da36927d6175a801ee50b16c5c1cd764a"
+checksum = "e8307f8433fc669985c70e6bd4f3109a43757445f606b344311184a9c772be2f"
 dependencies = [
  "bytes",
  "derive-new",
@@ -3671,15 +3724,27 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.18.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6186ba851df659ee1e43e5fa94b023c3b5dd0cb26d99cee85f22c3580eb4055"
+checksum = "c7e77e32834a12fe5a5d47f11e99e90d84aa71c514c5bbf87ada57c952747e90"
 dependencies = [
  "educe",
  "getrandom",
  "log",
  "rand",
+ "rand_distr",
+ "rustfft",
  "tract-nnef",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,5 @@ uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [profile.dev.package.tract-core]
 opt-level = 3
+# extremely slows down tract ^0.19 if enabled for non-trivial onnx models
+debug-assertions = false

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokenizers = { version = "0.13.2", default-features = false, features = ["onig"] }
-tract-onnx = "0.18.5"
+tract-onnx = "0.19.7"
 xayn-test-utils = { path = "../test-utils" }
 
 [dev-dependencies]

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -277,20 +277,9 @@ mod tests {
     use std::f32::consts::SQRT_2;
 
     use ndarray::{arr2, arr3};
-    use tract_onnx::prelude::IntoArcTensor;
     use xayn_test_utils::assert_approx_eq;
 
     use super::*;
-
-    #[test]
-    fn t() {
-        assert_approx_eq!(f32, [0.25, 1.25], Embedding::from([0.25, 1.25]));
-        assert_approx_eq!(
-            f32,
-            ndarray::arr1(&[1., 5.]) / 26_f32.sqrt(),
-            NormalizedEmbedding::try_from([0.25, 1.25]).unwrap(),
-        );
-    }
 
     #[test]
     fn test_normalize() {
@@ -312,40 +301,36 @@ mod tests {
 
     #[test]
     fn test_none() {
-        let prediction = arr3::<f32, _, _>(&[[[1., 2., 3.], [4., 5., 6.]]])
-            .into_arc_tensor()
-            .into();
+        let prediction = arr3(&[[[1., 2., 3.], [4., 5., 6.]]]).into();
         let embedding = NonePooler::pool(&prediction).unwrap();
         assert_approx_eq!(f32, embedding, [[1., 2., 3.], [4., 5., 6.]]);
     }
 
     #[test]
     fn test_first() {
-        let prediction = arr3::<f32, _, _>(&[[[1., 2., 3.], [4., 5., 6.]]])
-            .into_arc_tensor()
-            .into();
+        let prediction = arr3(&[[[1., 2., 3.], [4., 5., 6.]]]).into();
         let embedding = FirstPooler::pool(&prediction).unwrap();
         assert_approx_eq!(f32, embedding, [1., 2., 3.]);
     }
 
     #[test]
     fn test_average() {
-        let prediction = arr3::<f32, _, _>(&[[[1., 2., 3.], [4., 5., 6.]]]).into_arc_tensor();
+        let prediction = arr3(&[[[1., 2., 3.], [4., 5., 6.]]]).into();
 
         let mask = arr2(&[[0, 0]]).into();
-        let embedding = AveragePooler::pool(&prediction.clone().into(), &mask).unwrap();
+        let embedding = AveragePooler::pool(&prediction, &mask).unwrap();
         assert_approx_eq!(f32, embedding, [0., 0., 0.]);
 
         let mask = arr2(&[[0, 1]]).into();
-        let embedding = AveragePooler::pool(&prediction.clone().into(), &mask).unwrap();
+        let embedding = AveragePooler::pool(&prediction, &mask).unwrap();
         assert_approx_eq!(f32, embedding, [4., 5., 6.]);
 
         let mask = arr2(&[[1, 0]]).into();
-        let embedding = AveragePooler::pool(&prediction.clone().into(), &mask).unwrap();
+        let embedding = AveragePooler::pool(&prediction, &mask).unwrap();
         assert_approx_eq!(f32, embedding, [1., 2., 3.]);
 
         let mask = arr2(&[[1, 1]]).into();
-        let embedding = AveragePooler::pool(&prediction.into(), &mask).unwrap();
+        let embedding = AveragePooler::pool(&prediction, &mask).unwrap();
         assert_approx_eq!(f32, embedding, [2.5, 3.5, 4.5]);
     }
 }


### PR DESCRIPTION
**Reference**

- [ET-4101]

**Summary**

- update `tract-onnx` to `0.19` to allow for onnx opset 18 support
- use `TValue` instead of `Arc<Tensor>` because of a breaking change in tract


[ET-4101]: https://xainag.atlassian.net/browse/ET-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ