### PR TITLE
Do not give tags score to documents that do not have it

### DIFF
--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -101,7 +101,7 @@ impl Default for PersonalizationConfig {
             default_number_documents: 10,
             // FIXME: what is a default value we know works well with how we do knn?
             max_cois_for_knn: 10,
-            score_weights: [0.5, 0.5, 0.0],
+            score_weights: [0.7, 0.3, 0.0],
             store_user_history: true,
             max_stateless_history_size: 200,
             max_stateless_history_for_cois: 20,


### PR DESCRIPTION
The tag score of a document is decided by its position in a sorted (by tag weight) array.
When we have documents with tag weight `0` (that means that they do not match the user's tag) or if two documents have the exact count, we are "randomly" and arbitrarily associate different scores to them based on their position in the input.

This PR tries to mitigate the case in which documents have `0` weight. In this case, the no-weight documents are assigned `0` as a score instead of a score based on their position. As a side-effect of this means that if one document has a weight and the others don't, it will be significantly boosted. For this reason, I reduced the weight of the tag score from `0.5` to  `0.3`.
