### PR TITLE
[Merged by Bors] - ET-4451 personalized search with tags tests

### DIFF
--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -12,8 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
-
+use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
@@ -21,7 +20,7 @@ use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, uncha
 use xayn_test_utils::error::Panic;
 use xayn_web_api::{Ingestion, Personalization};
 
-async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Panic> {
+async fn ingest_with_dates(client: &Client, ingestion_url: &Url) -> Result<(), Panic> {
     send_assert(
         client,
         client
@@ -33,10 +32,35 @@ async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Panic> {
                     { "id": "d3", "snippet": "Politic", "properties": { "publication_date": "2023-02-12T20:20:20Z" } },
                     { "id": "d4", "snippet": "Laptop", "properties": { "publication_date": "2100-01-01T00:00:00Z" } },
                     { "id": "d5", "snippet": "Smartphone", "properties": { "publication_date": "2023-08-12T20:20:20Z" } },
-                    { "id": "d6", "snippet": "Computer", "properties": { "publication_date": "2021-05-12T20:20:20Z" } },
+                    { "id": "d6", "snippet": "Computers", "properties": { "publication_date": "2021-05-12T20:20:20Z" } },
                     { "id": "d7", "snippet": "Dogs" },
                     { "id": "d8", "snippet": "Chicken" },
                     { "id": "d9", "snippet": "Robot Chicken" }
+                ]
+            }))
+            .build()?,
+        StatusCode::CREATED,
+    )
+    .await;
+    Ok(())
+}
+
+async fn ingest_with_tags(client: &Client, ingestion_url: &Url) -> Result<(), Panic> {
+    send_assert(
+        client,
+        client
+            .post(ingestion_url.join("/documents")?)
+            .json(&json!({
+                "documents": [
+                    { "id": "d1", "snippet": "Computer", "tags": ["tec"] },
+                    { "id": "d2", "snippet": "Technology", "tags": ["tec", "soc"] },
+                    { "id": "d3", "snippet": "Politic", "tags": ["soc"] },
+                    { "id": "d4", "snippet": "Laptop", "tags": ["tec"] },
+                    { "id": "d5", "snippet": "Smartphone", "tags": ["tec", "soc"] },
+                    { "id": "d6", "snippet": "Computers", "tags": ["tec"] },
+                    { "id": "d7", "snippet": "Dogs" ,"tags": ["nat"] },
+                    { "id": "d8", "snippet": "Chicken", "tags": ["nat"] },
+                    { "id": "d9", "snippet": "Robot Chicken", "tags": ["nat", "tec"] }
                 ]
             }))
             .build()?,
@@ -87,13 +111,10 @@ enum PersonalizedDocumentsResponse {
 
 async fn personalize(
     client: &Client,
-    ingestion_url: &Url,
     personalization_url: &Url,
     published_after: Option<&str>,
     query: Option<&str>,
 ) -> Result<Vec<PersonalizedDocumentData>, Panic> {
-    ingest(client, ingestion_url).await?;
-
     let mut request = client
         .get(personalization_url.join("/users/u1/personalized_documents")?)
         .query(&[("count", "5")]);
@@ -131,26 +152,43 @@ async fn personalize(
     Ok(documents)
 }
 
+fn assert<const N: usize>(
+    documents: &[PersonalizedDocumentData],
+    ids: [&str; N],
+) -> Result<(), Panic> {
+    assert_eq!(
+        documents
+            .iter()
+            .map(|document| document.id.as_str())
+            .collect_vec(),
+        ids,
+    );
+    for documents in documents.windows(2) {
+        let [d1, d2] = documents else {unreachable!()};
+        assert!(1.0 >= d1.score);
+        assert!(d1.score > d2.score);
+        assert!(d2.score >= 0.0);
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_personalization_all_dates() {
     test_two_apps::<Ingestion, Personalization, _>(
         unchanged_config,
         unchanged_config,
         |client, ingestion_url, personalization_url, _| async move {
-            let documents =
-                personalize(&client, &ingestion_url, &personalization_url, None, None).await?;
-            assert_eq!(
+            ingest_with_dates(&client, &ingestion_url).await?;
+            let documents = personalize(&client, &personalization_url, None, None).await?;
+            println!(
+                "{:?}",
                 documents
                     .iter()
-                    .map(|document| document.id.as_str())
-                    .collect::<HashSet<_>>(),
-                ["d1", "d3", "d6", "d7", "d8"].into(),
+                    .map(|d| (d.id.as_str(), d.score))
+                    .collect_vec()
             );
-            assert!(documents
-                .iter()
-                .all(|document| (0.0..=1.0).contains(&document.score)));
-
-            Ok(())
+            assert(&documents, ["d8", "d6", "d1", "d7", "d3"])
         },
     )
     .await;
@@ -162,26 +200,15 @@ async fn test_personalization_limited_dates() {
         unchanged_config,
         unchanged_config,
         |client, ingestion_url, personalization_url, _| async move {
+            ingest_with_dates(&client, &ingestion_url).await?;
             let documents = personalize(
                 &client,
-                &ingestion_url,
                 &personalization_url,
                 Some("2022-01-01T00:00:00Z"),
                 None,
             )
             .await?;
-            assert_eq!(
-                documents
-                    .iter()
-                    .map(|document| document.id.as_str())
-                    .collect::<HashSet<_>>(),
-                ["d1", "d3"].into(),
-            );
-            assert!(documents
-                .iter()
-                .all(|document| (0.0..=1.0).contains(&document.score)));
-
-            Ok(())
+            assert(&documents, ["d1", "d3"])
         },
     )
     .await;
@@ -193,26 +220,29 @@ async fn test_personalization_with_query() {
         unchanged_config,
         unchanged_config,
         |client, ingestion_url, personalization_url, _| async move {
+            ingest_with_dates(&client, &ingestion_url).await?;
             let documents = personalize(
                 &client,
-                &ingestion_url,
                 &personalization_url,
                 None,
                 Some("Robot Technology Chicken"),
             )
             .await?;
-            assert_eq!(
-                documents
-                    .iter()
-                    .map(|document| document.id.as_str())
-                    .collect::<HashSet<_>>(),
-                ["d1", "d6", "d7", "d8"].into(),
-            );
-            assert!(documents
-                .iter()
-                .all(|document| (0.0..=1.0).contains(&document.score)));
+            assert(&documents, ["d8", "d6", "d1", "d7"])
+        },
+    )
+    .await;
+}
 
-            Ok(())
+#[tokio::test]
+async fn test_personalization_with_tags() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        unchanged_config,
+        unchanged_config,
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest_with_tags(&client, &ingestion_url).await?;
+            let documents = personalize(&client, &personalization_url, None, None).await?;
+            assert(&documents, ["d5", "d8", "d6", "d4", "d1"])
         },
     )
     .await;


### PR DESCRIPTION
**Reference**

- [ET-4451]

**Summary**

- add integration tests for personalized documents with tags
- more strict order checks for personalized documents and semantic search


[ET-4451]: https://xainag.atlassian.net/browse/ET-4451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ