### PR TITLE
ET-4355 bench coi personalization

### DIFF
--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -59,6 +59,11 @@ xayn-integration-tests = { path = "../integration-tests" }
 xayn-test-utils = { path = "../test-utils" }
 
 [[bench]]
+name = "coi_personalization"
+harness = false
+test = false
+
+[[bench]]
 name = "stateless_personalization"
 harness = false
 test = false

--- a/web-api/benches/coi_personalization.rs
+++ b/web-api/benches/coi_personalization.rs
@@ -1,0 +1,162 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, hint::black_box, time::Duration};
+
+use chrono::Utc;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use itertools::Itertools;
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::SmallRng,
+    SeedableRng,
+};
+use xayn_ai_bert::Embedding1;
+use xayn_ai_coi::{CoiConfig, CoiId, CoiStats, PositiveCoi, UserInterests};
+use xayn_web_api::bench_rerank;
+
+macro_rules! bench_rerank {
+    ($(
+        $function: ident,
+        $embedding_size: expr,
+        $document_size: expr,
+        $interest_size: expr
+    );+ $(;)?) => {$(
+        fn $function(c: &mut Criterion) {
+            let mut rng = SmallRng::from_entropy();
+            let floats = Uniform::new_inclusive(-1.0, 1.0);
+            let ints = Uniform::new(0, $interest_size);
+
+            let system = CoiConfig::default().build();
+            let timestamp = Utc::now();
+
+            let documents = (0..$document_size)
+                .map(|_| {
+                    let embedding = Embedding1::from(
+                        floats
+                            .sample_iter(&mut rng)
+                            .take($embedding_size)
+                            .collect_vec(),
+                    )
+                    .normalize()
+                    .unwrap();
+                    let tags = vec![format!("tag {}", ints.sample(&mut rng))];
+                    (embedding, tags)
+                })
+                .collect_vec();
+
+            let interests = (0..$interest_size)
+                .map(|i| {
+                    let id = CoiId::new();
+                    let point = Embedding1::from(
+                        floats
+                            .sample_iter(&mut rng)
+                            .take($embedding_size)
+                            .collect_vec(),
+                    )
+                    .normalize()
+                    .unwrap();
+                    let stats = CoiStats {
+                        view_count: i,
+                        view_time: Duration::from_secs(i as u64),
+                        last_view: timestamp,
+                    };
+                    PositiveCoi { id, point, stats }
+                })
+                .collect();
+            let interests = UserInterests {
+                positive: interests,
+                negative: Vec::new(),
+            };
+
+            let tag_weights = (0..$interest_size)
+                .map(|i| (format!("tag {i}"), i))
+                .collect::<HashMap<_, _>>();
+
+            let name = format!(
+                "rerank {} documents on {} interests (embedding size: {})",
+                $document_size,
+                $interest_size,
+                $embedding_size,
+            );
+            c.bench_function(
+                &name,
+                |b| b.iter_batched(
+                    || (documents.clone(), tag_weights.clone()),
+                    |(documents, tag_weights)| bench_rerank(
+                        black_box(&system),
+                        black_box(documents),
+                        black_box(&interests),
+                        black_box(tag_weights),
+                        black_box(timestamp),
+                    ),
+                    BatchSize::SmallInput,
+                ),
+            );
+        }
+    )+};
+}
+
+bench_rerank! {
+    bench_rerank_128_0_2, 128, 0, 2;
+    bench_rerank_128_10_2, 128, 10, 2;
+    bench_rerank_128_20_2, 128, 20, 2;
+    bench_rerank_128_30_2, 128, 30, 2;
+    bench_rerank_128_40_2, 128, 40, 2;
+
+    bench_rerank_128_0_5, 128, 0, 5;
+    bench_rerank_128_10_5, 128, 10, 5;
+    bench_rerank_128_20_5, 128, 20, 5;
+    bench_rerank_128_30_5, 128, 30, 5;
+    bench_rerank_128_40_5, 128, 40, 5;
+
+    bench_rerank_128_0_10, 128, 0, 10;
+    bench_rerank_128_10_10, 128, 10, 10;
+    bench_rerank_128_20_10, 128, 20, 10;
+    bench_rerank_128_30_10, 128, 30, 10;
+    bench_rerank_128_40_10, 128, 40, 10;
+}
+
+criterion_group!(
+    rerank_with_2_interests,
+    bench_rerank_128_0_2,
+    bench_rerank_128_10_2,
+    bench_rerank_128_20_2,
+    bench_rerank_128_30_2,
+    bench_rerank_128_40_2,
+);
+
+criterion_group!(
+    rerank_with_5_interests,
+    bench_rerank_128_0_5,
+    bench_rerank_128_10_5,
+    bench_rerank_128_20_5,
+    bench_rerank_128_30_5,
+    bench_rerank_128_40_5,
+);
+
+criterion_group!(
+    rerank_with_10_interests,
+    bench_rerank_128_0_10,
+    bench_rerank_128_10_10,
+    bench_rerank_128_20_10,
+    bench_rerank_128_30_10,
+    bench_rerank_128_40_10,
+);
+
+criterion_main!(
+    rerank_with_2_interests,
+    rerank_with_5_interests,
+    rerank_with_10_interests,
+);

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -52,5 +52,5 @@ pub use crate::{
     error::application::{ApplicationError, Error},
     ingestion::Ingestion,
     net::AppHandle,
-    personalization::{bench_derive_interests, Personalization},
+    personalization::{bench_derive_interests, bench_rerank, Personalization},
 };

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -22,7 +22,7 @@ use derive_more::AsRef;
 use serde::{Deserialize, Serialize};
 use xayn_ai_coi::{CoiConfig, CoiSystem};
 
-pub use self::stateless::bench_derive_interests;
+pub use self::{rerank::bench_rerank, stateless::bench_derive_interests};
 use crate::{
     app::{self, Application, SetupError},
     embedding::{self, Embedder},


### PR DESCRIPTION
**Reference**

- [ET-4355]

**Summary**

- benchmark the coi personalization reranker, this is parametrizable over the `embedding_size` & `document_size` & `interest_size`
- exclude more benchmark setup also from the `stateless_personalization` benchmark

**Example**

```
Benchmarking rerank 0 documents on 2 interests (embedding size: 128): Collecting 100 samples in estimated 5.0007 s (13M 
rerank 0 documents on 2 interests (embedding size: 128)
                        time:   [257.12 ns 260.35 ns 263.83 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking rerank 10 documents on 2 interests (embedding size: 128): Collecting 100 samples in estimated 5.0291 s (556
rerank 10 documents on 2 interests (embedding size: 128)
                        time:   [7.5560 µs 7.5698 µs 7.5836 µs]
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) low mild

Benchmarking rerank 20 documents on 2 interests (embedding size: 128): Collecting 100 samples in estimated 5.0781 s (288
rerank 20 documents on 2 interests (embedding size: 128)
                        time:   [15.008 µs 15.045 µs 15.083 µs]
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) low mild
  3 (3.00%) high mild

Benchmarking rerank 30 documents on 2 interests (embedding size: 128): Collecting 100 samples in estimated 5.0378 s (197
rerank 30 documents on 2 interests (embedding size: 128)
                        time:   [22.132 µs 22.192 µs 22.253 µs]
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) low mild
  1 (1.00%) high mild

Benchmarking rerank 40 documents on 2 interests (embedding size: 128): Collecting 100 samples in estimated 5.0982 s (146
rerank 40 documents on 2 interests (embedding size: 128)
                        time:   [29.393 µs 29.435 µs 29.475 µs]
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) low mild
  1 (1.00%) high mild

Benchmarking rerank 0 documents on 5 interests (embedding size: 128): Collecting 100 samples in estimated 5.0023 s (7.1M
rerank 0 documents on 5 interests (embedding size: 128)
                        time:   [520.96 ns 526.01 ns 531.26 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

Benchmarking rerank 10 documents on 5 interests (embedding size: 128): Collecting 100 samples in estimated 5.0469 s (470
rerank 10 documents on 5 interests (embedding size: 128)
                        time:   [9.0607 µs 9.0787 µs 9.0962 µs]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high severe

Benchmarking rerank 20 documents on 5 interests (embedding size: 128): Collecting 100 samples in estimated 5.0708 s (247
rerank 20 documents on 5 interests (embedding size: 128)
                        time:   [17.597 µs 17.626 µs 17.653 µs]
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) low mild
  1 (1.00%) high mild

Benchmarking rerank 30 documents on 5 interests (embedding size: 128): Collecting 100 samples in estimated 5.0900 s (172
rerank 30 documents on 5 interests (embedding size: 128)
                        time:   [25.652 µs 25.684 µs 25.716 µs]
Found 12 outliers among 100 measurements (12.00%)
  10 (10.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking rerank 40 documents on 5 interests (embedding size: 128): Collecting 100 samples in estimated 5.1037 s (126
rerank 40 documents on 5 interests (embedding size: 128)
                        time:   [34.495 µs 34.543 µs 34.590 µs]
Found 18 outliers among 100 measurements (18.00%)
  15 (15.00%) low mild
  3 (3.00%) high mild

Benchmarking rerank 0 documents on 10 interests (embedding size: 128): Collecting 100 samples in estimated 5.0046 s (4.0
rerank 0 documents on 10 interests (embedding size: 128)
                        time:   [916.87 ns 920.08 ns 923.04 ns]
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) low mild

Benchmarking rerank 10 documents on 10 interests (embedding size: 128): Collecting 100 samples in estimated 5.0602 s (38
rerank 10 documents on 10 interests (embedding size: 128)
                        time:   [11.252 µs 11.270 µs 11.289 µs]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking rerank 20 documents on 10 interests (embedding size: 128): Collecting 100 samples in estimated 5.0118 s (20
rerank 20 documents on 10 interests (embedding size: 128)
                        time:   [21.419 µs 21.451 µs 21.482 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low mild
  1 (1.00%) high severe

Benchmarking rerank 30 documents on 10 interests (embedding size: 128): Collecting 100 samples in estimated 5.0863 s (14
rerank 30 documents on 10 interests (embedding size: 128)
                        time:   [31.482 µs 31.526 µs 31.566 µs]
Found 13 outliers among 100 measurements (13.00%)
  10 (10.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking rerank 40 documents on 10 interests (embedding size: 128): Collecting 100 samples in estimated 5.0557 s (10
rerank 40 documents on 10 interests (embedding size: 128)
                        time:   [41.797 µs 41.873 µs 41.942 µs]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) low mild
  3 (3.00%) high mild
```
