### PR TITLE
[Merged by Bors] - ET-4444 improve rank combination

### DIFF
--- a/coi/src/context.rs
+++ b/coi/src/context.rs
@@ -25,6 +25,7 @@ use crate::{
     stats::{compute_coi_decay_factor, compute_coi_relevances},
 };
 
+/// The score ranges in the interval `[-1.0, 3.0]` if a positive coi exists.
 fn compute_score_for_closest_positive_coi(
     embedding: &NormalizedEmbedding,
     cois: &[PositiveCoi],
@@ -38,6 +39,7 @@ fn compute_score_for_closest_positive_coi(
     })
 }
 
+/// The score ranges in the interval `[-1.0, 1.0]` if a negative coi exists.
 fn compute_score_for_closest_negative_coi(
     embedding: &NormalizedEmbedding,
     cois: &[NegativeCoi],
@@ -63,6 +65,7 @@ impl UserInterests {
             && self.negative.len() >= config.min_negative_cois()
     }
 
+    /// The score ranges in the interval `[0.0, 1.0]` if a coi exists.
     fn compute_score_for_embedding(
         &self,
         embedding: &NormalizedEmbedding,
@@ -73,20 +76,19 @@ impl UserInterests {
             compute_score_for_closest_positive_coi(embedding, &self.positive, horizon, time),
             compute_score_for_closest_negative_coi(embedding, &self.negative, horizon, time),
         ) {
-            (Some(positive), Some(negative)) => Some(positive - negative),
-            (Some(positive), None) => Some(positive),
-            (None, Some(negative)) => Some(-negative),
+            (Some(positive), Some(negative)) => Some((positive - negative + 2.0) / 6.0),
+            (Some(positive), None) => Some((positive + 1.0) / 4.0),
+            (None, Some(negative)) => Some((-negative + 1.0) / 2.0),
             (None, None) => None,
         }
     }
 
     /// Computes the scores for all documents.
     ///
-    /// If the cois are empty, then `None` is returned as no scores can be computed. Otherwise the
-    /// map contains a score for each document.
+    /// Each score ranges in the interval `[0.0, 1.0]` if a coi exists. The [coi weighting] outlines
+    /// parts of the score calculation.
     ///
-    /// <https://xainag.atlassian.net/wiki/spaces/M2D/pages/2240708609/Discovery+engine+workflow#The-weighting-of-the-CoI>
-    /// outlines parts of the score calculation.
+    /// [coi weighting]: https://xainag.atlassian.net/wiki/spaces/M2D/pages/2240708609/Discovery+engine+workflow#The-weighting-of-the-CoI
     pub(crate) fn compute_scores_for_docs<D>(
         &self,
         documents: &[D],
@@ -118,14 +120,15 @@ mod tests {
         let config = Config::default();
         let cois = UserInterests::default();
         assert!(!cois.has_enough(&config));
+        let now = Utc::now();
         let cois = UserInterests {
-            positive: create_pos_cois([[1., 2., 3.]]),
+            positive: create_pos_cois([[1., 2., 3.]], now),
             negative: Vec::new(),
         };
         assert!(cois.has_enough(&config));
         let cois = UserInterests {
             positive: Vec::new(),
-            negative: create_neg_cois([[1., 2., 3.]]),
+            negative: create_neg_cois([[1., 2., 3.]], now),
         };
         assert!(!cois.has_enough(&config));
     }
@@ -133,10 +136,10 @@ mod tests {
     #[test]
     fn test_compute_score_for_embedding() {
         let now = Utc::now();
-        let mut positive = create_pos_cois([[62., 55., 11.], [76., 30., 80.]]);
+        let mut positive = create_pos_cois([[62., 55., 11.], [76., 30., 80.]], now);
         positive[0].stats.last_view = now - Duration::hours(12);
         positive[1].stats.last_view = now - Duration::hours(36);
-        let mut negative = create_neg_cois([[6., 61., 6.]]);
+        let mut negative = create_neg_cois([[6., 61., 6.]], now);
         negative[0].last_view = now - Duration::days(1);
         let cois = UserInterests { positive, negative };
 
@@ -149,10 +152,12 @@ mod tests {
             f32,
             score,
             // positive[1]: similarity * decay + relevance
-            0.785_516_44 * 0.231_573_88 + 0.115_786_94
+            (0.785_516_44 * 0.231_573_88 + 0.115_786_94
             // negative[0]: similarity * decay
-            - 0.774_465_7 * 0.475_020_83,
-            epsilon = 1e-6,
+            - 0.774_465_7 * 0.475_020_83
+            // normalize
+            + 2.0)
+                / 6.0,
         );
     }
 

--- a/coi/src/context.rs
+++ b/coi/src/context.rs
@@ -25,7 +25,7 @@ use crate::{
     stats::{compute_coi_decay_factor, compute_coi_relevances},
 };
 
-/// The score ranges in the interval `[-1.0, 3.0]` if a positive coi exists.
+/// The score ranges in the interval `[-1., 3.]` if a positive coi exists.
 fn compute_score_for_closest_positive_coi(
     embedding: &NormalizedEmbedding,
     cois: &[PositiveCoi],
@@ -39,7 +39,7 @@ fn compute_score_for_closest_positive_coi(
     })
 }
 
-/// The score ranges in the interval `[-1.0, 1.0]` if a negative coi exists.
+/// The score ranges in the interval `[-1., 1.]` if a negative coi exists.
 fn compute_score_for_closest_negative_coi(
     embedding: &NormalizedEmbedding,
     cois: &[NegativeCoi],
@@ -65,7 +65,7 @@ impl UserInterests {
             && self.negative.len() >= config.min_negative_cois()
     }
 
-    /// The score ranges in the interval `[0.0, 1.0]` if a coi exists.
+    /// The score ranges in the interval `[0., 1.]` if a coi exists.
     fn compute_score_for_embedding(
         &self,
         embedding: &NormalizedEmbedding,
@@ -76,16 +76,16 @@ impl UserInterests {
             compute_score_for_closest_positive_coi(embedding, &self.positive, horizon, time),
             compute_score_for_closest_negative_coi(embedding, &self.negative, horizon, time),
         ) {
-            (Some(positive), Some(negative)) => Some((positive - negative + 2.0) / 6.0),
-            (Some(positive), None) => Some((positive + 1.0) / 4.0),
-            (None, Some(negative)) => Some((-negative + 1.0) / 2.0),
+            (Some(positive), Some(negative)) => Some((positive - negative + 2.) / 6.),
+            (Some(positive), None) => Some((positive + 1.) / 4.),
+            (None, Some(negative)) => Some((-negative + 1.) / 2.),
             (None, None) => None,
         }
     }
 
     /// Computes the scores for all documents.
     ///
-    /// Each score ranges in the interval `[0.0, 1.0]` if a coi exists. The [coi weighting] outlines
+    /// Each score ranges in the interval `[0., 1.]` if a coi exists. The [coi weighting] outlines
     /// parts of the score calculation.
     ///
     /// [coi weighting]: https://xainag.atlassian.net/wiki/spaces/M2D/pages/2240708609/Discovery+engine+workflow#The-weighting-of-the-CoI
@@ -156,8 +156,8 @@ mod tests {
             // negative[0]: similarity * decay
             - 0.774_465_7 * 0.475_020_83
             // normalize
-            + 2.0)
-                / 6.0,
+            + 2.)
+                / 6.,
         );
     }
 

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -97,6 +97,8 @@ impl_coi_point! {
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
+///
+/// The similarity ranges in the interval `[-1.0, 1.0]`.
 pub(super) fn find_closest_coi_index(
     cois: &[impl CoiPoint],
     embedding: &NormalizedEmbedding,
@@ -112,6 +114,8 @@ pub(super) fn find_closest_coi_index(
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
+///
+/// The similarity ranges in the interval `[-1.0, 1.0]`.
 pub(super) fn find_closest_coi<'coi, CP>(
     cois: &'coi [CP],
     embedding: &NormalizedEmbedding,
@@ -123,6 +127,8 @@ where
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
+///
+/// The similarity ranges in the interval `[-1.0, 1.0]`.
 pub(super) fn find_closest_coi_mut<'coi, CP>(
     cois: &'coi mut [CP],
     embedding: &NormalizedEmbedding,
@@ -140,33 +146,37 @@ pub(crate) mod tests {
 
     use super::*;
 
-    pub(crate) fn create_cois<const M: usize, const N: usize, CP>(points: [[f32; N]; M]) -> Vec<CP>
+    pub(crate) fn create_cois<const M: usize, const N: usize, CP>(
+        points: [[f32; N]; M],
+        time: DateTime<Utc>,
+    ) -> Vec<CP>
     where
         CP: CoiPoint,
     {
-        let now = Utc::now();
         points
             .into_iter()
             .enumerate()
-            .map(|(id, point)| CP::new(CoiId::mocked(id), point.try_into().unwrap(), now))
+            .map(|(id, point)| CP::new(CoiId::mocked(id), point.try_into().unwrap(), time))
             .collect()
     }
 
     pub(crate) fn create_pos_cois<const M: usize, const N: usize>(
         points: [[f32; N]; M],
+        time: DateTime<Utc>,
     ) -> Vec<PositiveCoi> {
-        create_cois(points)
+        create_cois(points, time)
     }
 
     pub(crate) fn create_neg_cois<const M: usize, const N: usize>(
         points: [[f32; N]; M],
+        time: DateTime<Utc>,
     ) -> Vec<NegativeCoi> {
-        create_cois(points)
+        create_cois(points, time)
     }
 
     #[test]
     fn test_shift_coi_point_towards_other() {
-        let mut cois = create_pos_cois([[1., 1., 1.]]);
+        let mut cois = create_pos_cois([[1., 1., 1.]], Utc::now());
         let towards = [2., 3., 4.].try_into().unwrap();
         let shift_factor = 0.1;
         cois[0].shift_point(&towards, shift_factor).unwrap();
@@ -179,7 +189,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_shift_coi_point_towards_self() {
-        let mut cois = create_pos_cois([[1., 1., 1.]]);
+        let mut cois = create_pos_cois([[1., 1., 1.]], Utc::now());
         let towards = cois[0].point.clone();
         let shift_factor = 0.1;
         cois[0].shift_point(&towards, shift_factor).unwrap();
@@ -188,7 +198,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_find_closest_coi_single() {
-        let cois = create_pos_cois([[1., 2., 3.]]);
+        let cois = create_pos_cois([[1., 2., 3.]], Utc::now());
         let embedding = [1., 5., 9.].try_into().unwrap();
         let (index, similarity) = find_closest_coi_index(&cois, &embedding).unwrap();
         assert_eq!(index, 0);
@@ -197,7 +207,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_find_closest_coi() {
-        let cois = create_pos_cois([[6., 1., 8.], [12., 4., 0.], [0., 4., 13.]]);
+        let cois = create_pos_cois([[6., 1., 8.], [12., 4., 0.], [0., 4., 13.]], Utc::now());
         let embedding = [1., 5., 9.].try_into().unwrap();
         let (closest, similarity) = find_closest_coi(&cois, &embedding).unwrap();
         assert_approx_eq!(f32, closest.point, cois[2].point);
@@ -206,7 +216,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_find_closest_coi_equal() {
-        let cois = create_pos_cois([[1., 2., 3.]]);
+        let cois = create_pos_cois([[1., 2., 3.]], Utc::now());
         let embedding = [1., 2., 3.].try_into().unwrap();
         let (closest, similarity) = find_closest_coi(&cois, &embedding).unwrap();
         assert_approx_eq!(f32, closest.point, cois[0].point);

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -98,7 +98,7 @@ impl_coi_point! {
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
 ///
-/// The similarity ranges in the interval `[-1.0, 1.0]`.
+/// The similarity ranges in the interval `[-1., 1.]`.
 pub(super) fn find_closest_coi_index(
     cois: &[impl CoiPoint],
     embedding: &NormalizedEmbedding,
@@ -115,7 +115,7 @@ pub(super) fn find_closest_coi_index(
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
 ///
-/// The similarity ranges in the interval `[-1.0, 1.0]`.
+/// The similarity ranges in the interval `[-1., 1.]`.
 pub(super) fn find_closest_coi<'coi, CP>(
     cois: &'coi [CP],
     embedding: &NormalizedEmbedding,
@@ -128,7 +128,7 @@ where
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
 ///
-/// The similarity ranges in the interval `[-1.0, 1.0]`.
+/// The similarity ranges in the interval `[-1., 1.]`.
 pub(super) fn find_closest_coi_mut<'coi, CP>(
     cois: &'coi mut [CP],
     embedding: &NormalizedEmbedding,

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -114,8 +114,6 @@ pub(super) fn find_closest_coi_index(
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
-///
-/// The similarity ranges in the interval `[-1., 1.]`.
 pub(super) fn find_closest_coi<'coi, CP>(
     cois: &'coi [CP],
     embedding: &NormalizedEmbedding,
@@ -127,8 +125,6 @@ where
 }
 
 /// Finds the most similar centre of interest (`CoI`) for the given embedding.
-///
-/// The similarity ranges in the interval `[-1., 1.]`.
 pub(super) fn find_closest_coi_mut<'coi, CP>(
     cois: &'coi mut [CP],
     embedding: &NormalizedEmbedding,

--- a/coi/src/stats.rs
+++ b/coi/src/stats.rs
@@ -68,56 +68,72 @@ impl NegativeCoi {
 /// Computes the relevances of the positive cois.
 ///
 /// The relevance of each coi is computed from its view count and view time relative to the
-/// other cois. It's an unnormalized score from the interval `[0, ∞)`.
+/// other cois and ranges in the interval `[0.0, 2.0]`.
 pub fn compute_coi_relevances<'a>(
     cois: impl IntoIterator<IntoIter = impl Clone + Iterator<Item = &'a PositiveCoi>>,
     horizon: Duration,
     time: DateTime<Utc>,
 ) -> Vec<f32> {
     let cois = cois.into_iter();
-    #[allow(clippy::cast_precision_loss)] // small values
-    let view_counts =
-        cois.clone().map(|coi| coi.stats.view_count).sum::<usize>() as f32 + f32::EPSILON;
+
+    let view_counts = cois.clone().map(|coi| coi.stats.view_count).sum::<usize>();
+    #[allow(clippy::cast_precision_loss)] // acceptable for large values
+    let view_counts = if view_counts == 0 {
+        // arbitrary to allow for division since each view_count is zero
+        1.0
+    } else {
+        view_counts as f32
+    };
+
     let view_times = cois
         .clone()
         .map(|coi| coi.stats.view_time)
-        .sum::<Duration>()
-        .as_secs_f32()
-        + f32::EPSILON;
+        .sum::<Duration>();
+    let view_times = if view_times == Duration::ZERO {
+        // arbitrary to allow for division since each view_time is zero
+        1.0
+    } else {
+        view_times.as_secs_f32()
+    };
 
     cois.map(|coi| {
-        #[allow(clippy::cast_precision_loss)] // small values
+        #[allow(clippy::cast_precision_loss)] // acceptable for large values
         let view_count = coi.stats.view_count as f32 / view_counts;
         let view_time = coi.stats.view_time.as_secs_f32() / view_times;
         let decay = compute_coi_decay_factor(horizon, time, coi.stats.last_view);
 
-        #[allow(clippy::manual_clamp)] // prevent NaN propagation
-        ((view_count + view_time) * decay).max(0.).min(f32::MAX)
+        (view_count + view_time) * decay
     })
     .collect()
 }
 
-/// Computes the time decay factor for a coi based on its `last_view` stat relative to the current
-/// `time`.
+/// Computes the time decay factor for a coi.
+///
+/// The decay factor is based on its `last_view` stat relative to the current `time` and ranges in
+/// the interval `[0.0, 1.0]`.
 pub fn compute_coi_decay_factor(
     horizon: Duration,
     time: DateTime<Utc>,
     last_view: DateTime<Utc>,
 ) -> f32 {
-    const DAYS_SCALE: f32 = -0.1 / (60. * 60. * 24.);
-    let horizon = (horizon.as_secs_f32() * DAYS_SCALE).exp();
-    let days = (time
-        .signed_duration_since(last_view)
-        .to_std()
-        .unwrap_or_default()
-        .as_secs_f32()
-        * DAYS_SCALE)
-        .exp();
+    if horizon == Duration::ZERO {
+        return 0.0;
+    }
 
-    ((horizon - days) / (horizon - 1. - f32::EPSILON)).max(0.)
+    let Ok(days) = time.signed_duration_since(last_view).to_std() else {
+        return 1.0;
+    };
+
+    const DAYS_SCALE: f32 = -0.1 / (60. * 60. * 24.);
+    let horizon = (DAYS_SCALE * horizon.as_secs_f32()).exp();
+    let days = (DAYS_SCALE * days.as_secs_f32()).exp();
+
+    ((horizon - days) / (horizon - 1.)).max(0.0)
 }
 
 /// Computes a weight distributions across cois based on their relevance.
+///
+/// Each weight ranges in the interval `[0.0, 1.0]`.
 pub fn compute_coi_weights<'a>(
     cois: impl IntoIterator<IntoIter = impl Clone + Iterator<Item = &'a PositiveCoi>>,
     horizon: Duration,
@@ -125,25 +141,20 @@ pub fn compute_coi_weights<'a>(
 ) -> Vec<f32> {
     let relevances = compute_coi_relevances(cois, horizon, time)
         .into_iter()
-        .map(|rel| 1.0 - (-3.0 * rel).exp())
+        .map(|relevance| 1.0 - (-3.0 * relevance).exp())
         .collect_vec();
-
     let relevance_sum = relevances.iter().sum::<f32>();
-    relevances
-        .iter()
-        .map(|relevance| {
-            let weight = relevance / relevance_sum;
-            if weight.is_finite() {
-                weight
-            } else {
-                // should be ok for our use-case
-                #[allow(clippy::cast_precision_loss)]
-                let len = relevances.len() as f32;
-                // len can't be zero, because this iterator isn't entered for empty cois
-                1. / len
-            }
-        })
-        .collect()
+
+    if relevance_sum > 0.0 {
+        relevances
+            .iter()
+            .map(|relevance| relevance / relevance_sum)
+            .collect()
+    } else {
+        #[allow(clippy::cast_precision_loss)] // should be ok for our use case
+        let len = relevances.len().max(1) as f32;
+        vec![1.0 / len; relevances.len()]
+    }
 }
 
 #[cfg(test)]
@@ -155,68 +166,63 @@ mod tests {
 
     #[test]
     fn test_compute_relevances_empty_cois() {
-        let cois = Vec::new();
-        let horizon = Duration::from_secs(SECONDS_PER_DAY);
+        let cois = [];
+        let horizon = Duration::MAX;
+        let now = Utc::now();
 
-        let relevances = compute_coi_relevances(&cois, horizon, Utc::now());
+        let relevances = compute_coi_relevances(cois, horizon, now);
         assert!(relevances.is_empty());
     }
 
     #[test]
     fn test_compute_relevances_zero_horizon() {
-        let cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.]]);
+        let now = Utc::now();
+        let cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.]], now);
         let horizon = Duration::ZERO;
 
-        let relevances = compute_coi_relevances(&cois, horizon, Utc::now());
+        let relevances = compute_coi_relevances(&cois, horizon, now);
         assert_approx_eq!(f32, relevances, [0., 0.]);
     }
 
     #[test]
     fn test_compute_relevances_count() {
-        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
+        let now = Utc::now();
+        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]], now);
         cois[1].stats.view_count += 1;
         cois[2].stats.view_count += 2;
         let horizon = Duration::from_secs(SECONDS_PER_DAY);
 
-        let relevances = compute_coi_relevances(&cois, horizon, Utc::now());
-        assert_approx_eq!(
-            f32,
-            relevances,
-            [0.166_666_46, 0.333_332_93, 0.499_999_37],
-            epsilon = 1e-6,
-        );
+        let relevances = compute_coi_relevances(&cois, horizon, now);
+        assert_approx_eq!(f32, relevances, [0.166_666_67, 0.333_333_34, 0.5]);
     }
 
     #[test]
     fn test_compute_relevances_time() {
-        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
+        let now = Utc::now();
+        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]], now);
         cois[1].stats.view_time += Duration::from_secs(10);
         cois[2].stats.view_time += Duration::from_secs(20);
         let horizon = Duration::from_secs(SECONDS_PER_DAY);
 
-        let relevances = compute_coi_relevances(&cois, horizon, Utc::now());
-        assert_approx_eq!(
-            f32,
-            relevances,
-            [0.333_332_93, 0.666_666_7, 0.999_998_75],
-            epsilon = 1e-6,
-        );
+        let relevances = compute_coi_relevances(&cois, horizon, now);
+        assert_approx_eq!(f32, relevances, [0.333_333_34, 0.666_666_7, 1.0]);
     }
 
     #[test]
     fn test_compute_relevances_last() {
-        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
+        let now = Utc::now();
+        let mut cois = create_pos_cois([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]], now);
         cois[0].stats.last_view -= chrono::Duration::hours(12);
         cois[1].stats.last_view -= chrono::Duration::hours(36);
         cois[2].stats.last_view -= chrono::Duration::hours(60);
         let horizon = Duration::from_secs(2 * SECONDS_PER_DAY);
 
-        let relevances = compute_coi_relevances(&cois, horizon, Utc::now());
+        let relevances = compute_coi_relevances(&cois, horizon, now);
         assert_approx_eq!(
             f32,
             relevances,
-            [0.243_649_72, 0.077_191_26, 0.],
-            epsilon = 1e-6,
+            [0.243_649_84, 0.077_191_29, 0.0],
+            epsilon = 1e-7,
         );
     }
 
@@ -230,10 +236,13 @@ mod tests {
 
         let last = now - chrono::Duration::days(5);
         let factor = compute_coi_decay_factor(horizon, now, last);
-        assert_approx_eq!(f32, factor, 0.585_914_55, epsilon = 1e-6);
+        assert_approx_eq!(f32, factor, 0.585_914_55);
 
         let last = now - chrono::Duration::from_std(horizon).unwrap();
         let factor = compute_coi_decay_factor(horizon, now, last);
+        assert_approx_eq!(f32, factor, 0.);
+
+        let factor = compute_coi_decay_factor(Duration::ZERO, now, now);
         assert_approx_eq!(f32, factor, 0.);
     }
 }

--- a/coi/src/stats.rs
+++ b/coi/src/stats.rs
@@ -77,7 +77,7 @@ pub fn compute_coi_relevances<'a>(
     let cois = cois.into_iter();
 
     let view_counts = cois.clone().map(|coi| coi.stats.view_count).sum::<usize>();
-    #[allow(clippy::cast_precision_loss)] // acceptable for large values
+    #[allow(clippy::cast_precision_loss)]
     let view_counts = if view_counts == 0 {
         // arbitrary to allow for division since each view_count is zero
         1.
@@ -97,7 +97,7 @@ pub fn compute_coi_relevances<'a>(
     };
 
     cois.map(|coi| {
-        #[allow(clippy::cast_precision_loss)] // acceptable for large values
+        #[allow(clippy::cast_precision_loss)]
         let view_count = coi.stats.view_count as f32 / view_counts;
         let view_time = coi.stats.view_time.as_secs_f32() / view_times;
         let decay = compute_coi_decay_factor(horizon, time, coi.stats.last_view);

--- a/coi/src/system.rs
+++ b/coi/src/system.rs
@@ -90,8 +90,6 @@ impl System {
     }
 
     /// Calculates scores for the documents wrt the user interests.
-    ///
-    /// Each score ranges in the interval `[0., 1.]` if a coi exists.
     pub fn score<D>(
         &self,
         documents: &[D],

--- a/coi/src/system.rs
+++ b/coi/src/system.rs
@@ -89,7 +89,9 @@ impl System {
         cois.push(NegativeCoi::new(CoiId::new(), embedding.clone(), time));
     }
 
-    /// Calculates scores for the documents wrt the user interests (if there are any).
+    /// Calculates scores for the documents wrt the user interests.
+    ///
+    /// Each score ranges in the interval `[0., 1.]` if a coi exists.
     pub fn score<D>(
         &self,
         documents: &[D],

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -122,7 +122,7 @@ pub fn bench_rerank<S>(
         .enumerate()
         .map(|(id, (embedding, tags))| PersonalizedDocument {
             id: id.to_string().try_into().unwrap(),
-            score: 1.0,
+            score: 1.,
             embedding,
             properties: DocumentProperties::default(),
             tags: tags
@@ -161,8 +161,8 @@ mod tests {
             .map(|i| {
                 let id = i.to_string().try_into().unwrap();
 
-                let mut embedding = vec![1.0; n];
-                embedding[i] = 10.0;
+                let mut embedding = vec![1.; n];
+                embedding[i] = 10.;
                 let embedding = Embedding1::from(embedding).normalize().unwrap();
 
                 let tags = if i % 2 == 0 {
@@ -176,7 +176,7 @@ mod tests {
 
                 PersonalizedDocument {
                     id,
-                    score: 1.0,
+                    score: 1.,
                     embedding,
                     properties: DocumentProperties::default(),
                     tags,
@@ -188,8 +188,8 @@ mod tests {
     fn mock_coi(i: usize, n: usize, time: DateTime<Utc>) -> PositiveCoi {
         let id = CoiId::new();
 
-        let mut point = vec![0.0; n];
-        point[i] = 1.0;
+        let mut point = vec![0.; n];
+        point[i] = 1.;
         let point = Embedding1::from(point).normalize().unwrap();
 
         let stats = CoiStats {
@@ -238,12 +238,12 @@ mod tests {
         let two = "2".try_into().unwrap();
         let three = "3".try_into().unwrap();
         let four = "4".try_into().unwrap();
-        assert!(0.0 <= reranked[&&zero]);
+        assert!(0. <= reranked[&&zero]);
         assert_approx_eq!(f32, reranked[&&zero], reranked[&&two]);
         assert_approx_eq!(f32, reranked[&&zero], reranked[&&three]);
         assert!(reranked[&&zero] < reranked[&&one]);
         assert!(reranked[&&one] < reranked[&&four]);
-        assert!(reranked[&&one] <= 1.0);
+        assert!(reranked[&&four] <= 1.);
     }
 
     #[test]

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -50,13 +50,13 @@ fn rerank_by_tag_weight<'a>(
     if total_tag_weight == 0 {
         return HashMap::new();
     }
-    #[allow(clippy::cast_precision_loss)] // acceptable for large values
+    #[allow(clippy::cast_precision_loss)]
     let total_tag_weight = total_tag_weight as f32;
 
     documents
         .iter()
         .map(|document| {
-            #[allow(clippy::cast_precision_loss)] // acceptable for large values
+            #[allow(clippy::cast_precision_loss)]
             let weight = document
                 .tags
                 .iter()

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, collections::HashMap, hash::BuildHasher};
+use std::{collections::HashMap, hash::BuildHasher};
 
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -24,59 +24,47 @@ use crate::{
     personalization::PersonalizationConfig,
 };
 
-fn rank_keys_by_score<K, S>(
-    keys_with_score: impl IntoIterator<Item = (K, S)>,
-    mut sort_by: impl FnMut(&S, &S) -> Ordering,
-) -> impl Iterator<Item = (K, f32)> {
-    keys_with_score
-        .into_iter()
-        .sorted_unstable_by(|(_, s1), (_, s2)| sort_by(s1, s2))
-        .enumerate()
-        .map(
-            #[allow(clippy::cast_precision_loss)] // index is small enough
-            |(index, (key, _))| (key, 1. / (1 + index) as f32),
-        )
-}
-
-fn rerank_by_interest(
+fn rerank_by_interest<'a>(
     coi_system: &CoiSystem,
-    documents: &[PersonalizedDocument],
+    documents: &'a [PersonalizedDocument],
     interests: &UserInterests,
     time: DateTime<Utc>,
-) -> HashMap<DocumentId, f32> {
-    let scores = coi_system.score(documents, interests, time);
-    rank_keys_by_score(
-        documents
-            .iter()
-            .map(|document| document.id.clone())
-            .zip(scores),
-        |s1, s2| s1.total_cmp(s2).reverse(),
-    )
-    .collect()
+) -> HashMap<&'a DocumentId, f32> {
+    coi_system
+        .score(documents, interests, time)
+        .map(|scores| {
+            documents
+                .iter()
+                .map(|document| &document.id)
+                .zip(scores)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
-fn rerank_by_tag_weight(
-    documents: &[PersonalizedDocument],
+fn rerank_by_tag_weight<'a>(
+    documents: &'a [PersonalizedDocument],
     tag_weights: &HashMap<DocumentTag, usize>,
-) -> HashMap<DocumentId, f32> {
-    let mut weights = HashMap::<_, Vec<_>>::with_capacity(documents.len());
-    for document in documents {
-        let weight = document
-            .tags
-            .iter()
-            .map(|tag| tag_weights.get(tag).copied().unwrap_or_default())
-            .sum::<usize>();
-        weights.entry(weight).or_default().push(document.id.clone());
+) -> HashMap<&'a DocumentId, f32> {
+    let total_tag_weight = tag_weights.values().sum::<usize>();
+    if total_tag_weight == 0 {
+        return HashMap::new();
     }
+    #[allow(clippy::cast_precision_loss)] // acceptable for large values
+    let total_tag_weight = total_tag_weight as f32;
 
-    rank_keys_by_score(
-        weights
-            .into_iter()
-            .map(|(weight, documents)| (documents, weight)),
-        |w1, w2| w1.cmp(w2).reverse(),
-    )
-    .flat_map(|(documents, score)| documents.into_iter().map(move |document| (document, score)))
-    .collect()
+    documents
+        .iter()
+        .map(|document| {
+            #[allow(clippy::cast_precision_loss)] // acceptable for large values
+            let weight = document
+                .tags
+                .iter()
+                .map(|tag| tag_weights.get(tag).copied().unwrap_or_default())
+                .sum::<usize>() as f32;
+            (&document.id, weight / total_tag_weight)
+        })
+        .collect()
 }
 
 /// Reranks documents based on a combination of their interest, tag weight and elasticsearch scores.
@@ -94,33 +82,28 @@ pub(super) fn rerank_by_scores(
 ) {
     let interest_scores = rerank_by_interest(coi_system, documents, interests, time);
     let tag_weight_scores = rerank_by_tag_weight(documents, tag_weights);
-    let mut elasticsearch_scores = HashMap::with_capacity(documents.len());
 
-    for document in documents.iter_mut() {
-        elasticsearch_scores.insert(document.id.clone(), document.score);
-        document.score = score_weights[0] * interest_scores[&document.id]
-            + score_weights[1] * tag_weight_scores[&document.id]
-            + score_weights[2] * document.score;
+    let scores = documents
+        .iter()
+        .map(|document| {
+            let interest_score = interest_scores
+                .get(&document.id)
+                .copied()
+                .unwrap_or_default();
+            let tag_weight_score = tag_weight_scores
+                .get(&document.id)
+                .copied()
+                .unwrap_or_default();
+            score_weights[0] * interest_score
+                + score_weights[1] * tag_weight_score
+                + score_weights[2] * document.score
+        })
+        .collect_vec();
+    for (document, score) in documents.iter_mut().zip(scores) {
+        document.score = score;
     }
 
-    let max_score_weight = score_weights.into_iter().max_by(f32::total_cmp);
-    let secondary_sorting_factor = match score_weights
-        .into_iter()
-        .position(|score_weight| Some(score_weight) >= max_score_weight)
-    {
-        Some(0) => interest_scores,
-        Some(1) => tag_weight_scores,
-        Some(2) => elasticsearch_scores,
-        _ => unreachable!(),
-    };
-
-    documents.sort_unstable_by(|d1, d2| {
-        d1.score.total_cmp(&d2.score).reverse().then_with(|| {
-            secondary_sorting_factor[&d1.id]
-                .total_cmp(&secondary_sorting_factor[&d2.id])
-                .reverse()
-        })
-    });
+    documents.sort_unstable_by(|d1, d2| d1.score.total_cmp(&d2.score).reverse());
 }
 
 #[doc(hidden)]
@@ -165,7 +148,7 @@ pub fn bench_rerank<S>(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, time::Duration};
+    use std::time::Duration;
 
     use xayn_ai_bert::Embedding1;
     use xayn_ai_coi::{CoiConfig, CoiId, CoiStats, PositiveCoi};
@@ -218,48 +201,6 @@ mod tests {
         PositiveCoi { id, point, stats }
     }
 
-    fn ids_by_score(scores: &HashMap<DocumentId, f32>) -> Vec<&str> {
-        scores
-            .iter()
-            .sorted_by(|(_, s1), (_, s2)| s1.total_cmp(s2).reverse())
-            .map(|(document, _)| document.as_ref().as_str())
-            .collect()
-    }
-
-    #[test]
-    fn test_rank_keys_by_score_empty() {
-        assert!(rank_keys_by_score::<(), ()>([], |_, _| unreachable!())
-            .next()
-            .is_none());
-    }
-
-    #[test]
-    fn test_rank_keys_by_similar_scores() {
-        let scores = [("0", 0), ("1", 0), ("2", 0), ("3", 1), ("4", 2), ("5", 2)];
-        let keys = rank_keys_by_score(scores, |s1, s2| s1.cmp(s2).reverse())
-            .map(|(key, _)| key)
-            .collect_vec();
-        assert_eq!(keys.len(), 6);
-        assert_eq!(
-            keys[0..=1].iter().copied().collect::<HashSet<_>>(),
-            ["4", "5"].into(),
-        );
-        assert_eq!(keys[2], "3");
-        assert_eq!(
-            keys[3..=5].iter().copied().collect::<HashSet<_>>(),
-            ["0", "1", "2"].into(),
-        );
-    }
-
-    #[test]
-    fn test_rank_key_by_different_scores() {
-        let scores = [("0", 0), ("1", 2), ("2", 1), ("3", 4), ("4", 3), ("5", 5)];
-        let keys = rank_keys_by_score(scores, |s1, s2| s1.cmp(s2).reverse())
-            .map(|(key, _)| key)
-            .collect_vec();
-        assert_eq!(keys, ["5", "3", "4", "1", "2", "0"]);
-    }
-
     #[test]
     fn test_rerank_by_interest_empty() {
         let coi_system = CoiConfig::default().build();
@@ -277,8 +218,7 @@ mod tests {
         let interests = UserInterests::default();
         let time = Utc::now();
 
-        let reranked = rerank_by_interest(&coi_system, &documents, &interests, time);
-        assert_eq!(ids_by_score(&reranked), ["0", "1", "2", "3", "4"]);
+        assert!(rerank_by_interest(&coi_system, &documents, &interests, time).is_empty());
     }
 
     #[test]
@@ -293,13 +233,28 @@ mod tests {
         };
 
         let reranked = rerank_by_interest(&coi_system, &documents, &interests, time);
-        assert_eq!(ids_by_score(&reranked), ["4", "1", "0", "2", "3"]);
+        let zero = "0".try_into().unwrap();
+        let one = "1".try_into().unwrap();
+        let two = "2".try_into().unwrap();
+        let three = "3".try_into().unwrap();
+        let four = "4".try_into().unwrap();
+        assert!(0.0 <= reranked[&&zero]);
+        assert_approx_eq!(f32, reranked[&&zero], reranked[&&two]);
+        assert_approx_eq!(f32, reranked[&&zero], reranked[&&three]);
+        assert!(reranked[&&zero] < reranked[&&one]);
+        assert!(reranked[&&one] < reranked[&&four]);
+        assert!(reranked[&&one] <= 1.0);
     }
 
     #[test]
     fn test_rerank_by_tag_weight_empty() {
         let documents = Vec::default();
-        let tag_weights = HashMap::default();
+        let tag_weights = [
+            ("general".try_into().unwrap(), 4),
+            ("specific".try_into().unwrap(), 1),
+            ("other".try_into().unwrap(), 3),
+        ]
+        .into();
 
         assert!(rerank_by_tag_weight(&documents, &tag_weights).is_empty());
     }
@@ -310,14 +265,7 @@ mod tests {
         let documents = mock_documents(n);
         let tag_weights = HashMap::default();
 
-        let reranked = rerank_by_tag_weight(&documents, &tag_weights);
-        for i in 1..n {
-            assert_approx_eq!(
-                f32,
-                reranked[&"0".try_into().unwrap()],
-                reranked[&i.to_string().try_into().unwrap()],
-            );
-        }
+        assert!(rerank_by_tag_weight(&documents, &tag_weights).is_empty());
     }
 
     #[test]
@@ -332,20 +280,16 @@ mod tests {
         .into();
 
         let reranked = rerank_by_tag_weight(&documents, &tag_weights);
-        assert!(reranked[&"0".try_into().unwrap()] < reranked[&"1".try_into().unwrap()]);
+        let zero = "0".try_into().unwrap();
+        let one = "1".try_into().unwrap();
+        assert!(reranked[&&zero] < reranked[&&one]);
         for i in (2..n).step_by(2) {
-            assert_approx_eq!(
-                f32,
-                reranked[&"0".try_into().unwrap()],
-                reranked[&i.to_string().try_into().unwrap()],
-            );
+            let id = i.to_string().try_into().unwrap();
+            assert_approx_eq!(f32, reranked[&&zero], reranked[&&id]);
         }
         for i in (3..n).step_by(2) {
-            assert_approx_eq!(
-                f32,
-                reranked[&"1".try_into().unwrap()],
-                reranked[&i.to_string().try_into().unwrap()],
-            );
+            let id = i.to_string().try_into().unwrap();
+            assert_approx_eq!(f32, reranked[&&one], reranked[&&id]);
         }
     }
 }

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -164,9 +164,9 @@ macro_rules! assert_order {
         );
         for documents in $documents.windows(2) {
             let [d1, d2] = documents else { unreachable!() };
-            assert!(1.0 >= d1.score, $($arg)*);
+            assert!(1. >= d1.score, $($arg)*);
             assert!(d1.score > d2.score, $($arg)*);
-            assert!(d2.score >= 0.0, $($arg)*);
+            assert!(d2.score >= 0., $($arg)*);
         }
     };
 }

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -250,7 +250,7 @@ async fn test_personalization_with_tags() {
             let documents = personalize(&client, &personalization_url, None, None).await?;
             assert_order!(
                 &documents,
-                ["d5", "d8", "d6", "d4", "d1"],
+                ["d5", "d6", "d4", "d1", "d8"],
                 "unexpected personalized documents: {documents:?}",
             );
             Ok(())

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -90,9 +90,9 @@ macro_rules! assert_order {
         );
         for documents in $documents.windows(2) {
             let [d1, d2] = documents else { unreachable!() };
-            assert!(1.0 >= d1.score, $($arg)*);
+            assert!(1. >= d1.score, $($arg)*);
             assert!(d1.score > d2.score, $($arg)*);
-            assert!(d2.score >= 0.0, $($arg)*);
+            assert!(d2.score >= 0., $($arg)*);
         }
     };
 }
@@ -103,7 +103,7 @@ async fn test_full_personalization() {
         UNCHANGED_CONFIG,
         Some(toml! {
             [semantic_search]
-            score_weights = [0.5, 0.5, 0.0]
+            score_weights = [0.5, 0.5, 0.]
         }),
         |client, ingestion_url, personalization_url, _services| async move {
             ingest(&client, &ingestion_url).await?;
@@ -215,7 +215,7 @@ async fn test_full_personalization_with_inline_history() {
         UNCHANGED_CONFIG,
         Some(toml! {
             [semantic_search]
-            score_weights = [0.5, 0.5, 0.0]
+            score_weights = [0.5, 0.5, 0.]
         }),
         |client, ingestion_url, personalization_url, _services| async move {
             ingest(&client, &ingestion_url).await?;

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -199,7 +199,7 @@ async fn test_subtle_personalization() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d5", "d8", "d7"],
+                ["d6", "d4", "d5", "d7", "d8"],
                 "unexpected subtle personalized documents: {documents:?}",
             );
 


### PR DESCRIPTION
**Reference**

- [ET-4444]

**Summary**

coi crate:
- double check and note the ranges of the various scores, normalize the final interest score
- remove epsilon shifts and use proper division checks, update stricter tests
- only return scores if there are some (none only happens if there are no cois at all), it's up to the consumer to handle default scores

api crate:
- use interest scores from coi crate directly instead of index-based score, this transfers the similarity & relevance information of the interest score into the final score
- normalize the tag weight scores by the total tag weights and use it directly instead of the index-based score, this transfers the relative tag weight information into the final score
- default to zero instead of index-based score i one of the sub-scores doesn't exist
- remove secondary sorting factor, docs with same score now keep them
- update tests, the changed integration test results looks like an improvement wrt the reranked docs (subjective of course)


[ET-4444]: https://xainag.atlassian.net/browse/ET-4444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ