### PR TITLE
[Merged by Bors] - ET-4294 tenant specific testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,7 +4261,9 @@ name = "xayn-integration-tests"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "once_cell",
+ "rand",
  "regex",
  "reqwest",
  "scopeguard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,7 +4314,6 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
- "scopeguard",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +291,9 @@ name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "anymap2"
@@ -356,6 +368,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -1306,6 +1333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,6 +2863,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -4269,6 +4317,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "toml 0.7.3",
  "tracing",
@@ -4276,6 +4325,8 @@ dependencies = [
  "uuid",
  "xayn-test-utils",
  "xayn-web-api",
+ "xayn-web-api-db-ctrl",
+ "xayn-web-api-shared",
 ]
 
 [[package]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,7 +13,6 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-scopeguard =  "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 publish = false
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ["backtrace"] }
 chrono = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
@@ -16,6 +16,7 @@ reqwest = { workspace = true }
 scopeguard =  "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sqlx = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 toml = { workspace = true }
 tracing = { workspace = true }
@@ -23,3 +24,5 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 xayn-test-utils = { path = "../test-utils" }
 xayn-web-api = { path = "../web-api" }
+xayn-web-api-db-ctrl = { path = "../web-api-db-ctrl" }
+xayn-web-api-shared = { path = "../web-api-shared" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,7 +8,9 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 once_cell = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 scopeguard =  "1.1.0"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,6 +13,7 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -36,7 +36,7 @@ use once_cell::sync::Lazy;
 use rand::random;
 use reqwest::{header::HeaderMap, Client, Request, Response, StatusCode, Url};
 use secrecy::ExposeSecret;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 use sqlx::{Connection, Executor, PgConnection};
 use toml::{toml, Table, Value};
 use tracing::{error_span, instrument, Instrument};

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -170,9 +170,7 @@ pub async fn test_app<A, F>(
     let (configure, enable_legacy_tenant) =
         configure_with_enable_legacy_tenant_for_test(configure.unwrap_or_default());
 
-    let services = setup_web_dev_test_context(enable_legacy_tenant)
-        .await
-        .unwrap();
+    let services = setup_web_dev_services(enable_legacy_tenant).await.unwrap();
 
     let handle = start_test_application::<A>(&services, configure).await;
 
@@ -207,7 +205,7 @@ pub async fn test_two_apps<A1, A2, F>(
         configure_with_enable_legacy_tenant_for_test(configure_second.unwrap_or_default());
     assert_eq!(first_wit_legacy, second_with_legacy);
 
-    let services = setup_web_dev_test_context(first_wit_legacy).await.unwrap();
+    let services = setup_web_dev_services(first_wit_legacy).await.unwrap();
     let first_handle = start_test_application::<A1>(&services, configure_first).await;
     let second_handle = start_test_application::<A2>(&services, configure_second).await;
 
@@ -359,7 +357,7 @@ impl Services {
 /// Creates a postgres db and elastic search index for running a web-dev integration test.
 ///
 /// A uris usable for accessing the dbs are returned.
-async fn setup_web_dev_test_context(enable_legacy_tenant: bool) -> Result<Services, anyhow::Error> {
+async fn setup_web_dev_services(enable_legacy_tenant: bool) -> Result<Services, anyhow::Error> {
     clear_env();
     start_test_service_containers().unwrap();
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -35,6 +35,7 @@ use chrono::Utc;
 use once_cell::sync::Lazy;
 use rand::random;
 use reqwest::{header::HeaderMap, Client, Request, Response, StatusCode, Url};
+use secrecy::ExposeSecret;
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::{Connection, Executor, PgConnection};
 use toml::{toml, Table, Value};
@@ -274,6 +275,8 @@ pub async fn start_test_application<A>(services: &Services, configure: Table) ->
 where
     A: Application + 'static,
 {
+    let pg_config = services.silo.postgres_config();
+    let pg_password = pg_config.password.expose_secret().as_str();
     let pg_config = to_toml_value(services.silo.postgres_config()).unwrap();
     let es_config = to_toml_value(services.silo.elastic_config()).unwrap();
 
@@ -291,7 +294,7 @@ where
         &mut config,
         toml! {
             [storage.postgres]
-            password = "pw"
+            password = pg_password
         },
     );
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -135,6 +135,10 @@ pub fn initialize_test_logging() {
         logging::initialize(&logging::Config {
             file: None,
             level: LevelFilter::WARN,
+            // FIXME If we have json logging do fix the panic logging hock
+            //       to also log the backtrace instead of disabling the
+            //       panic hook.
+            install_panic_hook: false
         })
         .unwrap();
     });

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -430,7 +430,7 @@ pub async fn delete_db(target: &postgres::Config, management_db: &str) -> Result
 /// Start service containers.
 ///
 /// Does nothing on CI where they have to be started from the outside.
-fn start_test_service_containers() -> Result<(), anyhow::Error> {
+pub fn start_test_service_containers() -> Result<(), anyhow::Error> {
     static ONCE: Once = Once::new();
     let mut res = Ok(());
     ONCE.call_once(|| {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -138,7 +138,7 @@ pub fn initialize_test_logging() {
             // FIXME If we have json logging do fix the panic logging hock
             //       to also log the backtrace instead of disabling the
             //       panic hook.
-            install_panic_hook: false
+            install_panic_hook: false,
         })
         .unwrap();
     });
@@ -391,17 +391,31 @@ async fn setup_web_dev_test_context(enable_legacy_tenant: bool) -> Result<Servic
 }
 
 pub fn db_configs_for_testing(test_id: &str) -> (postgres::Config, elastic::Config) {
-    let mut pg_config = postgres::Config {
-        db: Some(test_id.to_owned()),
-        ..Default::default()
-    };
-    let mut es_config = elastic::Config::default();
+    let es_index_name = format!("{test_id}_default");
+    let pg_config;
+    let es_config;
     if *RUNS_IN_CONTAINER {
-        pg_config.base_url = "postgres://user:pw@postgres:5432/".into();
-        es_config.url = "http://elasticsearch:9200".into();
+        pg_config = postgres::Config {
+            db: Some(test_id.to_owned()),
+            base_url: "postgres://user:pw@postgres:5432/".into(),
+            ..Default::default()
+        };
+        es_config = elastic::Config {
+            url: "http://elasticsearch:9200".into(),
+            index_name: es_index_name,
+            ..Default::default()
+        };
     } else {
-        pg_config.base_url = "postgres://user:pw@localhost:3054/xayn".into();
-        es_config.url = "http://localhost:3092".into();
+        pg_config = postgres::Config {
+            db: Some(test_id.to_owned()),
+            base_url: "postgres://user:pw@localhost:3054/".into(),
+            ..Default::default()
+        };
+        es_config = elastic::Config {
+            url: "http://localhost:3092".into(),
+            index_name: es_index_name,
+            ..Default::default()
+        }
     }
     (pg_config, es_config)
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -232,7 +232,7 @@ fn configure_with_enable_legacy_tenant_for_test(mut config: Table) -> (Table, bo
         .get("tenants")
         .and_then(|config| config.get("enable_legacy_tenant"))
         .and_then(|value| value.as_bool())
-        // Default to false, this is a different default then used for deployments.
+        // This is a different default value then used for deployments.
         .unwrap_or_default();
 
     extend_config(

--- a/justfile
+++ b/justfile
@@ -248,10 +248,6 @@ _test-project-root:
     #!/usr/bin/env -S bash -eu -o pipefail
     echo -n {{justfile_directory()}}
 
-_test-generate-id:
-    #!/usr/bin/env -S bash -eu -o pipefail
-    echo -n "t$(date +%y%m%d_%H%M%S)_$(printf "%04x" "$RANDOM")"
-
 _test-create-dbs test_id:
     #!/usr/bin/env -S bash -eu -o pipefail
     if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then

--- a/justfile
+++ b/justfile
@@ -75,8 +75,8 @@ build: rust-build
 
 # Tests rust
 rust-test: download-assets
-    #!/usr/bin/env bash
-    set -eux -o pipefail
+    #!/usr/bin/env -S bash -eux -o pipefail
+    export RUST_BACKTRACE=1
     cargo test --lib --bins --tests --locked
     cargo test --doc --locked
 

--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ build: rust-build
 
 # Tests rust
 rust-test: download-assets
-    #!/usr/bin/env -S bash -eux -o pipefail
+    #!/usr/bin/env -S bash -eu -o pipefail
     export RUST_BACKTRACE=1
     cargo test --lib --bins --tests --locked
     cargo test --doc --locked
@@ -105,10 +105,9 @@ pre-push $CI="true":
     @{{just_executable()}} _pre-push
 
 download-assets *args:
-    #!/usr/bin/env bash
-    set -eux -o pipefail
+    #!/usr/bin/env -S bash -eu -o pipefail
     cd {{justfile_directory()}}/.github/scripts
-    {{ if env_var_or_default("CI", "false") == "false" { "export AWS_PROFILE=\"S3BucketsDeveloperAccess-690046978283\"" } else { "" } }}
+    {{ if env_var_or_default("CI", "false") == "false" { "export AWS_PROFILE=\"S3BucketsDeveloperAccess-690046978283\"; echo AWS_PROFILE=$AWS_PROFILE;" } else { "" } }}
     ./download_assets.sh {{args}}
 
 build-service-args name target="default" features="":

--- a/justfile
+++ b/justfile
@@ -248,37 +248,6 @@ _test-project-root:
     #!/usr/bin/env -S bash -eu -o pipefail
     echo -n {{justfile_directory()}}
 
-_test-create-dbs test_id:
-    #!/usr/bin/env -S bash -eu -o pipefail
-    if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
-        PG_HOST="postgres:5432"
-        ES_HOST="elasticsearch:9200"
-    else
-        PG_HOST="localhost:3054"
-        ES_HOST="localhost:3092"
-    fi
-    PG_BASE="postgresql://user:pw@${PG_HOST}"
-    ES_URL="http://${ES_HOST}/{{test_id}}"
-
-    psql -q -c "CREATE DATABASE {{test_id}};" "${PG_BASE}/xayn" 1>&2
-    ./web-api/elastic-search/create_es_index.sh "${ES_URL}"
-
-    echo "PG_URL=${PG_BASE}/{{test_id}}"
-    echo "ES_URL=${ES_URL}"
-
-_test-drop-dbs test_id:
-    #!/usr/bin/env -S bash -eu -o pipefail
-    if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
-        PG_HOST="postgres:5432"
-        ES_HOST="elasticsearch:9200"
-    else
-        PG_HOST="localhost:3054"
-        ES_HOST="localhost:3092"
-    fi
-
-    psql -q -c "DROP DATABASE {{test_id}} WITH (FORCE);" "postgresql://user:pw@${PG_HOST}/xayn" 1>&2
-    curl -sf -X DELETE "http://${ES_HOST}/{{test_id}}"
-
 alias r := rust-test
 alias t := test
 alias pp := pre-push

--- a/test-utils/src/env.rs
+++ b/test-utils/src/env.rs
@@ -25,6 +25,8 @@ use regex::Regex;
 /// - `LANG`
 /// - `PWD`
 /// - `CI`
+/// - `RUST_BACKTRACE`
+/// - `RUST_LIB_BACKTRACE`
 ///
 /// Additional exceptions to avoid potential complications
 /// with programs called by just, especially wrt to docker-compose
@@ -64,6 +66,8 @@ static ENV_PRUNE_EXCEPTIONS: Lazy<Regex> = Lazy::new(|| {
         |(?:^USER$)
         |(?:^CI$)
         |(?:^HOME$)
+        |(?:^RUST_BACKTRACE$)
+        |(?:^RUST_LIB_BACKTRACE$)
         |(?:^DBUS)
         |(?:^SYSTEMD)
         |(?:^DOCKER)

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -15,6 +15,7 @@
 mod elastic;
 mod postgres;
 
+pub use elastic::create_tenant as elastic_create_tenant;
 use sqlx::pool::PoolOptions;
 use xayn_web_api_shared::{
     elastic::{Client as EsClient, Config as EsConfig},

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -25,31 +25,35 @@ use xayn_web_api_shared::{
 //TODO
 pub type Error = anyhow::Error;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Silo {
+    postgres_config: PgConfig,
+    elastic_config: EsConfig,
     postgres: PgClient,
     elastic: EsClient,
     enable_legacy_tenant: Option<LegacyTenantInfo>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LegacyTenantInfo {
     pub es_index: String,
 }
 
 impl Silo {
     pub async fn new(
-        postgres: &PgConfig,
-        elastic: EsConfig,
+        postgres_config: PgConfig,
+        elastic_config: EsConfig,
         enable_legacy_tenant: Option<LegacyTenantInfo>,
     ) -> Result<Self, Error> {
         let postgres = PoolOptions::new()
-            .connect_with(postgres.to_connection_options()?)
+            .connect_with(postgres_config.to_connection_options()?)
             .await?;
 
-        let elastic = EsClient::new(elastic)?;
+        let elastic = EsClient::new(elastic_config.clone())?;
 
         Ok(Self {
+            postgres_config,
+            elastic_config,
             postgres,
             elastic,
             enable_legacy_tenant,
@@ -87,5 +91,13 @@ impl Silo {
         elastic::delete_tenant(&self.elastic, tenant_id).await?;
         tx.commit().await?;
         Ok(())
+    }
+
+    pub fn postgres_config(&self) -> &PgConfig {
+        &self.postgres_config
+    }
+
+    pub fn elastic_config(&self) -> &EsConfig {
+        &self.elastic_config
     }
 }

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -63,6 +63,8 @@ impl Default for Config {
         }
     }
 }
+
+#[derive(Debug)]
 struct Auth {
     user: String,
     password: Secret<String>,
@@ -74,7 +76,7 @@ impl Auth {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     auth: Arc<Auth>,
     url_to_index: Arc<SegmentableUrl>,
@@ -355,7 +357,7 @@ pub enum Error {
     EndpointNotFound(&'static str),
 }
 
-#[derive(derive_more::Into, Clone)]
+#[derive(derive_more::Into, Clone, Debug)]
 pub struct SegmentableUrl(Url);
 
 impl SegmentableUrl {

--- a/web-api-shared/src/postgres.rs
+++ b/web-api-shared/src/postgres.rs
@@ -32,26 +32,26 @@ pub struct Config {
     ///
     /// Passwords in the URL will be ignored, do not set the
     /// db password with the db url.
-    base_url: String,
+    pub base_url: String,
 
     /// Override port from base url.
-    port: Option<u16>,
+    pub port: Option<u16>,
 
     /// Override user from base url.
-    user: Option<String>,
+    pub user: Option<String>,
 
     /// Sets the password.
     #[serde(serialize_with = "serialize_redacted")]
-    password: Secret<String>,
+    pub password: Secret<String>,
 
     /// Override db from base url.
-    db: Option<String>,
+    pub db: Option<String>,
 
     /// Override default application name from base url.
-    application_name: Option<String>,
+    pub application_name: Option<String>,
 
     /// If true skips running db migrations on start up.
-    skip_migrations: bool,
+    pub skip_migrations: bool,
 
     /// Minimum number of connections in the pool.
     /// When the pool is built, this many connections will be automatically spun up.

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub file: Option<RelativePathBuf>,
     #[serde(with = "serde_level_filter")]
     pub level: LevelFilter,
+    pub install_panic_hook: bool,
 }
 
 impl Default for Config {
@@ -66,6 +67,7 @@ impl Default for Config {
         Self {
             file: None,
             level: LevelFilter::INFO,
+            install_panic_hook: true,
         }
     }
 }
@@ -78,7 +80,9 @@ impl Default for Config {
 /// should only call this function when you expect it to succeed.
 pub fn initialize(log_config: &Config) -> Result<(), TryInitError> {
     init_tracing_once(log_config)?;
-    init_panic_logging();
+    if log_config.install_panic_hook {
+        init_panic_logging();
+    }
     Ok(())
 }
 

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -257,7 +257,7 @@ impl Storage {
         tenant_config: &tenants::Config,
     ) -> Result<Option<TenantId>, SetupError> {
         let silo = Silo::new(
-            &config.postgres,
+            config.postgres.clone(),
             config.elastic.clone(),
             tenant_config
                 .enable_legacy_tenant

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": "[CWD]/tests/cmd/assets/foo/bar.log",
-    "level": "info"
+    "level": "info",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.4.3.2:1099",

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": null,
-    "level": "info"
+    "level": "info",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.0.0.1:4252",

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": null,
-    "level": "info"
+    "level": "info",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.0.0.1:4252",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": "[CWD]/tests/cmd/assets/foo/bar.log",
-    "level": "trace"
+    "level": "trace",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": null,
-    "level": "error"
+    "level": "error",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.0.0.1:4252",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": "[CWD]/tests/cmd/assets/foo/bar.log",
-    "level": "info"
+    "level": "info",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.0.1.1:3040",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -6,7 +6,8 @@ stdout = """
 {
   "logging": {
     "file": "[CWD]/tests/cmd/assets/foo/bar.log",
-    "level": "info"
+    "level": "info",
+    "install_panic_hook": true
   },
   "net": {
     "bind_to": "127.4.3.2:1099",

--- a/web-api/tests/document_candidates.rs
+++ b/web-api/tests/document_candidates.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use xayn_integration_tests::{send_assert, send_assert_json, test_app, unchanged_config};
+use xayn_integration_tests::{send_assert, send_assert_json, test_app, UNCHANGED_CONFIG};
 use xayn_test_utils::error::Panic;
 use xayn_web_api::Ingestion;
 
@@ -71,7 +71,7 @@ async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) ->
 
 #[tokio::test]
 async fn test_candidates_all() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
@@ -84,7 +84,7 @@ async fn test_candidates_all() {
 
 #[tokio::test]
 async fn test_candidates_some() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
@@ -97,7 +97,7 @@ async fn test_candidates_some() {
 
 #[tokio::test]
 async fn test_candidates_none() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
@@ -110,7 +110,7 @@ async fn test_candidates_none() {
 
 #[tokio::test]
 async fn test_candidates_not_default() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         send_assert(
             &client,
@@ -156,7 +156,7 @@ struct Error {
 
 #[tokio::test]
 async fn test_candidates_warning() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
@@ -184,7 +184,7 @@ async fn test_candidates_warning() {
 
 #[tokio::test]
 async fn test_candidates_reingestion() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         send_assert(
             &client,

--- a/web-api/tests/document_properties.rs
+++ b/web-api/tests/document_properties.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use xayn_integration_tests::{send_assert, send_assert_json, test_app, unchanged_config};
+use xayn_integration_tests::{send_assert, send_assert_json, test_app, UNCHANGED_CONFIG};
 use xayn_web_api::Ingestion;
 
 #[derive(Debug, Deserialize)]
@@ -33,7 +33,7 @@ enum Error {
 }
 
 async fn document_properties(is_candidate: bool) {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
             client
@@ -143,7 +143,7 @@ struct DocumentPropertyResponse {
 }
 
 async fn document_property(is_candidate: bool) {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
             client

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -22,7 +22,7 @@ use xayn_integration_tests::{
     send_assert_json,
     test_app,
     test_two_apps,
-    unchanged_config,
+    UNCHANGED_CONFIG,
 };
 use xayn_test_utils::error::Panic;
 use xayn_web_api::{Ingestion, Personalization};
@@ -68,7 +68,7 @@ struct Error {
 
 #[tokio::test]
 async fn test_ingestion_created() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         ingest(&client, &url).await?;
         send_assert(
             &client,
@@ -130,7 +130,7 @@ async fn test_ingestion_bad_request() {
 
 #[tokio::test]
 async fn test_deletion() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         ingest(&client, &url).await?;
         send_assert(
             &client,
@@ -170,8 +170,8 @@ struct SemanticSearchResponse {
 #[tokio::test]
 async fn test_reingestion_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             send_assert(
                 &client,
@@ -256,7 +256,7 @@ async fn test_reingestion_candidates() {
 // new and changed documents have been logged and manually check the databases
 #[tokio::test]
 async fn test_reingestion_snippets() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
             client

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -97,7 +97,7 @@ async fn test_ingestion_created() {
 
 #[tokio::test]
 async fn test_ingestion_bad_request() {
-    test_app::<Ingestion, _>(unchanged_config, |client, url, _| async move {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         let error = send_assert_json::<Error>(
             &client,
             client

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use chrono::{DateTime, TimeZone, Utc};
+use sqlx::{Connection, PgConnection};
+use xayn_integration_tests::{crate_db, db_configs_for_testing, generate_test_id, MANAGEMENT_DB};
+use xayn_web_api_db_ctrl::{LegacyTenantInfo, Silo};
+use xayn_web_api_shared::postgres::QuotedIdentifier;
+
+#[tokio::test]
+async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Result<(), anyhow::Error>
+{
+    let test_id = generate_test_id();
+    let (pg_config, es_config) = db_configs_for_testing(&test_id);
+
+    crate_db(&pg_config, MANAGEMENT_DB).await?;
+
+    let pg_options = pg_config.to_connection_options()?;
+    let mut conn = PgConnection::connect_with(&pg_options).await?;
+
+    sqlx::migrate!("../web-api-db-ctrl/postgres/tenant")
+        .run(&mut conn)
+        .await?;
+
+    let user_id = "foo_boar";
+    let last_seen = Utc.with_ymd_and_hms(2023, 2, 2, 3, 3, 3).unwrap();
+    sqlx::query("INSERT INTO users(user_id, last_seen) VALUES ($1, $2)")
+        .bind(user_id)
+        .bind(last_seen)
+        .execute(&mut conn)
+        .await?;
+
+    conn.close().await?;
+
+    let default_es_index = es_config.index_name.clone();
+    let silo = Silo::new(
+        pg_config,
+        es_config,
+        Some(LegacyTenantInfo {
+            es_index: default_es_index,
+        }),
+    )
+    .await?;
+    silo.admin_as_mt_user_hack().await?;
+    let Some(legacy_tenant_id) = silo.initialize().await? else {
+        panic!("initialization with legacy tenant didn't return a legacy tenant id");
+    };
+    let tenant_schema = QuotedIdentifier::db_name_for_tenant_id(&legacy_tenant_id);
+
+    let mut conn = PgConnection::connect_with(&pg_options).await?;
+    let query = format!("SELECT user_id, last_seen FROM {tenant_schema}.users;");
+    let (found_user_id, found_last_seen) = sqlx::query_as::<_, (String, DateTime<Utc>)>(&query)
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(found_user_id, user_id);
+    assert_eq!(found_last_seen, last_seen);
+    conn.close().await?;
+    Ok(())
+}

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -45,7 +45,7 @@ async fn legacy_test_setup() -> Result<(postgres::Config, elastic::Config), Erro
 }
 
 #[tokio::test]
-async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Result<(), Error> {
+async fn test_if_the_initializations_work_correctly_for_legacy_tenants() -> Result<(), Error> {
     let (pg_config, es_config) = legacy_test_setup().await?;
 
     let pg_options = pg_config.to_connection_options()?;
@@ -100,7 +100,7 @@ async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Resul
 }
 
 #[tokio::test]
-async fn test_if_the_initializations_works_correct_for_not_setup_legacy_tenants(
+async fn test_if_the_initializations_work_correctly_for_not_setup_legacy_tenants(
 ) -> Result<(), anyhow::Error> {
     let (pg_config, es_config) = legacy_test_setup().await?;
 

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -35,9 +35,7 @@ async fn legacy_test_setup() -> Result<(postgres::Config, elastic::Config), Erro
     start_test_service_containers()?;
 
     let test_id = generate_test_id();
-    let (pg_config, mut es_config) = db_configs_for_testing(&test_id);
-    // changed default index
-    es_config.index_name = format!("{}_{}", test_id, es_config.index_name);
+    let (pg_config, es_config) = db_configs_for_testing(&test_id);
 
     crate_db(&pg_config, MANAGEMENT_DB).await?;
 

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -19,6 +19,7 @@ use xayn_integration_tests::{
     crate_db,
     db_configs_for_testing,
     generate_test_id,
+    initialize_test_logging,
     start_test_service_containers,
     MANAGEMENT_DB,
 };
@@ -32,6 +33,7 @@ use xayn_web_api_shared::{
 
 async fn legacy_test_setup() -> Result<(postgres::Config, elastic::Config), Error> {
     clear_env();
+    initialize_test_logging();
     start_test_service_containers()?;
 
     let test_id = generate_test_id();

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -16,7 +16,7 @@ use anyhow::Error;
 use chrono::{DateTime, TimeZone, Utc};
 use sqlx::{Connection, PgConnection};
 use xayn_integration_tests::{
-    crate_db,
+    create_db,
     db_configs_for_testing,
     generate_test_id,
     initialize_test_logging,
@@ -39,7 +39,7 @@ async fn legacy_test_setup() -> Result<(postgres::Config, elastic::Config), Erro
     let test_id = generate_test_id();
     let (pg_config, es_config) = db_configs_for_testing(&test_id);
 
-    crate_db(&pg_config, MANAGEMENT_DB).await?;
+    create_db(&pg_config, MANAGEMENT_DB).await?;
 
     Ok((pg_config, es_config))
 }

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -14,13 +14,23 @@
 
 use chrono::{DateTime, TimeZone, Utc};
 use sqlx::{Connection, PgConnection};
-use xayn_integration_tests::{crate_db, db_configs_for_testing, generate_test_id, MANAGEMENT_DB};
+use xayn_integration_tests::{
+    crate_db,
+    db_configs_for_testing,
+    generate_test_id,
+    start_test_service_containers,
+    MANAGEMENT_DB,
+};
+use xayn_test_utils::env::clear_env;
 use xayn_web_api_db_ctrl::{LegacyTenantInfo, Silo};
 use xayn_web_api_shared::postgres::QuotedIdentifier;
 
 #[tokio::test]
 async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Result<(), anyhow::Error>
 {
+    clear_env();
+    start_test_service_containers()?;
+
     let test_id = generate_test_id();
     let (pg_config, es_config) = db_configs_for_testing(&test_id);
 
@@ -32,6 +42,8 @@ async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Resul
     sqlx::migrate!("../web-api-db-ctrl/postgres/tenant")
         .run(&mut conn)
         .await?;
+
+    //TODO create legacy index
 
     let user_id = "foo_boar";
     let last_seen = Utc.with_ymd_and_hms(2023, 2, 2, 3, 3, 3).unwrap();
@@ -69,3 +81,5 @@ async fn test_if_the_initializations_works_correct_for_legacy_tenants() -> Resul
     conn.close().await?;
     Ok(())
 }
+
+//TODO test with legacy tenant but no schema or index set up

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -243,8 +243,8 @@ async fn test_personalization_with_query() {
 #[tokio::test]
 async fn test_personalization_with_tags() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_tags(&client, &ingestion_url).await?;
             let documents = personalize(&client, &personalization_url, None, None).await?;

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, unchanged_config};
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_test_utils::error::Panic;
 use xayn_web_api::{Ingestion, Personalization};
 
@@ -174,8 +174,8 @@ macro_rules! assert_order {
 #[tokio::test]
 async fn test_personalization_all_dates() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
             let documents = personalize(&client, &personalization_url, None, None).await?;
@@ -193,8 +193,8 @@ async fn test_personalization_all_dates() {
 #[tokio::test]
 async fn test_personalization_limited_dates() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
             let documents = personalize(
@@ -218,8 +218,8 @@ async fn test_personalization_limited_dates() {
 #[tokio::test]
 async fn test_personalization_with_query() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
             let documents = personalize(

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -17,13 +17,7 @@ use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{
-    extend_config,
-    send_assert,
-    send_assert_json,
-    test_two_apps,
-    unchanged_config,
-};
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_test_utils::error::Panic;
 use xayn_web_api::{Ingestion, Personalization};
 
@@ -106,16 +100,11 @@ macro_rules! assert_order {
 #[tokio::test]
 async fn test_full_personalization() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [semantic_search]
-                    score_weights = [0.5, 0.5, 0.0]
-                },
-            )
-        },
+        UNCHANGED_CONFIG,
+        Some(toml! {
+            [semantic_search]
+            score_weights = [0.5, 0.5, 0.0]
+        }),
         |client, ingestion_url, personalization_url, _services| async move {
             ingest(&client, &ingestion_url).await?;
 
@@ -186,16 +175,11 @@ async fn test_full_personalization() {
 #[tokio::test]
 async fn test_subtle_personalization() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [semantic_search]
-                    score_weights = [0.05, 0.05, 0.9]
-                },
-            )
-        },
+        UNCHANGED_CONFIG,
+        Some(toml! {
+            [semantic_search]
+            score_weights = [0.05, 0.05, 0.9]
+        }),
         |client, ingestion_url, personalization_url, _services| async move {
             ingest(&client, &ingestion_url).await?;
             interact(&client, &personalization_url).await?;
@@ -228,16 +212,11 @@ async fn test_subtle_personalization() {
 #[tokio::test]
 async fn test_full_personalization_with_inline_history() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [semantic_search]
-                    score_weights = [0.5, 0.5, 0.0]
-                },
-            )
-        },
+        UNCHANGED_CONFIG,
+        Some(toml! {
+            [semantic_search]
+            score_weights = [0.5, 0.5, 0.0]
+        }),
         |client, ingestion_url, personalization_url, _services| async move {
             ingest(&client, &ingestion_url).await?;
 

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -15,7 +15,7 @@
 use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, unchanged_config};
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_test_utils::error::Panic;
 use xayn_web_api::{Ingestion, Personalization};
 
@@ -60,8 +60,8 @@ struct SemanticSearchResponse {
 #[tokio::test]
 async fn test_semantic_search() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,
@@ -120,8 +120,8 @@ async fn test_semantic_search() {
 #[tokio::test]
 async fn test_semantic_search_min_similarity() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,
@@ -175,8 +175,8 @@ async fn test_semantic_search_min_similarity() {
 #[tokio::test]
 async fn test_semantic_search_with_query() {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        unchanged_config,
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest(
                 &client,

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -18,13 +18,7 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{
-    extend_config,
-    send_assert,
-    send_assert_json,
-    test_two_apps,
-    unchanged_config,
-};
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_web_api::{Ingestion, Personalization};
 
 #[derive(Deserialize)]
@@ -39,16 +33,11 @@ struct PersonalizedDocumentsResponse {
 
 async fn store_user_history(enabled: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
-        unchanged_config,
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [personalization]
-                    store_user_history = enabled
-                },
-            );
-        },
+        UNCHANGED_CONFIG,
+        Some(toml! {
+            [personalization]
+            store_user_history = enabled
+        }),
         |client, ingestion, personalization, _| async move {
             send_assert(
                 &client,

--- a/web-api/tests/tenant_id_header.rs
+++ b/web-api/tests/tenant_id_header.rs
@@ -18,6 +18,7 @@ use toml::toml;
 use xayn_integration_tests::{extend_config, send_assert, test_app};
 use xayn_web_api::Ingestion;
 
+#[ignore = "TODO FIX"]
 #[tokio::test]
 async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
     test_app::<Ingestion, _>(
@@ -52,6 +53,7 @@ async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
     .await;
 }
 
+#[ignore = "TODO FIX"]
 #[tokio::test]
 async fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
     test_app::<Ingestion, _>(

--- a/web-api/tests/tenant_id_header.rs
+++ b/web-api/tests/tenant_id_header.rs
@@ -15,22 +15,16 @@
 use reqwest::{Client, StatusCode};
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{extend_config, send_assert, test_app};
+use xayn_integration_tests::{send_assert, test_app};
 use xayn_web_api::Ingestion;
 
-#[ignore = "TODO FIX"]
 #[tokio::test]
 async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
     test_app::<Ingestion, _>(
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [tenants]
-                    enable_legacy_tenant = false
-                },
-            );
-        },
+        Some(toml! {
+            [tenants]
+            enable_legacy_tenant = false
+        }),
         |_, url, _| async move {
             // don't use injected "X-Xayn-Tenant-Id" header
             let client = Client::new();
@@ -53,19 +47,13 @@ async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
     .await;
 }
 
-#[ignore = "TODO FIX"]
 #[tokio::test]
 async fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
     test_app::<Ingestion, _>(
-        |config| {
-            extend_config(
-                config,
-                toml! {
-                    [tenants]
-                    enable_legacy_tenant = true
-                },
-            )
-        },
+        Some(toml! {
+            [tenants]
+            enable_legacy_tenant = true
+        }),
         |_, url, _| async move {
             // don't use injected "X-Xayn-Tenant-Id" header
             let client = Client::new();


### PR DESCRIPTION
- [x] by default run tests with created tenants
- [x] allow configuring the usage of legacy tenant for tests
- [x] test legacy migration, but not to the degree the follow up PR does
- [x] better logging
- [x] no longer setup/tear down test dbs in justfile
- [x] better CI/in-container detection
- [x] use `web-api-db-ctrl::Silo` to setup/teardown test env   
  
**References:**

- story [ET-4344]
- issue [ET-4294]
- based on #919 based on #941
- followed by #942

[ET-4344]: https://xainag.atlassian.net/browse/ET-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4294]: https://xainag.atlassian.net/browse/ET-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ