### PR TITLE
[Merged by Bors] - ET-4418 rename X-Tenant-Id => X-Xayn-Tenant-id

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -168,7 +168,7 @@ pub async fn test_two_apps<A1, A2, F>(
 fn build_client(services: &Services) -> Arc<Client> {
     let mut default_headers = HeaderMap::default();
     default_headers.insert(
-        "X-Tenant-Id",
+        "X-Xayn-Tenant-Id",
         services.tenant_id.as_str().try_into().unwrap(),
     );
     Arc::new(

--- a/web-api/src/middleware/request_context.rs
+++ b/web-api/src/middleware/request_context.rs
@@ -209,7 +209,7 @@ where
     )
 }
 
-const TENANT_ID_HEADER: &str = "X-Tenant-Id";
+const TENANT_ID_HEADER: &str = "X-Xayn-Tenant-Id";
 
 fn extract_tenant_id(
     config: &tenants::Config,

--- a/web-api/tests/tenant_id_header.rs
+++ b/web-api/tests/tenant_id_header.rs
@@ -31,7 +31,7 @@ async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
             );
         },
         |_, url, _| async move {
-            // don't use injected "X-Tenant-Id" header
+            // don't use injected "X-Xayn-Tenant-Id" header
             let client = Client::new();
             send_assert(
                 &client,
@@ -65,7 +65,7 @@ async fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
             )
         },
         |_, url, _| async move {
-            // don't use injected "X-Tenant-Id" header
+            // don't use injected "X-Xayn-Tenant-Id" header
             let client = Client::new();
             send_assert(
                 &client,


### PR DESCRIPTION
Rename header to avoid conclusions.

**References:**

- story [ET-4411]
- issue [ET-4418]

[ET-4411]: https://xainag.atlassian.net/browse/ET-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4418]: https://xainag.atlassian.net/browse/ET-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ