### PR TITLE
[Merged by Bors] - ET-4331-spec-do-not-override-is-candidate

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -350,7 +350,7 @@ components:
             Behaves like `is_candidate` but will not overwrite any existing `is_candidate`
             value already stored in the database for this document.
 
-            Setting both this field and the `default_is_candidate` field will fail the request.
+            Setting both this field and the `is_candidate` field will fail the request.
           type: boolean
 
     IngestionRequest:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -334,9 +334,25 @@ components:
           items:
             $ref: './schemas/document.yml#/DocumentTag'
         is_candidate:
-          description: Indicates if the document is considered for recommendations.
+          description: |
+            Indicates if the document is considered for recommendations.
+
+            Always overwrite any existing `is_candidate` value from a previous ingestion.
+
+            Setting both this field and `default_is_candidate` will fail the request.
+
+            Setting neither will default to `is_candidate` being set to it's default value.
           type: boolean
           default: true
+
+        default_is_candidate:
+          description: |
+            Behaves like `is_candidate` but will not overwrite any existing `is_candidate`
+            value already stored in the database for this document.
+
+            Setting both this field and `default_is_candidate` will fail the request.
+          type: boolean
+
     IngestionRequest:
       type: object
       required: [documents]

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -339,7 +339,7 @@ components:
 
             Always overwrite any existing `is_candidate` value from a previous ingestion.
 
-            Setting both this field and `default_is_candidate` will fail the request.
+            Setting both this field and the `default_is_candidate` field will fail the request.
 
             Setting neither will default to `is_candidate` being set to it's default value.
           type: boolean
@@ -350,7 +350,7 @@ components:
             Behaves like `is_candidate` but will not overwrite any existing `is_candidate`
             value already stored in the database for this document.
 
-            Setting both this field and `default_is_candidate` will fail the request.
+            Setting both this field and the `default_is_candidate` field will fail the request.
           type: boolean
 
     IngestionRequest:


### PR DESCRIPTION

**Situation:**

- a customer re-ingests documents
- they always set `is_candidate = false`
- if they had already set `is_candidate` to `true` they don't want this to be overwritten when re-ingesting documents 

**References:**

- Story [ET-4330]
- Issue [ET-4331]

[ET-4330]: https://xainag.atlassian.net/browse/ET-4330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4331]: https://xainag.atlassian.net/browse/ET-4331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ