### PR TITLE
[Merged by Bors] - ET-4345 prepare es for multi tenant

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use xayn_ai_bert::InvalidEmbedding;
 
 use super::application::ApplicationError;
-use crate::{impl_application_error, models::DocumentId, Error};
+use crate::{impl_application_error, models::DocumentId, storage::elastic::ElasticError, Error};
 
 impl_application_error!(InvalidEmbedding => BAD_REQUEST);
 
@@ -130,6 +130,12 @@ impl From<String> for BadRequest {
         Self {
             message: Cow::Owned(message),
         }
+    }
+}
+
+impl From<ElasticError> for Error {
+    fn from(error: ElasticError) -> Self {
+        InternalError::from_std(error).into()
     }
 }
 

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -18,7 +18,7 @@ pub(crate) mod memory;
 pub(crate) mod postgres;
 mod utils;
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -230,7 +230,7 @@ pub struct Config {
 }
 
 pub(crate) struct Storage {
-    elastic: Arc<elastic::Client>,
+    elastic: elastic::Client,
     postgres: postgres::Database,
 }
 
@@ -240,7 +240,7 @@ impl Storage {
         enable_legacy_tenant: bool,
     ) -> Result<StorageBuilder, SetupError> {
         Ok(StorageBuilder {
-            elastic: Arc::new(elastic::Client::new(&config.elastic)?),
+            elastic: elastic::Client::builder(&config.elastic)?,
             postgres: postgres::Database::builder(&config.postgres, enable_legacy_tenant).await?,
         })
     }
@@ -248,14 +248,14 @@ impl Storage {
 
 #[derive(Clone)]
 pub(crate) struct StorageBuilder {
-    elastic: Arc<elastic::Client>,
+    elastic: elastic::ClientBuilder,
     postgres: postgres::DatabaseBuilder,
 }
 
 impl StorageBuilder {
     pub(crate) fn build_for(&self, tenant_id: &TenantId) -> Result<Storage, Error> {
         Ok(Storage {
-            elastic: self.elastic.clone(),
+            elastic: self.elastic.build(),
             postgres: self.postgres.build_for(tenant_id)?,
         })
     }

--- a/web-api/src/storage/elastic/client.rs
+++ b/web-api/src/storage/elastic/client.rs
@@ -12,7 +12,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, fmt::Debug, str::FromStr, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
+};
 
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
@@ -131,7 +136,7 @@ pub(super) struct BulkResponse<D> {
 impl<D> BulkResponse<D> {
     pub(super) fn failed_documents(self, operation: &'static str, allow_not_found: bool) -> Vec<D>
     where
-        D: Debug,
+        D: Display,
     {
         self.errors.then(|| {
             self
@@ -141,7 +146,7 @@ impl<D> BulkResponse<D> {
                     if let Some(response) = response.remove(operation) {
                         if !response.is_success_status(allow_not_found) {
                             error!(
-                                document_id=?response.id,
+                                document_id=%response.id,
                                 error=%response.error,
                                 "Elastic failed to {operation} document.",
                             );

--- a/web-api/src/storage/elastic/client.rs
+++ b/web-api/src/storage/elastic/client.rs
@@ -268,7 +268,7 @@ impl Client {
 pub(crate) enum Error {
     /// Transmitting a request or receiving the response failed: {0}
     Transport(reqwest::Error),
-    /// Elastic Search failed, status={status}, url={url}, \nbody={error}
+    /// Elastic Search failed, status={status}, url={url}, body={error}
     Status {
         status: StatusCode,
         url: Url,

--- a/web-api/src/storage/elastic/client.rs
+++ b/web-api/src/storage/elastic/client.rs
@@ -1,0 +1,262 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+use reqwest::{
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    Body,
+    StatusCode,
+    Url,
+};
+use secrecy::{ExposeSecret, Secret};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use tracing::error;
+
+use crate::{
+    app::SetupError,
+    error::common::InternalError,
+    utils::{serialize_redacted, serialize_to_ndjson},
+    Error,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub(crate) struct Config {
+    url: String,
+    user: String,
+    #[serde(serialize_with = "serialize_redacted")]
+    password: Secret<String>,
+    index_name: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            url: "http://localhost:9200".into(),
+            user: "elastic".into(),
+            password: String::from("changeme").into(),
+            index_name: "test_index".into(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Client {
+    config: Arc<Config>,
+    url_to_index: Url,
+    client: reqwest::Client,
+}
+
+impl Client {
+    pub(crate) fn builder(config: &Config) -> Result<ClientBuilder, SetupError> {
+        let mut base_url = config.url.parse::<SegmentableUrl>()?;
+
+        Ok(ClientBuilder {
+            config: Arc::new(config.clone()),
+            base_url: Arc::new(base_url),
+            client: reqwest::Client::new(),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ClientBuilder {
+    config: Arc<Config>,
+    base_url: Arc<SegmentableUrl>,
+    client: reqwest::Client,
+}
+
+impl ClientBuilder {
+    pub(crate) fn build(&self) -> Client {
+        Client {
+            config: self.config.clone(),
+            url_to_index: self.base_url.with_segments([&self.config.index_name]),
+            client: self.client.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum BulkInstruction<'a, D> {
+    Index {
+        #[serde(rename = "_id")]
+        id: &'a D,
+    },
+    Delete {
+        #[serde(rename = "_id")]
+        id: &'a D,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BulkItemResponse<D> {
+    #[serde(rename = "_id")]
+    pub(super) id: D,
+    pub(super) status: u16,
+    #[serde(default)]
+    pub(super) error: Value,
+}
+
+impl<D> BulkItemResponse<D> {
+    fn is_success_status(&self, allow_not_found: bool) -> bool {
+        StatusCode::from_u16(self.status)
+            .map(|status| {
+                (status == StatusCode::NOT_FOUND && allow_not_found) || status.is_success()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BulkResponse<D> {
+    pub(super) errors: bool,
+    pub(super) items: Vec<HashMap<String, BulkItemResponse<D>>>,
+}
+
+impl<D> BulkResponse<D> {
+    pub(super) fn failed_documents(self, operation: &'static str, allow_not_found: bool) -> Vec<D>
+    where
+        D: Debug,
+    {
+        self.errors.then(|| {
+            self
+                .items
+                .into_iter()
+                .filter_map(|mut response| {
+                    if let Some(response) = response.remove(operation) {
+                        if !response.is_success_status(allow_not_found) {
+                            error!(
+                                document_id=?response.id,
+                                error=%response.error,
+                                "Elastic failed to {operation} document.",
+                            );
+                            return Some(response.id);
+                        }
+                    } else {
+                        error!("Bulk {operation} request contains non {operation} responses: {response:?}");
+                    }
+                    None
+                })
+                .collect()
+        }).unwrap_or_default()
+    }
+}
+
+impl Client {
+    pub(crate) fn create_resource_path<'a>(
+        &self,
+        segments: impl IntoIterator<Item = &'a str>,
+        query_parts: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    ) -> Url {
+        let mut url = self.url_to_index.clone();
+        // UNWRAP_SAFE: In the constructor we already made sure it's a segmentable url.
+        url.path_segments_mut().unwrap().extend(segments);
+        let mut query_mut = url.query_pairs_mut();
+        for (key, value) in query_parts {
+            if let Some(value) = value {
+                query_mut.append_pair(key, value);
+            } else {
+                query_mut.append_key_only(key);
+            }
+        }
+        drop(query_mut);
+
+        url
+    }
+
+    pub(super) async fn bulk_request<D>(
+        &self,
+        requests: impl IntoIterator<Item = Result<impl Serialize, Error>>,
+    ) -> Result<BulkResponse<D>, Error>
+    where
+        D: DeserializeOwned,
+    {
+        let url = self.create_resource_path(["_bulk"], [("refresh", None)]);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-ndjson"),
+        );
+
+        let body = serialize_to_ndjson(requests)?;
+
+        self.query_with_bytes::<_, BulkResponse<D>>(url, Some((headers, body)))
+            .await?
+            .ok_or_else(|| InternalError::from_message("_bulk endpoint not found").into())
+    }
+
+    pub(super) async fn query_with_bytes<B, T>(
+        &self,
+        url: Url,
+        post_data: Option<(HeaderMap<HeaderValue>, B)>,
+    ) -> Result<Option<T>, Error>
+    where
+        B: Into<Body>,
+        T: DeserializeOwned,
+    {
+        let request_builder = if let Some((headers, body)) = post_data {
+            self.client.post(url).headers(headers).body(body)
+        } else {
+            self.client.get(url)
+        };
+
+        let response = request_builder
+            .basic_auth(
+                &self.config.user,
+                Some(self.config.password.expose_secret()),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
+            Ok(None)
+        } else if !status.is_success() {
+            let url = response.url().clone();
+            let body = response.bytes().await?;
+            let err_msg = String::from_utf8_lossy(&body);
+            Err(InternalError::from_message(format!(
+                "Elastic Search failed, status={status}, url={url}, \nbody={err_msg}"
+            ))
+            .into())
+        } else {
+            Ok(Some(response.json().await?))
+        }
+    }
+
+    pub(super) async fn query_with_json<B, T>(
+        &self,
+        url: Url,
+        body: Option<B>,
+    ) -> Result<Option<T>, Error>
+    where
+        B: Serialize,
+        T: DeserializeOwned,
+    {
+        let post_data = body
+            .map(|json| -> Result<_, Error> {
+                let mut headers = HeaderMap::new();
+                headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                let body = serde_json::to_vec(&json)?;
+                Ok((headers, body))
+            })
+            .transpose()?;
+
+        self.query_with_bytes(url, post_data).await
+    }
+}

--- a/web-api/src/utils.rs
+++ b/web-api/src/utils.rs
@@ -16,8 +16,6 @@ use figment::value::magic::RelativePathBuf as FigmentRelativePathBuf;
 use secrecy::Secret;
 use serde::{Deserialize, Serialize, Serializer};
 
-use crate::Error;
-
 #[derive(Serialize, Deserialize, Debug, Deref)]
 #[serde(transparent)]
 pub(crate) struct RelativePathBuf {
@@ -46,8 +44,8 @@ where
 
 /// Serialize a sequence of serializable items into ndjson.
 pub(crate) fn serialize_to_ndjson(
-    items: impl IntoIterator<Item = Result<impl Serialize, Error>>,
-) -> Result<Vec<u8>, Error> {
+    items: impl IntoIterator<Item = Result<impl Serialize, serde_json::Error>>,
+) -> Result<Vec<u8>, serde_json::Error> {
     let mut body = Vec::new();
     for item in items {
         serde_json::to_writer(&mut body, &item?)?;


### PR DESCRIPTION
Prepares for changes in follow up PRs:

- split elastic Client  into core web-api independent client code and our requests/endpoints
  - the generic parts get moved into elastic/client, later we will move them to `web-api-shared`  
- create a `ClientBuilder`
- `SegmentableUrl` abstraction
- use `Arc` as appropiate 
- don't depend on `DocumentId` in `elastic/client.rs`
- have custom error type in `elastic/client.rs` 