### PR TITLE
[Merged by Bors] - ET-4304 tenant id str instead of UUID

### DIFF
--- a/web-api/src/middleware/request_context.rs
+++ b/web-api/src/middleware/request_context.rs
@@ -218,19 +218,15 @@ fn trim_ascii(ascii: &[u8]) -> &[u8] {
 fn trim_ascii_start(ascii: &[u8]) -> &[u8] {
     ascii
         .iter()
-        .position(is_not_ascii_whitespace)
+        .position(|byte| !byte.is_ascii_whitespace())
         .map_or(&[], |new_first| &ascii[new_first..])
 }
 
 fn trim_ascii_end(ascii: &[u8]) -> &[u8] {
     ascii
         .iter()
-        .rposition(is_not_ascii_whitespace)
+        .rposition(|byte| !byte.is_ascii_whitespace())
         .map_or(&[], |new_last| &ascii[..=new_last])
-}
-
-fn is_not_ascii_whitespace(byte: &u8) -> bool {
-    !byte.is_ascii_whitespace()
 }
 
 #[cfg(test)]

--- a/web-api/src/middleware/request_context.rs
+++ b/web-api/src/middleware/request_context.rs
@@ -91,13 +91,13 @@ pub(crate) struct InvalidTenantId {
 impl TenantId {
     pub(crate) fn missing() -> Self {
         static MISSING: Lazy<Arc<str>> = Lazy::new(|| "missing".into());
-        TenantId(MISSING.clone())
+        Self(MISSING.clone())
     }
 
     #[allow(dead_code)]
     fn random_legacy_tenant_id() -> Self {
         let random_id: u64 = rand::random();
-        TenantId(format!("legacy.{random_id:0>16x}").as_str().into())
+        Self(format!("legacy.{random_id:0>16x}").as_str().into())
     }
 
     fn try_parse_ascii(ascii: &[u8]) -> Result<Self, InvalidTenantId> {


### PR DESCRIPTION
I copied the final version of TenantId (from the db management PR) and then changed it to use `Arc<str>` instead of `UUID`.

This means there is a bit of other changes:

- a InvalidTenantId error type
- additional derives needed in later PRs
  - including sqlx::Type/sqlx::transparent 
- parsing from `ascii` instead of `HeaderValue` 
  - (because it will get moved into `web-api-shared`, which doesn't depend on actix_web and it's the actix version of `HeaderValue`)
  
For now I arbitrarily constrained the TenantId to   `^[a-zA-Z0-9_:@.-]{1,50}$`  we could bump the length to 61 and allow any chars the quoted postgres identifier supports. But I think having it more constrained for now is a good idea.