### PR TITLE
[Merged by Bors] - Reduce memory usage for postgres and elatic during tests or dev

### DIFF
--- a/web-api/compose.db.yml
+++ b/web-api/compose.db.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:15.2
+    mem_limit: 1024m
     restart: always
     environment:
       POSTGRES_USER: user
@@ -16,16 +17,9 @@ services:
       timeout: 5s
       retries: 5
 
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - "${HOST_PORT_SCOPE:-30}80:8080"
-    networks:
-      - internal
-
   elasticsearch:
     image: elasticsearch:8.7.0
+    mem_limit: 2048m
     restart: always
     environment:
       - discovery.type=single-node
@@ -63,6 +57,14 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+
+  # adminer:
+  #   image: adminer
+  #   restart: always
+  #   ports:
+  #     - "${HOST_PORT_SCOPE:-30}80:8080"
+  #   networks:
+  #     - internal
 
   # kibana:
   #   image: kibana:8.4.0


### PR DESCRIPTION
Reduce the memory that the databases can use. This hopefully will help with the timeout we have in the tests. But in general is nice to not have half of the memory on the system take from ES.