### PR TITLE
[Merged by Bors] - Update ci image

### DIFF
--- a/.github/docker/Dockerfile.ci-image
+++ b/.github/docker/Dockerfile.ci-image
@@ -1,4 +1,4 @@
-FROM debian:11.6-slim
+FROM debian:bookworm-20230502-slim
 
 ARG rust_version
 ARG just_version
@@ -13,13 +13,10 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
       ca-certificates wget curl git zstd gcc libc6-dev \ 
-      nodejs npm postgresql-client python3.9 python3-pip \
-      unzip; \
+      nodejs npm postgresql-client python3.11 python3-pip \
+      unzip lld awscli g++-aarch64-linux-gnu libc6-dev-arm64-cross \
+      ; \
     rm -rf /var/lib/apt/lists/*;
-
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-	./aws/install
 
 # Begin: Rust base
 # Taken from https://github.com/rust-lang/docker-rust/blob/f558c4c660fd925e278da432640342de993f2bc7/1.68.0/bullseye/slim/Dockerfile
@@ -31,13 +28,13 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='bb31eaf643926b2ee9f4d8d6fc0e2835e03c0a60f34d324048aa194f0b29a71c' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6626b90205d7fe7058754c8e993b7efd91dedc6833a11a225b296b7c2941194f' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='4ccaa7de6b8be1569f6b764acc28e84f5eca342f5162cd5c810891bff7ed7f74' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='34392b53a25c56435b411d3e575b63aab962034dd1409ba405e708610c829607' ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e7b0f47557c1afcd86939b118cbcf7fb95a5d1d917bdd355157b63ca00fc4333' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.25.2/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
@@ -56,6 +53,7 @@ RUN set -eux; \
 
 RUN set -eux; \
     rustup component add clippy; \
+    rustup target add aarch64-unknown-linux-gnu; \
     rustup toolchain install nightly --component rustfmt --profile minimal; \
     rustc +nightly --version; \
     cargo install just --version="${just_version}"; \

--- a/.github/docker/Dockerfile.ci-image
+++ b/.github/docker/Dockerfile.ci-image
@@ -19,7 +19,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*;
 
 # Begin: Rust base
-# Taken from https://github.com/rust-lang/docker-rust/blob/f558c4c660fd925e278da432640342de993f2bc7/1.68.0/bullseye/slim/Dockerfile
+# Taken from https://github.com/rust-lang/docker-rust/blob/e715973ebf70db0f75722a8d68339fe4a2ecf8c8/1.69.0/bookworm/slim/Dockerfile
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -10,7 +10,7 @@ jobs:
   cargo-format:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
@@ -24,7 +24,7 @@ jobs:
   cargo-clippy:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
@@ -38,7 +38,7 @@ jobs:
   cargo-test:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 20
     env:
       XAYN_INGESTION__NET__BIND_TO: "127.0.0.1:3030"
@@ -88,7 +88,7 @@ jobs:
   cargo-doc:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -26,7 +26,7 @@ jobs:
     needs: rust-checks
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 5
     if: ${{ always() }}
     steps:

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -23,7 +23,7 @@ permissions:
 
 env:
   image_name: xaynetci/yellow
-  release_tag: v12
+  release_tag: v13
 
 jobs:
   build-docker-image:

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -36,13 +36,6 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
 
-      - name: Determine rust version
-        shell: bash
-        run: |
-          set -eux
-          RUST_VERSION=$(perl -ne 'print $1 if /channel = \"(.*)\"/' rust-toolchain.toml)
-          echo "rust_version=${RUST_VERSION}" >> $GITHUB_ENV
-
       - name: Determine image tag
         run: |
           IMAGE_TAG="$(git rev-parse --short "$GITHUB_SHA")"
@@ -52,16 +45,7 @@ jobs:
         shell: bash
         run: |
           set -eux
-          source .env
-          docker build \
-            --build-arg rust_version="${{ env.rust_version }}" \
-            --build-arg just_version="${JUST_VERSION}" \
-            --build-arg cargo_sort_version="${CARGO_SORT_VERSION}" \
-            --build-arg spectral_cli_version="${SPECTRAL_CLI_VERSION}" \
-            --build-arg ibm_openapi_ruleset_version="${IBM_OPENAPI_RULESET_VERSION}" \
-            --build-arg validator_version="${VALIDATOR_VERSION}" \
-            --tag "${{ env.image_name }}:${{ env.image_tag }}" \
-            - < .github/docker/Dockerfile.ci-image
+          just build-ci-image "${{ env.image_name }}:${{ env.image_tag }}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
   open-api:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
   
@@ -36,7 +36,7 @@ jobs:
     if: ${{ always() }}
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -39,7 +39,7 @@ jobs:
   services-build:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -54,11 +54,6 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
-
-          apt update -y && apt upgrade -y
-          apt install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross
-
-          rustup target add aarch64-unknown-linux-gnu
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/justfile
+++ b/justfile
@@ -171,6 +171,21 @@ build-service-image $CRATE_PATH $BIN $ASSET_DIR="":
     docker build -f "$CRATE_PATH/Dockerfile" -t "xayn-$CRATE_PATH-$BIN" "$out"
     rm -rf "$out"
 
+build-ci-image $IMAGE_NAME $IMAGE_TAG:
+    #!/usr/bin/env -S bash -eux -o pipefail
+    set -eux
+    RUST_VERSION=$(perl -ne 'print $1 if /channel = \"(.*)\"/' {{justfile_directory()}}/rust-toolchain.toml)
+
+    docker build \
+      --build-arg rust_version="${RUST_VERSION}" \
+      --build-arg just_version="${JUST_VERSION}" \
+      --build-arg cargo_sort_version="${CARGO_SORT_VERSION}" \
+      --build-arg spectral_cli_version="${SPECTRAL_CLI_VERSION}" \
+      --build-arg ibm_openapi_ruleset_version="${IBM_OPENAPI_RULESET_VERSION}" \
+      --build-arg validator_version="${VALIDATOR_VERSION}" \
+      --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+      - < .github/docker/Dockerfile.ci-image
+
 compose-all-build $SMBERT="smbert_v0003":
     #!/usr/bin/env -S bash -eux -o pipefail
     {{just_executable()}} build-service-image web-api personalization

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.69.0"
 profile = "default"

--- a/web-api/Dockerfile
+++ b/web-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bookworm-20230502-slim
 WORKDIR /app
 COPY ./ ./
 ENTRYPOINT ["/app/server.bin"]

--- a/web-api/src/storage/postgres/client.rs
+++ b/web-api/src/storage/postgres/client.rs
@@ -148,7 +148,7 @@ impl Database {
             sqlx::migrate!().run(&pool).await?;
 
             //FIXME handle legacy tenant here (in follow up PR)
-            let _ = enable_legacy_tenant;
+            let _: bool = enable_legacy_tenant;
         }
 
         Ok(DatabaseBuilder { pool })


### PR DESCRIPTION
This was created to install `lld` but since is a bit of a pain to update the image I fitted in it multiple changes.

* Use `bookworm-20230502-slim` instead of debian stable. Bookworm is now in hard freeze and it will become the new stable in summer. It allows us to install awscli from the package manager and to have an up-to-date toolchain that is more similar to what we have on our machine. We were already using bookworm for the image that we use to deploy. 
* Install `lld` so that we can use it later on
* Install the packages and target that are needed to compile for `arm64`
* Update to rustup 1.26 and rust 1.69
* Move the code that generates the image to a justfile task to be able to test it more easily
