### PR TITLE
[Merged by Bors] - fix problem with generated code

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -341,9 +341,8 @@ components:
 
             Setting both this field and the `default_is_candidate` field will fail the request.
 
-            Setting neither will default to `is_candidate` being set to it's default value.
+            Setting neither will default to `is_candidate = true`.
           type: boolean
-          default: true
 
         default_is_candidate:
           description: |


### PR DESCRIPTION
don't annotate the default value for is_candidate

if we do so there are some cases in which `is_candidate` will be unexpectedly set to the default value, instead of not being set using the server default.