### PR TITLE
[Merged by Bors] - ET-4439 disable hybrid search

### DIFF
--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -193,7 +193,10 @@ async fn test_reingestion_candidates() {
                 &client,
                 client
                     .post(personalization_url.join("/semantic_search")?)
-                    .json(&json!({ "document": { "query": "snippet" } }))
+                    .json(&json!({
+                        "document": { "query": "snippet" },
+                        "enable_hybrid_search": true
+                    }))
                     .build()?,
                 StatusCode::OK,
             )
@@ -226,7 +229,10 @@ async fn test_reingestion_candidates() {
                 &client,
                 client
                     .post(personalization_url.join("/semantic_search")?)
-                    .json(&json!({ "document": { "query": "snippet" } }))
+                    .json(&json!({
+                        "document": { "query": "snippet" },
+                        "enable_hybrid_search": true
+                    }))
                     .build()?,
                 StatusCode::OK,
             )

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -122,7 +122,7 @@ async fn personalize(
         request = request.query(&[("published_after", published_after)]);
     }
     if let Some(query) = query {
-        request = request.query(&[("query", query)]);
+        request = request.query(&[("query", query), ("enable_hybrid_search", "true")]);
     }
     let request = request.build()?;
 

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -207,6 +207,7 @@ async fn test_semantic_search_with_query() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "this is one sentence" },
+                        "enable_hybrid_search": true
                     }))
                     .build()?,
                 StatusCode::OK,


### PR DESCRIPTION
**Reference**

- [ET-4439]

**Summary**

- disable hybrid search by default, it can optionally be enabled via the `enable_hybrid_search` flag at the respective endpoints
- enable hybrid search for those integration tests which were set up for that


[ET-4439]: https://xainag.atlassian.net/browse/ET-4439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ