### PR TITLE
[Merged by Bors] - Remove naming conflict in the api

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -98,6 +98,7 @@ paths:
       tags:
         - back office
       deprecated: true
+      operationId: listDocumentCandidatesDeprecated
       summary: Get the documents considered for recommendations.
       description: Get the documents considered for recommendations.
       responses:
@@ -113,6 +114,7 @@ paths:
       tags:
         - back office
       deprecated: true
+      operationId: replaceDocumentCandidatesDeprecated
       summary: Set the documents considered for recommendations.
       description: Set the documents considered for recommendations.
       requestBody:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -97,9 +97,9 @@ paths:
     get:
       tags:
         - back office
+      deprecated: true
       summary: Get the documents considered for recommendations.
       description: Get the documents considered for recommendations.
-      operationId: listDocumentCandidates
       responses:
         '200':
           description: successful operation
@@ -112,9 +112,9 @@ paths:
     put:
       tags:
         - back office
+      deprecated: true
       summary: Set the documents considered for recommendations.
       description: Set the documents considered for recommendations.
-      operationId: replaceDocumentCandidates
       requestBody:
         required: true
         content:
@@ -237,6 +237,40 @@ paths:
       summary: Delete a document property
       description: Deletes the property of the document.
       operationId: deleteDocumentProperty
+      responses:
+        '204':
+          description: successful operation
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
+
+  /candidates:
+    get:
+      tags:
+        - back office
+      summary: Get the documents considered for recommendations.
+      description: Get the documents considered for recommendations.
+      operationId: listDocumentCandidates
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCandidatesResponse'
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
+    put:
+      tags:
+        - back office
+      summary: Set the documents considered for recommendations.
+      description: Set the documents considered for recommendations.
+      operationId: replaceDocumentCandidates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentCandidatesRequest'
       responses:
         '204':
           description: successful operation

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -45,6 +45,11 @@ use crate::{
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     config
         .service(
+            web::resource("/candidates")
+                .route(web::get().to(get_document_candidates.error_with_request_id()))
+                .route(web::put().to(set_document_candidates.error_with_request_id())),
+        )
+        .service(
             web::resource("/documents")
                 .route(web::post().to(new_documents.error_with_request_id()))
                 .route(web::delete().to(delete_documents.error_with_request_id())),


### PR DESCRIPTION
`/documents/candidates`  can conflict with `/documents/<id>`. At the moment there isn't such a conflict because of different methods but this will forbid us from adding methods to `/documents/<id>` and in general can confusing for the end user and us.