### PR TITLE
[Merged by Bors] - ET-4237 avoid recalculating embedding for existing docs

### DIFF
--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -30,6 +30,7 @@ use crate::{
         application::WithRequestIdExt,
         common::{
             BadRequest,
+            DocumentIdAsObject,
             DocumentNotFound,
             DocumentPropertyNotFound,
             FailedToDeleteSomeDocuments,
@@ -37,7 +38,7 @@ use crate::{
             IngestingDocumentsFailed,
         },
     },
-    models::{self, DocumentId, DocumentProperties, DocumentProperty},
+    models::{self, DocumentId, DocumentProperties, DocumentProperty, DocumentTag},
     storage,
     Error,
 };
@@ -51,7 +52,7 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
         )
         .service(
             web::resource("/documents")
-                .route(web::post().to(new_documents.error_with_request_id()))
+                .route(web::post().to(upsert_documents.error_with_request_id()))
                 .route(web::delete().to(delete_documents.error_with_request_id())),
         )
         .service(
@@ -96,7 +97,7 @@ const fn default_is_candidate() -> bool {
 }
 
 #[derive(Debug, Deserialize)]
-struct IngestedDocument {
+struct UnvalidatedIngestedDocument {
     id: String,
     #[serde(deserialize_with = "deserialize_string_not_empty_or_zero_bytes")]
     snippet: String,
@@ -108,14 +109,53 @@ struct IngestedDocument {
     is_candidate: bool,
 }
 
+#[derive(Debug)]
+struct IngestedDocument {
+    id: DocumentId,
+    snippet: String,
+    properties: DocumentProperties,
+    tags: Vec<DocumentTag>,
+    is_candidate: bool,
+}
+
+impl UnvalidatedIngestedDocument {
+    fn validate(self) -> Result<IngestedDocument, DocumentIdAsObject> {
+        let validate = || -> anyhow::Result<_> {
+            let id = self.id.as_str().try_into()?;
+            let properties = self
+                .properties
+                .into_iter()
+                .map(|(id, property)| id.try_into().map(|id| (id, property)))
+                .try_collect()?;
+            let tags = self.tags.into_iter().map(TryInto::try_into).try_collect()?;
+
+            Ok(IngestedDocument {
+                id,
+                snippet: self.snippet,
+                properties,
+                tags,
+                is_candidate: self.is_candidate,
+            })
+        };
+
+        validate().map_err(|error| {
+            error!(
+                "Document with id '{}' caused a PipelineError: {:#?}",
+                self.id, error,
+            );
+            self.id.into()
+        })
+    }
+}
+
 /// Represents body of a POST documents request.
 #[derive(Debug, Deserialize)]
 struct IngestionRequestBody {
-    documents: Vec<IngestedDocument>,
+    documents: Vec<UnvalidatedIngestedDocument>,
 }
 
 #[instrument(skip_all)]
-async fn new_documents(
+async fn upsert_documents(
     state: Data<AppState>,
     Json(body): Json<IngestionRequestBody>,
 ) -> Result<impl Responder, Error> {
@@ -132,54 +172,78 @@ async fn new_documents(
         .into());
     }
 
-    let start = Instant::now();
-
     let (documents, mut failed_documents) = body
         .documents
         .into_iter()
-        .map(|document| {
-            let map_document = || -> anyhow::Result<_> {
-                let id = document.id.as_str().try_into()?;
-                let properties = document
-                    .properties
-                    .into_iter()
-                    .map(|(id, property)| id.try_into().map(|id| (id, property)))
-                    .try_collect()?;
-                let tags = document
-                    .tags
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .try_collect()?;
-                let embedding = state.embedder.run(&document.snippet)?;
+        .map(UnvalidatedIngestedDocument::validate)
+        .partition_result::<Vec<_>, Vec<_>, _, _>();
+    let snippets = storage::Document::get_excerpted(
+        &state.storage,
+        documents.iter().map(|document| &document.id),
+    )
+    .await?
+    .into_iter()
+    .map(|document| (document.id, document.snippet))
+    .collect::<HashMap<_, _>>();
+    let (changed_documents, new_documents) =
+        documents.into_iter().partition::<Vec<_>, _>(|document| {
+            snippets
+                .get(&document.id)
+                .map(|snippet| document.snippet == *snippet)
+                .unwrap_or_default()
+        });
 
-                Ok(models::IngestedDocument {
-                    id,
-                    snippet: document.snippet,
-                    properties,
-                    tags,
-                    embedding,
-                    is_candidate: document.is_candidate,
-                })
-            };
+    // checked above that all changed documents exist, hence no extended failed documents
+    storage::DocumentCandidate::remove(
+        &state.storage,
+        changed_documents
+            .iter()
+            .filter_map(|document| (!document.is_candidate).then_some(&document.id)),
+    )
+    .await?;
+    for document in &changed_documents {
+        storage::DocumentProperties::put(&state.storage, &document.id, &document.properties)
+            .await?;
+        storage::Tag::put(&state.storage, &document.id, &document.tags).await?;
+    }
+    storage::DocumentCandidate::add(
+        &state.storage,
+        changed_documents
+            .iter()
+            .filter_map(|document| document.is_candidate.then_some(&document.id)),
+    )
+    .await?;
 
-            map_document().map_err(|error| {
+    let start = Instant::now();
+    let new_documents = new_documents
+        .into_iter()
+        .filter_map(|document| match state.embedder.run(&document.snippet) {
+            Ok(embedding) => Some(models::IngestedDocument {
+                id: document.id,
+                snippet: document.snippet,
+                properties: document.properties,
+                tags: document.tags,
+                embedding,
+                is_candidate: document.is_candidate,
+            }),
+            Err(error) => {
                 error!(
                     "Document with id '{}' caused a PipelineError: {:#?}",
                     document.id, error,
                 );
-                document.id.into()
-            })
+                failed_documents.push(document.id.into());
+                None
+            }
         })
-        .partition_result::<Vec<_>, Vec<_>, _, _>();
-
+        .collect_vec();
     info!(
-        "{} embeddings calculated in {} sec",
-        documents.len(),
+        "{} new embeddings calculated in {} seconds and {} unchanged embeddings skipped",
+        new_documents.len(),
         start.elapsed().as_secs(),
+        changed_documents.len(),
     );
-
     failed_documents.extend(
-        storage::Document::insert(&state.storage, documents)
+        storage::Document::insert(&state.storage, new_documents)
             .await?
             .into_iter()
             .map(Into::into),

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -185,6 +185,7 @@ async fn upsert_documents(
     .into_iter()
     .map(|document| (document.id, document.snippet))
     .collect::<HashMap<_, _>>();
+
     let (changed_documents, new_documents) =
         documents.into_iter().partition::<Vec<_>, _>(|document| {
             snippets
@@ -236,6 +237,7 @@ async fn upsert_documents(
             }
         })
         .collect_vec();
+
     info!(
         "{} new embeddings calculated in {} seconds and {} unchanged embeddings skipped",
         new_documents.len(),

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -188,6 +188,12 @@ pub(crate) struct IngestedDocument {
     pub(crate) is_candidate: bool,
 }
 
+#[derive(Debug)]
+pub(crate) struct ExcerptedDocument {
+    pub(crate) id: DocumentId,
+    pub(crate) snippet: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -497,6 +497,29 @@ impl Client {
             .await?
             .map(|_| Some(())))
     }
+
+    pub(super) async fn insert_document_tags(
+        &self,
+        id: &DocumentId,
+        tags: &[DocumentTag],
+    ) -> Result<Option<()>, Error> {
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
+        let url = self.create_resource_path(["_update", id.as_ref()], None);
+        let body = Some(json!({
+            "script": {
+                "source": "ctx._source.tags = params.tags",
+                "params": {
+                    "tags": tags
+                }
+            },
+            "_source": false
+        }));
+
+        Ok(self
+            .query_with_json::<_, IgnoredResponse>(url, body)
+            .await?
+            .map(|_| ()))
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
**Reference**

- [ET-4237]

**Summary**

- during ingestion check if a document is new or changed
  - we currently consider it changed if the id exists and the snippet is the same
  - if the id doesn't exist or if the snippet changed (ie recalculation of the embedding) we consider it new
- ingest a new document like before, ie overwriting if the id already exists
- update the parts of a changed document, ie properties & tags & candidate status


[ET-4237]: https://xainag.atlassian.net/browse/ET-4237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ