### PR TITLE
[Merged by Bors] - Set high limit for request size

### DIFF
--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -98,7 +98,8 @@ where
         client_request_timeout,
     } = (*app_state).as_ref();
 
-    let json_config = JsonConfig::default();
+    // limits are handled by the infrastructure
+    let json_config = JsonConfig::default().limit(u32::MAX as usize);
     let web_app_state = web::Data::from(app_state.clone());
 
     let server = HttpServer::new(move || {


### PR DESCRIPTION
Set the limit for the request high. The default is two low for us and we want to handle this limits only in the infrastructure.