### PR TITLE
[Merged by Bors] - ET-4478 replace custom with stabilized total float cmp

### DIFF
--- a/coi/src/config.rs
+++ b/coi/src/config.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 use crate::{
     system::System,
-    utils::{serde_duration_as_days, SECONDS_PER_DAY_U64},
+    utils::{serde_duration_as_days, SECONDS_PER_DAY},
 };
 
 /// Configurations of the coi system.
@@ -46,7 +46,7 @@ impl Default for Config {
             threshold: 0.67,
             min_positive_cois: 1,
             min_negative_cois: 0,
-            horizon: Duration::from_secs(SECONDS_PER_DAY_U64 * 30),
+            horizon: Duration::from_secs(30 * SECONDS_PER_DAY),
         }
     }
 }

--- a/coi/src/lib.rs
+++ b/coi/src/lib.rs
@@ -48,5 +48,4 @@ pub use crate::{
     point::{CoiPoint, NegativeCoi, PositiveCoi},
     stats::{compute_coi_decay_factor, compute_coi_relevances, compute_coi_weights, CoiStats},
     system::System as CoiSystem,
-    utils::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc},
 };

--- a/coi/src/point.rs
+++ b/coi/src/point.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use xayn_ai_bert::{InvalidEmbedding, NormalizedEmbedding};
 
-use crate::{id::CoiId, stats::CoiStats, utils::nan_safe_f32_cmp_desc};
+use crate::{id::CoiId, stats::CoiStats};
 
 /// A positive `CoI`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -106,7 +106,7 @@ pub(super) fn find_closest_coi_index(
         .map(|coi| embedding.dot_product(coi.point()))
         .enumerate()
         .collect_vec();
-    similarities.sort_by(|(_, a), (_, b)| nan_safe_f32_cmp_desc(a, b));
+    similarities.sort_by(|(_, s1), (_, s2)| s1.total_cmp(s2).reverse());
 
     similarities.first().copied()
 }

--- a/coi/src/utils.rs
+++ b/coi/src/utils.rs
@@ -12,55 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::cmp::Ordering;
-
-/// Pretend that f32 has a total ordering.
-///
-/// `NaN` is treated as the lowest possible value if `nan_min`, similar to what [`f32::max`] does.
-/// Otherwise it is treated as the highest possible value, similar to what [`f32::min`] does.
-#[inline]
-#[allow(clippy::trivially_copy_pass_by_ref)] // required by calling functions
-fn nan_safe_f32_cmp_base(a: &f32, b: &f32, nan_min: bool) -> Ordering {
-    a.partial_cmp(b).unwrap_or_else(|| {
-        // if `partial_cmp` returns None we have at least one `NaN`,
-        let cmp = match (a.is_nan(), b.is_nan()) {
-            (true, true) => Ordering::Equal,
-            (true, _) => Ordering::Less,
-            (_, true) => Ordering::Greater,
-            _ => unreachable!("partial_cmp returned None but both numbers are not NaN"),
-        };
-        if nan_min {
-            cmp
-        } else {
-            cmp.reverse()
-        }
-    })
-}
-
-/// Allows comparing and sorting f32 even if `NaN` is involved.
-///
-/// Pretend that f32 has a total ordering.
-///
-/// `NaN` is treated as the lowest possible value, similar to what [`f32::max`] does.
-///
-/// If this is used for sorting this will lead to an ascending order, like
-/// for example `[NaN, 0.5, 1.5, 2.0]`.
-///
-/// By switching the input parameters around this can be used to create a
-/// descending sorted order, like e.g.: `[2.0, 1.5, 0.5, NaN]`.
-#[inline]
-#[allow(clippy::trivially_copy_pass_by_ref)] // required by calling functions
-pub fn nan_safe_f32_cmp(a: &f32, b: &f32) -> Ordering {
-    nan_safe_f32_cmp_base(a, b, true)
-}
-
-/// `nan_safe_f32_cmp_desc(a,b)` is syntax sugar for `nan_safe_f32_cmp(b, a)`
-#[inline]
-#[allow(clippy::trivially_copy_pass_by_ref)] // required by calling functions
-pub fn nan_safe_f32_cmp_desc(a: &f32, b: &f32) -> Ordering {
-    nan_safe_f32_cmp(b, a)
-}
-
 /// The number of seconds per day (without leap seconds).
 pub(crate) const SECONDS_PER_DAY_F32: f32 = 86400.;
 
@@ -95,46 +46,8 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
     use serde_json::{from_str, to_string};
-    use xayn_test_utils::assert_approx_eq;
 
     use super::*;
-
-    #[test]
-    fn test_nan_safe_f32_cmp_sorts_in_the_right_order() {
-        let data = &mut [f32::NAN, 1., 5., f32::NAN, 4.];
-        data.sort_by(nan_safe_f32_cmp);
-
-        assert_approx_eq!(f32, &data[2..], [1., 4., 5.], ulps = 0);
-        assert!(data[0].is_nan());
-        assert!(data[1].is_nan());
-
-        data.sort_by(nan_safe_f32_cmp_desc);
-
-        assert_approx_eq!(f32, &data[..3], [5., 4., 1.], ulps = 0);
-        assert!(data[3].is_nan());
-        assert!(data[4].is_nan());
-
-        let data = &mut [1., 5., 3., 4.];
-
-        data.sort_by(nan_safe_f32_cmp);
-        assert_approx_eq!(f32, &data[..], [1., 3., 4., 5.], ulps = 0);
-
-        data.sort_by(nan_safe_f32_cmp_desc);
-        assert_approx_eq!(f32, &data[..], [5., 4., 3., 1.], ulps = 0);
-    }
-
-    #[test]
-    fn test_nan_safe_f32_cmp_nans_compare_as_expected() {
-        assert_eq!(nan_safe_f32_cmp(&f32::NAN, &f32::NAN), Ordering::Equal);
-        assert_eq!(nan_safe_f32_cmp(&-12., &f32::NAN), Ordering::Greater);
-        assert_eq!(nan_safe_f32_cmp_desc(&-12., &f32::NAN), Ordering::Less);
-        assert_eq!(nan_safe_f32_cmp(&f32::NAN, &-12.), Ordering::Less);
-        assert_eq!(nan_safe_f32_cmp_desc(&f32::NAN, &-12.), Ordering::Greater);
-        assert_eq!(nan_safe_f32_cmp(&12., &f32::NAN), Ordering::Greater);
-        assert_eq!(nan_safe_f32_cmp_desc(&12., &f32::NAN), Ordering::Less);
-        assert_eq!(nan_safe_f32_cmp(&f32::NAN, &12.), Ordering::Less);
-        assert_eq!(nan_safe_f32_cmp_desc(&f32::NAN, &12.), Ordering::Greater);
-    }
 
     #[derive(Deserialize, Serialize)]
     struct Days(#[serde(with = "serde_duration_as_days")] Duration);

--- a/coi/src/utils.rs
+++ b/coi/src/utils.rs
@@ -13,30 +13,28 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// The number of seconds per day (without leap seconds).
-pub(crate) const SECONDS_PER_DAY_F32: f32 = 86400.;
+pub(crate) const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
 
-/// The number of seconds per day (without leap seconds).
-pub(crate) const SECONDS_PER_DAY_U64: u64 = 86400;
-
+/// Serde of a duration as full days (rounds down).
 pub(crate) mod serde_duration_as_days {
     use std::time::Duration;
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use crate::utils::SECONDS_PER_DAY_U64;
+    use crate::utils::SECONDS_PER_DAY;
 
     pub(crate) fn serialize<S>(horizon: &Duration, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        (horizon.as_secs() / SECONDS_PER_DAY_U64).serialize(serializer)
+        (horizon.as_secs() / SECONDS_PER_DAY).serialize(serializer)
     }
 
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
     where
         D: Deserializer<'de>,
     {
-        u64::deserialize(deserializer).map(|days| Duration::from_secs(SECONDS_PER_DAY_U64 * days))
+        u64::deserialize(deserializer).map(|days| Duration::from_secs(SECONDS_PER_DAY * days))
     }
 }
 
@@ -54,7 +52,7 @@ mod tests {
 
     #[test]
     fn test_less() -> Result<(), Box<dyn Error>> {
-        let duration = Duration::from_secs(SECONDS_PER_DAY_U64 - 1);
+        let duration = Duration::from_secs(SECONDS_PER_DAY - 1);
         let serialized = to_string(&Days(duration))?;
         assert_eq!(serialized, "0");
         let deserialized = from_str::<Days>(&serialized)?.0;
@@ -64,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_equal() -> Result<(), Box<dyn Error>> {
-        let duration = Duration::from_secs(SECONDS_PER_DAY_U64);
+        let duration = Duration::from_secs(SECONDS_PER_DAY);
         let serialized = to_string(&Days(duration))?;
         assert_eq!(serialized, "1");
         let deserialized = from_str::<Days>(&serialized)?.0;
@@ -74,11 +72,11 @@ mod tests {
 
     #[test]
     fn test_greater() -> Result<(), Box<dyn Error>> {
-        let duration = Duration::from_secs(SECONDS_PER_DAY_U64 + 1);
+        let duration = Duration::from_secs(SECONDS_PER_DAY + 1);
         let serialized = to_string(&Days(duration))?;
         assert_eq!(serialized, "1");
         let deserialized = from_str::<Days>(&serialized)?.0;
-        assert_eq!(deserialized, Duration::from_secs(SECONDS_PER_DAY_U64));
+        assert_eq!(deserialized, Duration::from_secs(SECONDS_PER_DAY));
         Ok(())
     }
 }

--- a/web-api/src/mind/data.rs
+++ b/web-api/src/mind/data.rs
@@ -21,7 +21,6 @@ use ndarray::{Array, Array1, Dimension, Ix2, ShapeBuilder, SliceArg};
 use npyz::WriterBuilder;
 use rand::{rngs::StdRng, seq::IteratorRandom, SeedableRng};
 use serde::{de, Deserialize, Deserializer};
-use xayn_ai_coi::nan_safe_f32_cmp_desc;
 use xayn_test_utils::error::Panic;
 
 use crate::models::{DocumentId, DocumentTag, UserId};
@@ -222,7 +221,7 @@ where
 
     fn compute(relevance: &[f32], k: &[usize]) -> Array1<f32> {
         let mut optimal_order = relevance.to_vec();
-        optimal_order.sort_by(nan_safe_f32_cmp_desc);
+        optimal_order.sort_by(|r1, r2| r1.total_cmp(r2).reverse());
         let last = k
             .iter()
             .max()

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use futures_util::{stream::FuturesUnordered, Stream, StreamExt};
 use itertools::Itertools;
 use tracing::error;
-use xayn_ai_coi::{compute_coi_weights, nan_safe_f32_cmp, PositiveCoi};
+use xayn_ai_coi::{compute_coi_weights, PositiveCoi};
 
 use crate::{
     error::common::InternalError,
@@ -55,7 +55,7 @@ where
         let coi_weights = compute_coi_weights(interests.clone(), self.horizon, self.time);
         let cois = interests
             .zip(coi_weights)
-            .sorted_by(|(_, a_weight), (_, b_weight)| nan_safe_f32_cmp(b_weight, a_weight))
+            .sorted_by(|(_, w1), (_, w2)| w1.total_cmp(w2).reverse())
             .take(self.max_cois)
             .collect_vec();
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -21,7 +21,6 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use xayn_ai_bert::NormalizedEmbedding;
-use xayn_ai_coi::{nan_safe_f32_cmp, nan_safe_f32_cmp_desc};
 
 use self::client::BulkInstruction;
 use crate::{
@@ -126,8 +125,8 @@ impl Client {
             let bm25_scores = self.search_request(body).await?;
             let max_bm25_score = bm25_scores
                 .values()
+                .max_by(|s1, s2| s1.total_cmp(s2))
                 .copied()
-                .max_by(nan_safe_f32_cmp)
                 .unwrap_or_default()
                 .max(1.0);
 
@@ -142,7 +141,7 @@ impl Client {
 
             knn_scores = knn_scores
                 .into_iter()
-                .sorted_unstable_by(|(_, s1), (_, s2)| nan_safe_f32_cmp_desc(s1, s2))
+                .sorted_unstable_by(|(_, s1), (_, s2)| s1.total_cmp(s2).reverse())
                 .take(params.count)
                 .collect();
         }

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -38,14 +38,7 @@ use sqlx::{
 };
 use tracing::info;
 use xayn_ai_bert::NormalizedEmbedding;
-use xayn_ai_coi::{
-    nan_safe_f32_cmp_desc,
-    CoiId,
-    CoiStats,
-    NegativeCoi,
-    PositiveCoi,
-    UserInterests,
-};
+use xayn_ai_coi::{CoiId, CoiStats, NegativeCoi, PositiveCoi, UserInterests};
 
 use super::{InteractionUpdateContext, TagWeights};
 use crate::{
@@ -283,8 +276,11 @@ impl Database {
                     .await?,
             );
         }
-        documents.sort_unstable_by(|a, b| {
-            nan_safe_f32_cmp_desc(&scores(&a.id).unwrap(), &scores(&b.id).unwrap())
+        documents.sort_unstable_by(|d1, d2| {
+            scores(&d1.id)
+                .unwrap()
+                .total_cmp(&scores(&d2.id).unwrap())
+                .reverse()
         });
 
         Ok(documents)


### PR DESCRIPTION
**Reference**

- [ET-4478]
- https://github.com/xaynetwork/xayn_discovery_engine/pull/937#discussion_r1189954142

**Summary**

- replace our custom `nan_safe_f32_cmp()` with the stabilized `f32::total_cmp()`
- cleanup remaining `coi::utils`


[ET-4478]: https://xainag.atlassian.net/browse/ET-4478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ