### PR TITLE
[Merged by Bors] - ET-4477 fix hybrid search merging

### DIFF
--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -18,9 +18,10 @@ use std::collections::HashMap;
 
 pub(crate) use client::{Client, ClientBuilder, Config, Error as ElasticError};
 use itertools::Itertools;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use xayn_ai_bert::NormalizedEmbedding;
+use xayn_ai_coi::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc};
 
 use self::client::BulkInstruction;
 use crate::{
@@ -115,79 +116,38 @@ impl Client {
         if let Some(min_similarity) = params.min_similarity {
             body.insert("min_score".to_string(), json!(min_similarity));
         }
+        let mut knn_scores = self.search_request(&body).await?;
+
         if let Some(query) = params.query {
+            body.remove("knn");
             filter.insert("must".to_string(), json!({ "match": { "snippet": query }}));
             body.insert("query".to_string(), json!({ "bool": filter }));
-            body.insert("explain".to_string(), json!(true));
+
+            let bm25_scores = self.search_request(body).await?;
+            let max_bm25_score = bm25_scores
+                .values()
+                .copied()
+                .max_by(nan_safe_f32_cmp)
+                .unwrap_or_default()
+                .max(1.0);
+
+            // mixed knn and bm25 scores need to be normalized
+            for (id, bm25_score) in bm25_scores {
+                let bm25_score = bm25_score / max_bm25_score;
+                knn_scores
+                    .entry(id)
+                    .and_modify(|knn_score| *knn_score = 0.5 * *knn_score + 0.5 * bm25_score)
+                    .or_insert(bm25_score);
+            }
+
+            knn_scores = knn_scores
+                .into_iter()
+                .sorted_unstable_by(|(_, s1), (_, s2)| nan_safe_f32_cmp_desc(s1, s2))
+                .take(params.count)
+                .collect();
         }
 
-        let scores = self
-            .query_with_json::<_, SearchResponse<NoSource>>(
-                self.create_resource_path(["_search"], None),
-                Some(body),
-            )
-            .await?
-            .map(|response| {
-                if params.query.is_some() {
-                    // mixed knn and bm25 scores need to be normalized
-                    const KNN_DESCRIPTION: &str = "within top k documents";
-                    let mut max_bm25_score = None;
-                    let scores = response
-                        .hits
-                        .hits
-                        .into_iter()
-                        .map(|hit| {
-                            // details has exactly one or two elements: knn or bm25 or both
-                            let mut knn_score = None;
-                            let mut bm25_score = None;
-                            let detail = &hit.explanation.details[0];
-                            if detail.description == KNN_DESCRIPTION {
-                                knn_score = Some(detail.value);
-                            } else {
-                                bm25_score = Some(detail.value);
-                            }
-                            if let Some(detail) = hit.explanation.details.get(1) {
-                                if detail.description == KNN_DESCRIPTION {
-                                    knn_score = Some(detail.value);
-                                } else {
-                                    bm25_score = Some(detail.value);
-                                }
-                            }
-                            if bm25_score > max_bm25_score {
-                                max_bm25_score = bm25_score;
-                            }
-                            (hit.id, knn_score, bm25_score)
-                        })
-                        .collect_vec();
-
-                    let max_bm25_score = max_bm25_score.unwrap_or_default().max(1.0);
-                    scores
-                        .into_iter()
-                        .map(|(id, knn_score, bm25_score)| {
-                            let score = match (knn_score, bm25_score) {
-                                (Some(knn_score), Some(bm25_score)) => {
-                                    0.5 * knn_score + 0.5 * bm25_score / max_bm25_score
-                                }
-                                (Some(knn_score), None) => knn_score,
-                                (None, Some(bm25_score)) => bm25_score / max_bm25_score,
-                                (None, None) => unreachable!(),
-                            };
-                            (id, score)
-                        })
-                        .collect::<HashMap<_, _>>()
-                } else {
-                    // only knn scores are already normalized
-                    response
-                        .hits
-                        .hits
-                        .into_iter()
-                        .map(|hit| (hit.id, hit.score))
-                        .collect::<HashMap<_, _>>()
-                }
-            })
-            .unwrap_or_default();
-
-        Ok(scores)
+        Ok(knn_scores)
     }
 
     pub(super) async fn insert_documents(
@@ -371,53 +331,6 @@ impl Client {
             .query_with_json::<_, IgnoredResponse>(url, body)
             .await?
             .map(|_| ()))
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct Detail {
-    description: String,
-    value: f32,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct Explanation {
-    details: Vec<Detail>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Hit<T> {
-    #[serde(rename = "_id")]
-    id: DocumentId,
-    #[allow(dead_code)]
-    #[serde(rename = "_source")]
-    source: T,
-    #[serde(rename = "_score")]
-    score: f32,
-    #[serde(default)]
-    #[serde(rename = "_explanation")]
-    explanation: Explanation,
-}
-
-#[derive(Debug, Deserialize)]
-struct Hits<T> {
-    hits: Vec<Hit<T>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SearchResponse<T> {
-    hits: Hits<T>,
-}
-
-#[derive(Debug)]
-struct NoSource;
-
-impl<'de> Deserialize<'de> for NoSource {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Self)
     }
 }
 


### PR DESCRIPTION
**Reference**

- [ET-4477]

**Summary**

- move `SearchResponse` into `storage::elastic::client` and make it generic like `BulkResponse`
- make two separate es queries for knn and optionally bm25 and merge the sets with normalized scores in the post-processing


[ET-4477]: https://xainag.atlassian.net/browse/ET-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ