### PR TITLE
[Merged by Bors] - workspace-wide license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.68.0"
+license = "AGPL-3.0-only"
 
 [workspace.dependencies]
 anyhow = "1.0.69"

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -3,7 +3,7 @@ name = "xayn-ai-bert"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-license = "AGPL-3.0-only"
+license = { workspace = true }
 
 [dependencies]
 derive_more = { workspace = true }

--- a/coi/Cargo.toml
+++ b/coi/Cargo.toml
@@ -3,7 +3,7 @@ name = "xayn-ai-coi"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-license = "AGPL-3.0-only"
+license = { workspace = true }
 
 [dependencies]
 chrono = { workspace = true }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "xayn-integration-tests"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-license = "AGPL-3.0-only"
+license = { workspace = true }
 publish = false
 
 [dependencies]

--- a/summarizer/Cargo.toml
+++ b/summarizer/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 description = "Reduce long text to few relevant sentences"
-license = "AGPL-3.0-only"
+license = { workspace = true }
 
 [dependencies]
 ndarray = { workspace = true }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -3,7 +3,7 @@ name = "xayn-test-utils"
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-license = "AGPL-3.0-only"
+license = { workspace = true }
 publish = false
 
 [dependencies]

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 description = "Wep Api server for the document personalization service."
-license = "AGPL-3.0-only"
+license = { workspace = true }
 
 [dependencies]
 actix-cors = "0.6.4"


### PR DESCRIPTION
**Summary**

- set the `AGPL-3.0-only` in the workspace's `Cargo.toml` and use it in the crates, we only name other licenses in a crate directly if needed
