### PR TITLE
[Merged by Bors] - explict example for ingestion

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -352,6 +352,15 @@ components:
 
             Setting both this field and the `is_candidate` field will fail the request.
           type: boolean
+      example:
+        id: document_1
+        snippet: lorem ipsum delores
+        properties:
+          is_blue: true
+        tags:
+          - news
+          - tech
+        is_candidate: true
 
     IngestionRequest:
       type: object
@@ -363,6 +372,21 @@ components:
           maxItems: 100
           items:
             $ref: '#/components/schemas/IngestedDocument'
+      example:
+        documents:
+          - id: document_1
+            snippet: lorem ipsum delores
+            properties:
+              is_blue: true
+            tags:
+              - news
+              - tech
+            is_candidate: false
+          - id: document_2
+            snippet: more lorem less ipsum
+            tags:
+              - exclusive
+            default_is_candidate: false
     IngestionError:
       allOf:
         - $ref: './schemas/error.yml#/GenericError'

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Back Office API
-  version: 1.0.0-rc11
+  version: 1.0.0-rc13
   description: |-
     # Back Office
     The back office is typically used within server-side apps.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Front Office API
-  version: 1.0.0-rc11
+  version: 1.0.0-rc13
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.


### PR DESCRIPTION
The auto generated examples do contain both `is_candidate` and `default_is_candidate` which is invalid.

But we can't (easily/cleanly) add constraints that only either of them is allowed as depending on how we do so this either trips over the linter or the API generator.