### PR TITLE
[Merged by Bors] - FIX reduce integration test verbosity

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -185,6 +185,9 @@ where
     let pg_url = services.postgres.as_str();
 
     let mut config = toml! {
+        [logging]
+        level = "warn"
+
         [storage.postgres]
         base_url = pg_url
 

--- a/web-api/elastic-search/create_es_index.sh
+++ b/web-api/elastic-search/create_es_index.sh
@@ -13,6 +13,6 @@ while ! curl -sf -X OPTIONS "${URL}" ; do
     sleep 1;
 done;
 
-curl -if -X PUT "${URL}?pretty" \
+curl -isf -X PUT "${URL}?pretty" \
     -H 'Content-Type: application/json' \
     -d @mapping.json


### PR DESCRIPTION
**Summary**

- reduce verbosity of integration tests: less cmd echos & higher log level

**Example**

before:
```
running 1 test
+ PROJECT=web-dev
++ docker ps --filter label=com.docker.compose.project=web-dev
++ wc -l
+ [[        4 -gt 1 ]]
+ echo 'web-dev composition is already running, SKIPPING STARTUP'
+ exit 0
CREATE DATABASE
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   620  100    95  100   525   1735   9592 --:--:-- --:--:-- --:--:-- 11923
2023-03-20T14:11:27.102612Z  INFO xayn_web_api::app: pwd="/Users/janpetsche/Documents/Git/xayn_discovery_engine/web-api"
2023-03-20T14:11:27.976236Z  INFO tract_linalg::arm64: CPU optimisation: AppleM    
2023-03-20T14:11:27.985592Z  INFO setup_database{self=Config { base_url: "postgresql://user:pw@localhost:3054/t230320_151126_4027", port: None, user: None, password: Secret([REDACTED alloc::string::String]), db: None, application_name: None, skip_migrations: false }}: xayn_web_api::storage::postgres: starting postgres setup
2023-03-20T14:11:28.133228Z  INFO xayn_web_api::net: bound_to=127.0.0.1:59986
2023-03-20T14:11:28.133308Z  INFO actix_server::builder: starting 10 workers
2023-03-20T14:11:28.134187Z  INFO actix_server::server: Tokio runtime found; starting in existing Tokio runtime
2023-03-20T14:11:28.203312Z  INFO request{path=/documents method=POST request_id=8599b3f5-2e89-4bf9-a20a-a09bfef6251b}:new_documents: xayn_web_api::ingestion::routes: 2 embeddings calculated in 0 sec
2023-03-20T14:11:28.328891Z ERROR request{path=/documents/d3/properties method=GET request_id=6c0c912d-191f-48e9-a15c-54084416d2f0}: xayn_web_api::error::application: error=The requested document was not found.
2023-03-20T14:11:28.329251Z  INFO actix_server::accept: accept thread stopped
2023-03-20T14:11:28.329264Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329273Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329279Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329296Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329313Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329336Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329412Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329499Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329273Z  INFO actix_server::worker: shutting down idle worker
2023-03-20T14:11:28.329575Z  INFO actix_server::worker: shutting down idle worker
DROP DATABASE
test test_ingestion ... ok
```

after:
```
running 1 test
2023-03-20T15:18:47.800629Z ERROR xayn_web_api::error::application: error=The requested document was not found.
test test_ingestion ... ok
```