### PR TITLE
ET-3837 migration docker image

### DIFF
--- a/.github/docker/Dockerfile.migration
+++ b/.github/docker/Dockerfile.migration
@@ -1,0 +1,12 @@
+# https://kerkour.com/rust-small-docker-image
+
+FROM rust:latest AS builder
+RUN update-ca-certificates
+WORKDIR /migration
+COPY ./ .
+RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --bin migration --release --features ET-3837
+
+FROM gcr.io/distroless/cc
+WORKDIR /migration
+COPY --from=builder /migration/target/release/migration ./
+ENTRYPOINT ["/migration/migration"]

--- a/web-api/src/migration.rs
+++ b/web-api/src/migration.rs
@@ -38,7 +38,7 @@ pub struct Config {
 }
 
 pub async fn start() -> Result<(), anyhow::Error> {
-    let config = config::load::<Config>(["XAYN_MIGRATION"]);
+    let config = config::load::<Config>(["XAYN_MIGRATION", "XAYN_WEB_API"]);
 
     init_tracing(&config.logging);
     let storage = config.storage.setup().await?;

--- a/web-api/src/migration.rs
+++ b/web-api/src/migration.rs
@@ -29,7 +29,9 @@ use crate::{
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
+    #[serde(default)]
     logging: logging::Config,
+    #[serde(default)]
     storage: storage::Config,
     n: NonZeroU16,
     t: NonZeroU64,


### PR DESCRIPTION
**Reference**

- [ET-3837]
- followed by #833

**Summary**

- add docker image with stand-alone migration binary

```
docker build -t migration -f .github/docker/Dockerfile.migration .
docker run migration --help
```

[ET-3837]: https://xainag.atlassian.net/browse/ET-3837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ