### PR TITLE
[Merged by Bors] - ET-4338 improve ingestion log levels

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -86,13 +86,21 @@ pub(crate) struct FailedToDeleteSomeDocuments {
 
 impl_application_error!(FailedToDeleteSomeDocuments => BAD_REQUEST, INFO);
 
-/// The ingestion of some documents failed.
+/// The validation of some documents failed.
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct IngestingDocumentsFailed {
+pub(crate) struct FailedToValidateDocuments {
     pub(crate) documents: Vec<DocumentIdAsObject>,
 }
 
-impl_application_error!(IngestingDocumentsFailed => INTERNAL_SERVER_ERROR, ERROR);
+impl_application_error!(FailedToValidateDocuments => BAD_REQUEST, INFO);
+
+/// The ingestion of some documents failed.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct FailedToIngestDocuments {
+    pub(crate) documents: Vec<DocumentIdAsObject>,
+}
+
+impl_application_error!(FailedToIngestDocuments => INTERNAL_SERVER_ERROR, ERROR);
 
 /// Failed to set some document candidates.
 #[derive(Debug, Display, Error, Serialize)]


### PR DESCRIPTION
**Reference**

- [ET-4338]
- #882
- requires #914

**Summary**

- during ingestion split the `failed_documents` into `invalid_documents` and `failed_documents`
- split the returned error into `FailedToValidateDocuments`/400 and `FailedToIngestDocuments`/500


[ET-4338]: https://xainag.atlassian.net/browse/ET-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ