### PR TITLE
Add loading of model with one output that is already the embedding

### DIFF
--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -53,6 +53,7 @@ pub use crate::{
         FirstPooler,
         InvalidEmbedding,
         NonePooler,
+        NonePooler1D,
         NormalizedEmbedding,
     },
 };

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -103,7 +103,9 @@ impl Model {
         Ok(Model {
             model,
             token_size: config.token_size,
-            embedding_size: config.extract("model.output.0.shape.2")?,
+            embedding_size: config
+                .extract("model.output.0.shape.2")
+                .or_else(|_| config.extract("model.output.0.shape.1"))?,
         })
     }
 

--- a/bert/src/pipeline.rs
+++ b/bert/src/pipeline.rs
@@ -24,6 +24,7 @@ use crate::{
     AveragePooler,
     FirstPooler,
     NonePooler,
+    NonePooler1D,
 };
 
 /// A pipeline can be built from a [`Config`] and consists of a tokenizer, a model and a pooler.
@@ -56,6 +57,18 @@ where
         let encoding = self.tokenizer.encode(sequence)?;
         let prediction = self.model.predict(encoding)?;
         NonePooler::pool(&prediction).map_err(Into::into)
+    }
+}
+
+impl<T> Pipeline<T, NonePooler1D>
+where
+    T: Tokenize,
+{
+    /// Computes the embedding of the sequence.
+    pub fn run(&self, sequence: impl AsRef<str>) -> Result<Embedding1, PipelineError> {
+        let encoding = self.tokenizer.encode(sequence)?;
+        let prediction = self.model.predict(encoding)?;
+        NonePooler1D::pool(&prediction).map_err(Into::into)
     }
 }
 

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -229,6 +229,22 @@ impl NonePooler {
     }
 }
 
+/// An inert pooling strategy for one dimensional arrays.
+///
+/// The prediction is just passed through.
+pub struct NonePooler1D;
+
+impl NonePooler1D {
+    /// Passes through the prediction.
+    pub(crate) fn pool(prediction: &Prediction) -> Result<Embedding1, TractError> {
+        Ok(prediction
+            .to_array_view()?
+            .slice(s![0, ..])
+            .to_owned()
+            .into())
+    }
+}
+
 /// A first token pooling strategy.
 ///
 /// The prediction is pooled over its first tokens (`[CLS]`).


### PR DESCRIPTION
Allows to load a model that has only one layer and the layer is already the embedding.