### PR TITLE
[Merged by Bors] - ET-4329 Remove request size limit

### DIFF
--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -64,9 +64,6 @@ pub struct Config {
     /// Address to which the server should bind.
     pub(crate) bind_to: SocketAddr,
 
-    /// Max body size limit which should be applied to all endpoints
-    pub(crate) max_body_size: usize,
-
     /// Keep alive timeout in seconds
     #[serde(with = "serde_duration_as_seconds")]
     pub(crate) keep_alive: Duration,
@@ -80,7 +77,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             bind_to: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 4252).into(),
-            max_body_size: 524_288,
             keep_alive: Duration::from_secs(61),
             client_request_timeout: Duration::from_secs(0),
         }
@@ -98,12 +94,11 @@ where
 {
     let &Config {
         bind_to,
-        max_body_size,
         keep_alive,
         client_request_timeout,
     } = (*app_state).as_ref();
 
-    let json_config = JsonConfig::default().limit(max_body_size);
+    let json_config = JsonConfig::default();
     let web_app_state = web::Data::from(app_state.clone());
 
     let server = HttpServer::new(move || {

--- a/web-api/tests/cmd/assets/config.toml
+++ b/web-api/tests/cmd/assets/config.toml
@@ -3,7 +3,6 @@ file = "foo/bar.log"
 
 [net]
 bind_to = "127.0.1.1:3040"
-max_body_size = 64
 
 [storage.elastic]
 url = "http://localhost:3219"

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.4.3.2:1099",
-    "max_body_size": 64,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.0.1:4252",
-    "max_body_size": 524288,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.0.1:4252",
-    "max_body_size": 524288,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.1.1:3040",
-    "max_body_size": 4422,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.0.1:4252",
-    "max_body_size": 524288,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.0.1.1:3040",
-    "max_body_size": 64,
     "keep_alive": 61,
     "client_request_timeout": 0
   },

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -10,7 +10,6 @@ stdout = """
   },
   "net": {
     "bind_to": "127.4.3.2:1099",
-    "max_body_size": 64,
     "keep_alive": 61,
     "client_request_timeout": 0
   },


### PR DESCRIPTION
Remove the size limit from the application, it is implemented at the infrastructure level.