### PR TITLE
[Merged by Bors] - ET-4332 impl do not override is candidate

### DIFF
--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -242,7 +242,7 @@ async fn upsert_documents(
         .map(|document| {
             let (snippet, is_candidate) = existing_data
                 .get(&document.id)
-                .map(|(s, c)| (s, *c))
+                .map(|(snippet, is_candidate)| (snippet, *is_candidate))
                 .unzip();
 
             let new_is_candidate = document.is_candidate_op.resolve(is_candidate);

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -124,7 +124,7 @@ enum IsCandidateOp {
 }
 
 impl IsCandidateOp {
-    /// Returns the new value and `has_existing && is_changed_value`
+    /// Returns a `NewIsCandidate` instance.
     fn resolve(self, existing: Option<bool>) -> NewIsCandidate {
         match self {
             IsCandidateOp::SetTo(new) => NewIsCandidate {
@@ -144,7 +144,9 @@ impl IsCandidateOp {
 #[derive(Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
 struct NewIsCandidate {
+    /// The new value of `is_candidate`.
     value: bool,
+    /// `true` if there had been an existing value for `is_candidate` and it differs from the new value
     existing_and_has_changed: bool,
 }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -192,6 +192,7 @@ pub(crate) struct IngestedDocument {
 pub(crate) struct ExcerptedDocument {
     pub(crate) id: DocumentId,
     pub(crate) snippet: String,
+    pub(crate) is_candidate: bool,
 }
 
 #[cfg(test)]

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -294,6 +294,7 @@ impl storage::Document for Storage {
                 documents.0.get(id).map(|document| ExcerptedDocument {
                     id: id.clone(),
                     snippet: document.snippet.clone(),
+                    is_candidate: document.is_candidate,
                 })
             })
             .collect();

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -392,7 +392,7 @@ impl Database {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error> {
         let mut builder = QueryBuilder::new(
-            "SELECT document_id, snippet
+            "SELECT document_id, snippet, is_candidate
             FROM document
             WHERE document_id IN ",
         );
@@ -405,8 +405,12 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row| {
-                        let (id, snippet) = FromRow::from_row(&row)?;
-                        Ok(ExcerptedDocument { id, snippet })
+                        let (id, snippet, is_candidate) = FromRow::from_row(&row)?;
+                        Ok(ExcerptedDocument {
+                            id,
+                            snippet,
+                            is_candidate,
+                        })
                     })
                     .fetch_all(&mut *tx)
                     .await?,


### PR DESCRIPTION
If `default_is_candidate` is given instead of `is_candidate` we will use any existing `is_candidate` setting from the database for given document id and only use the value of `default_is_candidate` if the document is new.

Specifying both `default_is_candidate` and `is_candidate` is an error handled the same way as a malformed document id, tag name or similar.

**References:**

- story: [ET-4330]
- task: [ET-4332]

[ET-4330]: https://xainag.atlassian.net/browse/ET-4330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4332]: https://xainag.atlassian.net/browse/ET-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ