### PR TITLE
[Merged by Bors] - ET-4113 increase log level for embedding computation

### DIFF
--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -23,7 +23,7 @@ use anyhow::bail;
 use itertools::{Either, Itertools};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use tokio::time::Instant;
-use tracing::{error, info, instrument};
+use tracing::{debug, error, instrument};
 use xayn_summarizer::{summarize, Config, Source, Summarizer};
 
 use super::AppState;
@@ -337,7 +337,7 @@ async fn upsert_documents(
         )
         .collect_vec();
 
-    info!(
+    debug!(
         "{} new embeddings calculated in {} seconds and {} unchanged embeddings skipped",
         new_documents.len(),
         start.elapsed().as_secs(),


### PR DESCRIPTION
**Reference**

- [ET-4113]

**Summary**

- raise the log level for the embedding computations to `debug`


[ET-4113]: https://xainag.atlassian.net/browse/ET-4113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ