### PR TITLE
[Merged by Bors] - ET-4326 fix missing tracing span for lower level subscribers

### DIFF
--- a/web-api/src/middleware/tracing.rs
+++ b/web-api/src/middleware/tracing.rs
@@ -20,7 +20,7 @@ use actix_web::{
 };
 use futures_util::FutureExt;
 use serde::Serialize;
-use tracing::{info_span, trace, Instrument};
+use tracing::{error_span, trace, Instrument};
 use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, derive_more::Display, Serialize)]
@@ -46,7 +46,9 @@ where
     S::Future: 'static,
 {
     let request_id = RequestId::generate();
-    let span = info_span!(
+    // the request span must have the lowest level, otherwise it will not be added to the logs if a
+    // subscriber with a lower level filter than the span level is used
+    let span = error_span!(
         "request",
         path = %request.request().path(),
         method = %request.request().method(),


### PR DESCRIPTION
**Reference**

- [ET-4326]
- followed by #876

**Summary**

- fix missing tracing span for lower level subscribers

**Example**

currently a subscriber with `warn` or lower level will produce logs without a span like
```
2023-04-13T08:21:02.803589Z ERROR xayn_web_api::error::application: error=The requested document was not found.
```
and now it will produce logs with a span like
```
2023-04-13T08:19:04.546106Z ERROR request{path=/documents/d3/properties method=GET request_id=6eb739f9-4fb7-44a8-bb7b-c7a3d3094e2e}: xayn_web_api::error::application: error=The requested document was not found.
```
as intented. this didn't show up for `info` or higher level subscribers because the span level was `info` as well.


[ET-4326]: https://xainag.atlassian.net/browse/ET-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ