### PR TITLE
[Merged by Bors] - ET-4314 normalize hybrid search score

### DIFF
--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -146,6 +146,9 @@ async fn test_personalization_all_dates() {
                     .collect::<HashSet<_>>(),
                 ["d1", "d3", "d6", "d7", "d8"].into(),
             );
+            assert!(documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },
@@ -174,6 +177,9 @@ async fn test_personalization_limited_dates() {
                     .collect::<HashSet<_>>(),
                 ["d1", "d3"].into(),
             );
+            assert!(documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },
@@ -202,6 +208,9 @@ async fn test_personalization_with_query() {
                     .collect::<HashSet<_>>(),
                 ["d1", "d6", "d7", "d8"].into(),
             );
+            assert!(documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -73,7 +73,6 @@ async fn interact(client: &Client, personalization_url: &Url) -> Result<(), Pani
 #[derive(Debug, Deserialize)]
 struct PersonalizedDocumentData {
     id: String,
-    #[allow(dead_code)]
     score: f32,
     #[allow(dead_code)]
     #[serde(default)]
@@ -133,6 +132,10 @@ async fn test_full_personalization() {
                 "unexpected not enough interactions documents: {:?}",
                 not_enough_interactions.documents,
             );
+            assert!(not_enough_interactions
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             interact(&client, &personalization_url).await?;
 
@@ -154,6 +157,10 @@ async fn test_full_personalization() {
                 "unexpected not personalized documents: {:?}",
                 not_personalized.documents,
             );
+            assert!(not_personalized
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             let fully_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
@@ -178,6 +185,10 @@ async fn test_full_personalization() {
                 "unexpected fully personalized documents: {:?}",
                 fully_personalized.documents,
             );
+            assert!(fully_personalized
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },
@@ -225,6 +236,10 @@ async fn test_subtle_personalization() {
                 "unexpected subtle personalized documents: {:?}",
                 subtle_personalized.documents,
             );
+            assert!(subtle_personalized
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },
@@ -271,6 +286,10 @@ async fn test_full_personalization_with_inline_history() {
                 "unexpected not enough interactions documents: {:?}",
                 not_enough_interactions.documents,
             );
+            assert!(not_enough_interactions
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             let not_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
@@ -290,6 +309,10 @@ async fn test_full_personalization_with_inline_history() {
                 "unexpected not personalized documents: {:?}",
                 not_personalized.documents,
             );
+            assert!(not_personalized
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             let fully_personalized = send_assert_json::<SemanticSearchResponse>(
                 &client,
@@ -317,6 +340,10 @@ async fn test_full_personalization_with_inline_history() {
                 "unexpected fully personalized documents: {:?}",
                 fully_personalized.documents,
             );
+            assert!(fully_personalized
+                .documents
+                .iter()
+                .all(|document| (0.0..=1.0).contains(&document.score)));
 
             Ok(())
         },

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -102,6 +102,9 @@ async fn test_semantic_search() {
                 assert_eq!(first.id, "d3");
                 assert_eq!(second.id, "d2");
                 assert!(first.score > second.score);
+                assert!((0.0..first.score).contains(&second.score));
+                assert!((second.score..=1.0).contains(&first.score));
+                assert!((0.0..=1.0).contains(&second.score));
                 assert!(first.properties.is_null());
                 assert_eq!(second.properties, json!({ "dodo": 4 }))
             } else {
@@ -158,7 +161,7 @@ async fn test_semantic_search_min_similarity() {
 
             if let [first] = &documents[..] {
                 assert_eq!(first.id, "d3");
-                assert!(first.score >= 0.6);
+                assert!((0.6..=1.0).contains(&first.score));
             } else {
                 panic!("Unexpected number of documents: {documents:?}");
             }
@@ -214,8 +217,9 @@ async fn test_semantic_search_with_query() {
                 assert_eq!(first.id, "d1");
                 assert_eq!(second.id, "d3");
                 assert_eq!(third.id, "d2");
-                assert!(first.score > second.score);
-                assert!(second.score > third.score);
+                assert!((0.0..second.score).contains(&third.score));
+                assert!((third.score..first.score).contains(&second.score));
+                assert!((second.score..=1.0).contains(&first.score));
                 assert!(first.properties.is_null());
                 assert!(second.properties.is_null());
                 assert_eq!(third.properties, json!({ "dodo": 4 }))


### PR DESCRIPTION
**Reference**

- [ET-4314]

**Summary**

- normalize the ES score for hybrid search: in case where a document only has a bm25 score but no knn score and the distribution of bm25 scores in that query is bad, the normalized score is likely to be bad as well (but we can't do much better without expensive multi-query strategies). in all other cases the normalization is likely to be good enough.
- there is one main caveat though currently: the normalization happens for each search call, so if we eg make a search call for multiple cois and then combine the returned documents, then the score normalization is applied to each subset of documents returned for each coi instead of for all documents together. this can lead to skewed scores if the score distribution for each subset varies much. if we want to normalize over multiple search calls, we would need to return the intermediate normalization components instead of the normalized scores. i guess if this is required, it should be done in a follow up pr.


[ET-4314]: https://xainag.atlassian.net/browse/ET-4314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ