### PR TITLE
[Merged by Bors] - ET-4435 move knn storage impl detail

### DIFF
--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -49,6 +49,11 @@ impl Client {
         &self,
         params: KnnSearchParams<'a, impl IntoIterator<Item = &'a DocumentId>>,
     ) -> Result<HashMap<DocumentId, f32>, Error> {
+        // knn search with `k`/`num_candidates` set to zero is a bad request
+        if params.count == 0 {
+            return Ok(HashMap::new());
+        }
+
         let time = params.time.to_rfc3339();
         // the existing documents are not filtered in the query to avoid too much work for a cold
         // path, filtering them afterwards can occasionally lead to less than k results though


### PR DESCRIPTION
**Reference**

- [ET-4435]

**Summary**

- move the `count == 0` check from the personalization routes into the es/pg storage impl
- safeguard the `num_candidates` against rounding errors in `count` to ensure the `count <= num_candidates` invariant


[ET-4435]: https://xainag.atlassian.net/browse/ET-4435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ