### PR TITLE
[Merged by Bors] - ET-4414 check migrations are not changed

### DIFF
--- a/.github/workflows/on-pr-branch-push.yml
+++ b/.github/workflows/on-pr-branch-push.yml
@@ -32,14 +32,6 @@ jobs:
       - name: Validate openapi
         run: just validate-openapi
 
-  check-migration-unchanged:
-    runs-on: hetzner-pm
-    container:
-      image: xaynetci/yellow:v12
-    steps:
-      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
-      - run: just validate-migrations-unchanged ${{ github.event.pull_request.base.sha }}
-
   copyright:
     if: ${{ always() }}
     runs-on: hetzner-pm

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,0 +1,15 @@
+name: CI -- PR Specific Events
+
+on:
+  pull_request:
+    branches-ignore:
+      - '_bors*'
+      
+jobs:
+  check-migration-unchanged:
+    runs-on: hetzner-pm
+    container:
+      image: xaynetci/yellow:v12
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+      - run: just validate-migrations-unchanged ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI -- PR Specific Events
+name: CI (PR Specific Jobs)
 
 on:
   pull_request:
@@ -16,4 +16,6 @@ jobs:
       image: xaynetci/yellow:v12
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
-      - run: just validate-migrations-unchanged ${{ github.event.pull_request.base.sha }}
+      - run: |
+          git config --global --add safe.directory "$(pwd)"
+          just validate-migrations-unchanged "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
   check-migration-unchanged:
     runs-on: hetzner-pm
     container:
-      image: xaynetci/yellow:v12
+      image: xaynetci/yellow:v13
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       - run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
     branches-ignore:
       - '_bors*'
-      
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-migration-unchanged:
     runs-on: hetzner-pm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,9 +28,17 @@ jobs:
       image: xaynetci/yellow:v13
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
-  
+
       - name: Validate openapi
         run: just validate-openapi
+
+  check-migration-unchanged:
+    runs-on: hetzner-pm
+    container:
+      image: xaynetci/yellow:v12
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+      - run: just validate-migrations-unchanged ${{ github.event.pull_request.base.sha }}
 
   copyright:
     if: ${{ always() }}

--- a/justfile
+++ b/justfile
@@ -231,6 +231,27 @@ validate-openapi:
         spectral lint --verbose -F warn "$file"
     done
 
+validate-migrations-unchanged cmp_ref:
+    #!/usr/bin/env -S bash -eu -o pipefail
+    if ! git rev-list "{{ cmp_ref }}".."{{ cmp_ref }}"; then
+        git fetch --depth=1 "$(git remote get-url origin)" "{{ cmp_ref }}"
+    fi
+
+    changed_migrations=( $(\
+        git diff --name-only "{{ cmp_ref }}" | \
+        grep -E "^web-api/migrations/.*" \
+    ) ) || true
+
+    if [ "${#changed_migrations[@]}" -gt 0 ]; then
+        for migration in "${changed_migrations[@]}"; do
+            echo "Migrations was changed ${migration}" >&2
+        done
+        exit 1
+    else
+        echo "OK - migrations unchanged"
+    fi
+
+
 print-just-env:
     export
 


### PR DESCRIPTION
- [x] add a just action to check if a migration is unchanged since a specific commit
- [x] use that action on pull requests to check that we don't accidentally change migrations

one limitations is that it doesn't understand files being moved. Which means we should merge it after reverting the reversions (which moves the migrations). It's unlikely that we move migrations in the future.

**References:**

- story [ET-4411]
- issue [ET-4414]

[ET-4411]: https://xainag.atlassian.net/browse/ET-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4414]: https://xainag.atlassian.net/browse/ET-4414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ