### PR TITLE
remove old lint todo

### DIFF
--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -18,8 +18,6 @@
 #![cfg_attr(not(test), forbid(unsafe_code))]
 #![cfg_attr(test, deny(unsafe_code))]
 #![deny(
-    // TODO: check if/how this can be enabled as this has conflicts inherently rooted in actix-web trait bounds
-    // clippy::future_not_send,
     clippy::pedantic,
     noop_method_call,
     rust_2018_idioms,


### PR DESCRIPTION
> clippy::future_not_send

There is little reason but a lot of overhead to use this for us.

Due to actix pinning request handlers to threads they don't need to be `Send`.

As long as we don't switch to axum or similar we have no reason to enforce them being `Send`.

As it wasn't enforced until now  many of our futures are in turn not send, and for some actix specific ones it might be non trivial to make them send.

Fell free to bors r+ this next week if it's approved.

