### PR TITLE
[Merged by Bors] - ET-4413 (1/2) preperation for migration tests  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-ai-bert"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "csv",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-ai-coi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-integration-tests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-summarizer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ndarray",
  "serde",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-test-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "float-cmp",
  "ndarray",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "xayn-web-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml 0.7.3",
+ "tracing-subscriber",
  "uuid",
  "xayn-test-utils",
  "xayn-web-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.68.0"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0.39"
 tokio = { version = "1.26.0", default-features = false }
 toml = "0.7.3"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [profile.dev.package.tract-core]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "1.0.39"
 tokio = { version = "1.26.0", default-features = false }
 toml = "0.7.3"
 tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 [profile.dev.package.tract-core]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 toml = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 xayn-test-utils = { path = "../test-utils" }
 xayn-web-api = { path = "../web-api" }

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -36,7 +36,7 @@ sqlx = { workspace = true, features = ["chrono", "uuid"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
+tracing-subscriber = { workspace = true }
 url = { version = "2.3.1", features = ["serde"] }
 urlencoding = "2.1.2"
 uuid = { workspace = true }

--- a/web-api/src/app.rs
+++ b/web-api/src/app.rs
@@ -25,7 +25,6 @@ use tracing::info;
 pub(crate) use self::state::{AppState, TenantState};
 use crate::{
     logging,
-    logging::init_tracing,
     net::{self, AppHandle},
     storage,
     tenants,
@@ -69,8 +68,6 @@ pub async fn start<A>(config: A::Config) -> Result<AppHandle, SetupError>
 where
     A: Application + 'static,
 {
-    init_tracing(config.as_ref());
-
     info!({ ?config }, "starting service");
 
     let pwd = current_dir().unwrap_or_else(|_| PathBuf::from("<no working directory set>"));

--- a/web-api/src/bin/ingestion.rs
+++ b/web-api/src/bin/ingestion.rs
@@ -13,12 +13,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use tracing::instrument;
-use xayn_web_api::{application_names, config, start, Ingestion};
+use xayn_web_api::{application_names, config, logging, start, Application, Ingestion};
+
+type Config = <Ingestion as Application>::Config;
 
 #[tokio::main]
 #[instrument(err)]
 async fn main() -> Result<(), anyhow::Error> {
-    let config = config::load(application_names!());
+    let config: Config = config::load(application_names!());
+    logging::initialize(config.as_ref())?;
     start::<Ingestion>(config)
         .await?
         .wait_for_termination()

--- a/web-api/src/bin/personalization.rs
+++ b/web-api/src/bin/personalization.rs
@@ -13,12 +13,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use tracing::instrument;
-use xayn_web_api::{application_names, config, start, Personalization};
+use xayn_web_api::{application_names, config, logging, start, Application, Personalization};
+
+type Config = <Personalization as Application>::Config;
 
 #[tokio::main]
 #[instrument(err)]
 async fn main() -> Result<(), anyhow::Error> {
-    let config = config::load(application_names!());
+    let config: Config = config::load(application_names!());
+    logging::initialize(config.as_ref())?;
     start::<Personalization>(config)
         .await?
         .wait_for_termination()

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -54,3 +54,7 @@ pub use crate::{
     net::AppHandle,
     personalization::{bench_derive_interests, bench_rerank, Personalization},
 };
+
+/// Allow migration tests to have access to the elastic search mapping this uses.
+//FIXME: Remove once we only test migrations upward from a version with `web-api-db-ctrl`
+pub static ELASTIC_MAPPING: &str = include_str!("../elastic-search/mapping.json");

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -36,7 +36,7 @@ pub mod config;
 mod embedding;
 mod error;
 mod ingestion;
-mod logging;
+pub mod logging;
 mod middleware;
 #[cfg(test)]
 mod mind;

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -73,6 +73,9 @@ impl Default for Config {
 /// Initializes the logging.
 ///
 /// This should be called before [`crate::start()`] is called.
+///
+/// Even through this returns an error if logging was already initialized you
+/// should only call this function when you expect it to succeed.
 pub fn initialize(log_config: &Config) -> Result<(), TryInitError> {
     init_tracing_once(log_config)?;
     init_panic_logging();

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -74,7 +74,7 @@ impl Default for Config {
 ///
 /// This should be called before [`crate::start()`] is called.
 ///
-/// Even through this returns an error if logging was already initialized you
+/// Even though this returns an error if logging was already initialized you
 /// should only call this function when you expect it to succeed.
 pub fn initialize(log_config: &Config) -> Result<(), TryInitError> {
     init_tracing_once(log_config)?;

--- a/web-api/src/utils.rs
+++ b/web-api/src/utils.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize, Debug, Deref)]
 #[serde(transparent)]
-pub(crate) struct RelativePathBuf {
+pub struct RelativePathBuf {
     #[serde(serialize_with = "FigmentRelativePathBuf::serialize_relative")]
     inner: FigmentRelativePathBuf,
 }


### PR DESCRIPTION
- [X] decouples starting applications from logging initializing
  - currently we use a `static Once` to make sure logging is not initialized twice
  - but if we include two different versions of the application into one integration test we now have two Once cells but still only one logging facility, so it will fail :  
    -  we always want to init the logging with the newest dispatcher setup, never with the one from the older version we pull in for migration tests 
  - using `try_init()` for logging also has some issues, e.g. when writing logs to files you might truncate multiple times instead of once (as this is done before the `try_init()`)
  - additionally it is now a bit more clean in the sense that before you had the illusion you could configure logging for each application in a test, but it was once for all applications across all tests, so configuring any `[logging]` parameter in a test could lead to unstable arbitrary feeling results
  - a even better solution would be to use scoped logging dispatchers instead of global ones, that would not only allow us to have the logs setup per test and properly not printed if the test doesn't fail but also to change logging config per test. But it's outside of the scope of this PR.

- [x] include the ES schema in the `web-api` lib so that we can use it in migration tests
  - the build release binaries should strip it out through dead code analysis

**References:**

- issue [ET-4413]
- story [ET-4411]
- followed by #919 then #907 then #942

[ET-4413]: https://xainag.atlassian.net/browse/ET-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ