### PR TITLE
[Merged by Bors] - ET-4014 bench stateless personalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "bincode",
  "chrono",
  "clap 4.1.8",
+ "criterion",
  "csv",
  "derive_more",
  "displaydoc",

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -43,6 +43,7 @@ xayn-ai-coi = { path = "../coi", features = ["sqlx"] }
 
 [dev-dependencies]
 bincode = "1.3.3"
+criterion = { workspace = true }
 instant-distance = { version = "0.6.0", features = ["with-serde"] }
 npyz = "0.7.4"
 ouroboros = "0.15.6"
@@ -51,3 +52,8 @@ toml = { workspace = true }
 trycmd = "0.14.14"
 xayn-integration-tests = { path = "../integration-tests" }
 xayn-test-utils = { path = "../test-utils" }
+
+[[bench]]
+name = "stateless_personalization"
+harness = false
+test = false

--- a/web-api/benches/stateless_personalization.rs
+++ b/web-api/benches/stateless_personalization.rs
@@ -1,0 +1,119 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::hint::black_box;
+
+use chrono::Utc;
+use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use xayn_ai_bert::Embedding1;
+use xayn_ai_coi::CoiConfig;
+use xayn_web_api::bench_derive_interests;
+
+fn derive_interests_with_identical_embeddings(embedding_size: usize, interest_size: usize) {
+    let system = CoiConfig::default().build();
+    let timestamp = Utc::now();
+    let embedding = Embedding1::from(vec![1.0; embedding_size])
+        .normalize()
+        .unwrap();
+    let history = vec![(timestamp, embedding); interest_size];
+    bench_derive_interests(black_box(&system), black_box(history));
+}
+
+macro_rules! bench_identical {
+    ($($function: ident, $embedding_size: expr, $interest_size: expr);+ $(;)?) => {$(
+        fn $function(c: &mut Criterion) {
+            let name = format!(
+                "derive {} interests with identical embeddings ({})",
+                $interest_size,
+                $embedding_size,
+            );
+            c.bench_function(&name, |b| {
+                b.iter(|| {
+                    derive_interests_with_identical_embeddings($embedding_size, $interest_size)
+                })
+            });
+        }
+    )+};
+}
+
+bench_identical! {
+    bench_derive_interests_with_identical_embedding_128_0, 128, 0;
+    bench_derive_interests_with_identical_embedding_128_10, 128, 10;
+    bench_derive_interests_with_identical_embedding_128_20, 128, 20;
+    bench_derive_interests_with_identical_embedding_128_30, 128, 30;
+    bench_derive_interests_with_identical_embedding_128_40, 128, 40;
+}
+
+criterion_group!(
+    interests_with_identiccal_embeddings,
+    bench_derive_interests_with_identical_embedding_128_0,
+    bench_derive_interests_with_identical_embedding_128_10,
+    bench_derive_interests_with_identical_embedding_128_20,
+    bench_derive_interests_with_identical_embedding_128_30,
+    bench_derive_interests_with_identical_embedding_128_40,
+);
+
+fn derive_interests_with_orthogonal_embeddings(embedding_size: usize, interest_size: usize) {
+    let system = CoiConfig::default().build();
+    let timestamp = Utc::now();
+    let history = (0..interest_size)
+        .map(|i| {
+            let mut embedding = vec![0.0; embedding_size];
+            embedding[i] = 1.0;
+            let embedding = Embedding1::from(embedding).normalize().unwrap();
+            (timestamp, embedding)
+        })
+        .collect_vec();
+    bench_derive_interests(black_box(&system), black_box(history));
+}
+
+macro_rules! bench_orthogonal {
+    ($($function: ident, $embedding_size: expr, $interest_size: expr);+ $(;)?) => {$(
+        fn $function(c: &mut Criterion) {
+            let name = format!(
+                "derive {} interests with orthogonal embeddings ({})",
+                $interest_size,
+                $embedding_size,
+            );
+            c.bench_function(&name, |b| {
+                b.iter(|| {
+                    derive_interests_with_orthogonal_embeddings($embedding_size, $interest_size)
+                })
+            });
+        }
+    )+};
+}
+
+bench_orthogonal! {
+    bench_derive_interests_with_orthogonal_embedding_128_0, 128, 0;
+    bench_derive_interests_with_orthogonal_embedding_128_10, 128, 10;
+    bench_derive_interests_with_orthogonal_embedding_128_20, 128, 20;
+    bench_derive_interests_with_orthogonal_embedding_128_30, 128, 30;
+    bench_derive_interests_with_orthogonal_embedding_128_40, 128, 40;
+}
+
+criterion_group!(
+    interests_with_orthogonal_embeddings,
+    bench_derive_interests_with_orthogonal_embedding_128_0,
+    bench_derive_interests_with_orthogonal_embedding_128_10,
+    bench_derive_interests_with_orthogonal_embedding_128_20,
+    bench_derive_interests_with_orthogonal_embedding_128_30,
+    bench_derive_interests_with_orthogonal_embedding_128_40,
+);
+
+criterion_main!(
+    interests_with_identiccal_embeddings,
+    interests_with_orthogonal_embeddings,
+);

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -51,5 +51,5 @@ pub use crate::{
     error::application::{ApplicationError, Error},
     ingestion::Ingestion,
     net::AppHandle,
-    personalization::Personalization,
+    personalization::{bench_derive_interests, Personalization},
 };

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -22,6 +22,7 @@ use derive_more::AsRef;
 use serde::{Deserialize, Serialize};
 use xayn_ai_coi::{CoiConfig, CoiSystem};
 
+pub use self::stateless::bench_derive_interests;
 use crate::{
     app::{self, Application, SetupError},
     embedding::{self, Embedder},

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -144,6 +144,23 @@ pub(super) fn derive_interests_and_tag_weights<'a>(
     (user_interests, tag_weights)
 }
 
+#[doc(hidden)]
+pub fn bench_derive_interests(
+    coi_system: &CoiSystem,
+    history: Vec<(DateTime<Utc>, NormalizedEmbedding)>,
+) {
+    // small allocation overhead, but we don't have to expose a lot of private items
+    let history = history
+        .into_iter()
+        .map(|(timestamp, embedding)| LoadedHistoryEntry {
+            timestamp,
+            embedding,
+            tags: Vec::new(),
+        })
+        .collect_vec();
+    derive_interests_and_tag_weights(coi_system, &history);
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{Duration, TimeZone};


### PR DESCRIPTION
**Reference**

- [ET-4014]

**Summary**

- add benchmarks for the coi loop of the stateless personalization which cover both edge cases, all other cases should lie somewhere in between:
  - every history item shifts the coi (except for the very first one which has to create the first coi) by using identical embeddings
  - every history item creates a new coi by using orthogonal embeddings

```
Benchmarking derive 0 interests with identical embeddings (128): Collecting 100 samples in estimated 5.0004 s (31M itera
derive 0 interests with identical embeddings (128)
                        time:   [155.36 ns 156.49 ns 157.73 ns]

Benchmarking derive 10 interests with identical embeddings (128): Collecting 100 samples in estimated 5.0076 s (1.5M ite
derive 10 interests with identical embeddings (128)
                        time:   [3.2377 µs 3.2424 µs 3.2476 µs]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking derive 20 interests with identical embeddings (128): Collecting 100 samples in estimated 5.0058 s (858k ite
derive 20 interests with identical embeddings (128)
                        time:   [5.8165 µs 5.8220 µs 5.8286 µs]
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

Benchmarking derive 30 interests with identical embeddings (128): Collecting 100 samples in estimated 5.0147 s (586k ite
derive 30 interests with identical embeddings (128)
                        time:   [8.5808 µs 8.6041 µs 8.6265 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking derive 40 interests with identical embeddings (128): Collecting 100 samples in estimated 5.0401 s (439k ite
derive 40 interests with identical embeddings (128)
                        time:   [11.338 µs 11.390 µs 11.441 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking derive 0 interests with orthogonal embeddings (128): Collecting 100 samples in estimated 5.0002 s (100M ite
derive 0 interests with orthogonal embeddings (128)
                        time:   [50.027 ns 50.104 ns 50.202 ns]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

Benchmarking derive 10 interests with orthogonal embeddings (128): Collecting 100 samples in estimated 5.0186 s (722k it
derive 10 interests with orthogonal embeddings (128)
                        time:   [6.8721 µs 6.8797 µs 6.8878 µs]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

Benchmarking derive 20 interests with orthogonal embeddings (128): Collecting 100 samples in estimated 5.0416 s (328k it
derive 20 interests with orthogonal embeddings (128)
                        time:   [15.263 µs 15.290 µs 15.320 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking derive 30 interests with orthogonal embeddings (128): Collecting 100 samples in estimated 5.1086 s (197k it
derive 30 interests with orthogonal embeddings (128)
                        time:   [25.692 µs 25.720 µs 25.750 µs]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Benchmarking derive 40 interests with orthogonal embeddings (128): Collecting 100 samples in estimated 5.0190 s (131k it
derive 40 interests with orthogonal embeddings (128)
                        time:   [38.088 µs 38.131 µs 38.174 µs]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```

[ET-4014]: https://xainag.atlassian.net/browse/ET-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ