### PR TITLE
[Merged by Bors] - simplify request id injection

### DIFF
--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -27,18 +27,13 @@ use tracing::{error, info, instrument};
 
 use super::AppState;
 use crate::{
-    app::TenantState,
-    error::{
-        application::WithRequestIdExt,
-        common::{
-            BadRequest,
-            DocumentIdAsObject,
-            DocumentNotFound,
-            DocumentPropertyNotFound,
-            FailedToDeleteSomeDocuments,
-            FailedToSetSomeDocumentCandidates,
-            IngestingDocumentsFailed,
-        },
+    error::common::{
+        BadRequest,
+        DocumentNotFound,
+        DocumentPropertyNotFound,
+        FailedToDeleteSomeDocuments,
+        FailedToSetSomeDocumentCandidates,
+        IngestingDocumentsFailed,
     },
     models::{self, DocumentId, DocumentProperties, DocumentProperty, DocumentTag},
     storage,
@@ -49,34 +44,31 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
     config
         .service(
             web::resource("/candidates")
-                .route(web::get().to(get_document_candidates.error_with_request_id()))
-                .route(web::put().to(set_document_candidates.error_with_request_id())),
+                .route(web::get().to(get_document_candidates))
+                .route(web::put().to(set_document_candidates)),
         )
         .service(
             web::resource("/documents")
-                .route(web::post().to(upsert_documents.error_with_request_id()))
-                .route(web::delete().to(delete_documents.error_with_request_id())),
+                .route(web::post().to(upsert_documents))
+                .route(web::delete().to(delete_documents)),
         )
         .service(
             web::resource("/documents/candidates")
-                .route(web::get().to(get_document_candidates.error_with_request_id()))
-                .route(web::put().to(set_document_candidates.error_with_request_id())),
+                .route(web::get().to(get_document_candidates))
+                .route(web::put().to(set_document_candidates)),
         )
-        .service(
-            web::resource("/documents/{document_id}")
-                .route(web::delete().to(delete_document.error_with_request_id())),
-        )
+        .service(web::resource("/documents/{document_id}").route(web::delete().to(delete_document)))
         .service(
             web::resource("/documents/{document_id}/properties")
-                .route(web::get().to(get_document_properties.error_with_request_id()))
-                .route(web::put().to(put_document_properties.error_with_request_id()))
-                .route(web::delete().to(delete_document_properties.error_with_request_id())),
+                .route(web::get().to(get_document_properties))
+                .route(web::put().to(put_document_properties))
+                .route(web::delete().to(delete_document_properties)),
         )
         .service(
             web::resource("/documents/{document_id}/properties/{property_id}")
-                .route(web::get().to(get_document_property.error_with_request_id()))
-                .route(web::put().to(put_document_property.error_with_request_id()))
-                .route(web::delete().to(delete_document_property.error_with_request_id())),
+                .route(web::get().to(get_document_property))
+                .route(web::put().to(put_document_property))
+                .route(web::delete().to(delete_document_property)),
         );
 }
 

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -27,8 +27,10 @@ use tracing::{error, info, instrument};
 
 use super::AppState;
 use crate::{
+    app::TenantState,
     error::common::{
         BadRequest,
+        DocumentIdAsObject,
         DocumentNotFound,
         DocumentPropertyNotFound,
         FailedToDeleteSomeDocuments,

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -14,14 +14,14 @@
 
 //! The web engine & api.
 
-#![forbid(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 #![cfg_attr(test, deny(unsafe_code))]
 #![deny(
     clippy::pedantic,
     noop_method_call,
     rust_2018_idioms,
-    unused_qualifications
+    unused_qualifications,
+    unsafe_op_in_unsafe_fn
 )]
 #![warn(unreachable_pub, rustdoc::missing_crate_level_docs)]
 #![allow(

--- a/web-api/src/middleware/request_context.rs
+++ b/web-api/src/middleware/request_context.rs
@@ -17,7 +17,8 @@ use std::{future::Future, str, sync::Arc};
 use actix_web::{
     body::BoxBody,
     dev::{Service, ServiceRequest, ServiceResponse},
-    HttpMessage, HttpRequest,
+    HttpMessage,
+    HttpRequest,
 };
 use anyhow::anyhow;
 use futures_util::{

--- a/web-api/src/middleware/request_context.rs
+++ b/web-api/src/middleware/request_context.rs
@@ -17,8 +17,7 @@ use std::{future::Future, str, sync::Arc};
 use actix_web::{
     body::BoxBody,
     dev::{Service, ServiceRequest, ServiceResponse},
-    HttpMessage,
-    HttpRequest,
+    HttpMessage, HttpRequest,
 };
 use anyhow::anyhow;
 use futures_util::{
@@ -30,6 +29,7 @@ use regex::bytes;
 use serde::{Deserialize, Serialize};
 use sqlx::Type;
 use thiserror::Error;
+use tokio::{task::futures::TaskLocalFuture, task_local};
 use tracing::{error_span, instrument, trace, Instrument};
 use uuid::Uuid;
 
@@ -119,6 +119,10 @@ impl TenantId {
 #[serde(transparent)]
 pub(crate) struct RequestId(Uuid);
 
+task_local! {
+    static CURRENT_REQUEST_ID: RequestId;
+}
+
 impl RequestId {
     pub(crate) fn generate() -> Self {
         Self(Uuid::new_v4())
@@ -126,6 +130,21 @@ impl RequestId {
 
     pub(crate) const fn missing() -> Self {
         Self(Uuid::nil())
+    }
+
+    pub(crate) fn wrap_future<F>(self, future: F) -> TaskLocalFuture<RequestId, F>
+    where
+        F: 'static + Future,
+    {
+        CURRENT_REQUEST_ID.scope(self, future)
+    }
+
+    pub(crate) fn extract_from_task_local_storage() -> Result<RequestId, AccessError> {
+        CURRENT_REQUEST_ID
+            .try_with(|id| *id)
+            .map_err(|_| AccessError {
+                method: "extract_from_task_local_storage",
+            })
     }
 }
 
@@ -179,10 +198,12 @@ where
     request.extensions_mut().insert(context);
 
     Either::Right(
-        service
-            .call(request)
-            .instrument(span.clone())
-            .inspect(|_| trace!(parent: span, "request processed")),
+        request_id.wrap_future(
+            service
+                .call(request)
+                .instrument(span.clone())
+                .inspect(|_| trace!(parent: span, "request processed")),
+        ),
     )
 }
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -42,7 +42,6 @@ use super::{
 use crate::{
     app::TenantState,
     error::{
-        application::WithRequestIdExt,
         common::{BadRequest, DocumentNotFound},
         warning::Warning,
     },
@@ -53,16 +52,11 @@ use crate::{
 
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     let users = web::scope("/users/{user_id}")
+        .service(web::resource("interactions").route(web::patch().to(interactions)))
         .service(
-            web::resource("interactions")
-                .route(web::patch().to(interactions.error_with_request_id())),
-        )
-        .service(
-            web::resource("personalized_documents")
-                .route(web::get().to(personalized_documents.error_with_request_id())),
+            web::resource("personalized_documents").route(web::get().to(personalized_documents)),
         );
-    let semantic_search = web::resource("/semantic_search")
-        .route(web::post().to(semantic_search.error_with_request_id()));
+    let semantic_search = web::resource("/semantic_search").route(web::post().to(semantic_search));
 
     config.service(users).service(semantic_search);
 }


### PR DESCRIPTION
This replaces complex type magic used to inject the request ID into an error with a simple task local storage injection.

IMHO this is what I should have done from the beginning.

Sure "magic implicit parameters" in form of task local data aren't grate but:

- we anyway use a extension system which doesn't enforce the existence of the value through the type system. In case of the type magic we use the `HttpRequest` extensions, which if we forget to put the request id in will fail at runtime and is kinda like a implicit parameter. In case of TLS we use TLS and fail at runtime if we forget to put it there the same way (but with an error message which better points to the source of failure).  **So the type magic doesn't provide any additional type safety, only complexity.**

- the type magic is complicated an hostile to changes, error messages in it are also worse due to being less specific

- the type magic breaks actix macros like `#[get('/...')]` through if we want to use that is a different question

- as extractors are run as part of actix there is no risk of accidentally calling it in a `tokio::spawn`ed sub-task 

- if we for some reason run it outside of the context of the actix request handler we can always inject  it using `wrap_future` , but for integration tests this is not necessary and for unit tests outside of unit testing the request id injection unlikely to ever matter. 