### PR TITLE
[Merged by Bors] - ET-4442 group rerank_by_tag_weight

### DIFF
--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -181,7 +181,7 @@ async fn test_full_personalization() {
             .await;
             assert_eq!(
                 fully_personalized.ids(),
-                ["d6", "d8", "d5", "d4", "d7"],
+                ["d8", "d5", "d4", "d6", "d7"],
                 "unexpected fully personalized documents: {:?}",
                 fully_personalized.documents,
             );
@@ -336,7 +336,7 @@ async fn test_full_personalization_with_inline_history() {
             .await;
             assert_eq!(
                 fully_personalized.ids(),
-                ["d6", "d8", "d5", "d4", "d7"],
+                ["d8", "d5", "d4", "d6", "d7"],
                 "unexpected fully personalized documents: {:?}",
                 fully_personalized.documents,
             );


### PR DESCRIPTION
**Reference**

- [ET-4442]

**Summary**

- group the documents by their summed tag weights and assign the same score to all documents with equal weight


[ET-4442]: https://xainag.atlassian.net/browse/ET-4442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ