### PR TITLE
[Merged by Bors] - Set run name to branch and model name

### DIFF
--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -25,6 +25,8 @@ on:
           Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<platform>.
           Step 'Images name' will print the name of the generated images.
 
+run-name: ${{ github.ref_name }} - ${{ inputs.model_name }}_${{ inputs.model_version }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Set run name for the workflow to '<branch> - <model_name>_<model_version>'