### PR TITLE
[Merged by Bors] - ET-4295 expose silo management api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,6 +4412,7 @@ dependencies = [
  "itertools 0.10.5",
  "once_cell",
  "reqwest",
+ "serde",
  "serde_json",
  "sqlx",
  "tokio",

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -43,7 +43,7 @@ use tracing::{error_span, instrument, Instrument};
 use tracing_subscriber::filter::LevelFilter;
 use xayn_test_utils::{env::clear_env, error::Panic};
 use xayn_web_api::{config, logging, start, AppHandle, Application};
-use xayn_web_api_db_ctrl::{LegacyTenantInfo, Silo};
+use xayn_web_api_db_ctrl::{Silo, Tenant};
 use xayn_web_api_shared::{
     elastic,
     postgres::{self, QuotedIdentifier},
@@ -331,18 +331,20 @@ pub fn generate_test_id() -> String {
 
 #[derive(Clone, Debug)]
 pub struct Services {
-    /// Id of the test.
+    /// Id of the test
     pub test_id: String,
     /// Silo management API
     pub silo: Silo,
-    /// Id of the auto generated tenant
-    pub tenant_id: TenantId,
+    /// Tenant created for the test
+    pub tenant: Tenant,
 }
 
 impl Services {
-    #[instrument(skip(self), fields(%test_id=self.tenant_id), err)]
+    #[instrument(skip(self), fields(%test_id=self.tenant.tenant_id), err)]
     pub async fn cleanup_test(self) -> Result<(), Error> {
-        self.silo.delete_tenant(&self.tenant_id).await?;
+        self.silo
+            .delete_tenant(self.tenant.tenant_id.clone())
+            .await?;
         delete_db(self.silo.postgres_config(), MANAGEMENT_DB).await?;
         Ok(())
     }
@@ -362,23 +364,23 @@ async fn setup_web_dev_services(enable_legacy_tenant: bool) -> Result<Services, 
 
     create_db(&pg_config, MANAGEMENT_DB).await?;
 
-    let default_es_index = es_config.index_name.clone();
     let silo = Silo::new(
-        pg_config,
-        es_config,
-        enable_legacy_tenant.then_some(LegacyTenantInfo {
-            es_index: default_es_index,
-        }),
+        pg_config, es_config,
+        // we create the legacy tenant using the silo API,
+        // there are separate tests for the testing the migration
+        None,
     )
     .await?;
     silo.admin_as_mt_user_hack().await?;
     silo.initialize().await?;
-    silo.create_tenant(&tenant_id).await?;
+    let tenant = silo
+        .create_tenant(tenant_id.clone(), enable_legacy_tenant)
+        .await?;
 
     Ok(Services {
         test_id,
         silo,
-        tenant_id,
+        tenant,
     })
 }
 

--- a/web-api-db-ctrl/Cargo.toml
+++ b/web-api-db-ctrl/Cargo.toml
@@ -12,6 +12,7 @@ futures-util = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json =  { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -149,7 +149,7 @@ impl Silo {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub enum Operation {
     ListTenants,
     CreateTenant {

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -84,9 +84,8 @@ impl Silo {
         tenant_id: TenantId,
         is_legacy: bool,
     ) -> Result<Tenant, Error> {
-        //TODO allow creating legacy tenants post non legacy init
         let mut tx = self.postgres.begin().await?;
-        postgres::create_tenant(&mut tx, &tenant_id).await?;
+        postgres::create_tenant(&mut tx, &tenant_id, is_legacy).await?;
         elastic::create_tenant(&self.elastic, &tenant_id).await?;
         tx.commit().await?;
         Ok(Tenant {
@@ -155,6 +154,7 @@ pub enum Operation {
     ListTenants,
     CreateTenant {
         tenant_id: TenantId,
+        #[serde(default)]
         is_legacy: bool,
     },
     DeleteTenant {

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -163,6 +163,7 @@ pub enum Operation {
 }
 
 #[derive(Serialize)]
+#[serde(untagged)]
 pub enum OperationSucceeded {
     ListTenants { tenants: Vec<Tenant> },
     CreateTenant { tenant: Tenant },

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -16,6 +16,7 @@ mod elastic;
 mod postgres;
 
 pub use elastic::create_tenant as elastic_create_tenant;
+use serde::{Deserialize, Serialize};
 use sqlx::pool::PoolOptions;
 use xayn_web_api_shared::{
     elastic::{Client as EsClient, Config as EsConfig},
@@ -74,24 +75,70 @@ impl Silo {
         postgres::admin_as_mt_user_hack(&self.postgres).await
     }
 
-    pub async fn list_tenants(&self) -> Result<Vec<TenantId>, Error> {
+    pub async fn list_tenants(&self) -> Result<Vec<Tenant>, Error> {
         postgres::list_tenants(&self.postgres).await
     }
 
-    pub async fn create_tenant(&self, new_id: &TenantId) -> Result<(), Error> {
+    pub async fn create_tenant(
+        &self,
+        tenant_id: TenantId,
+        is_legacy: bool,
+    ) -> Result<Tenant, Error> {
+        //TODO allow creating legacy tenants post non legacy init
         let mut tx = self.postgres.begin().await?;
-        postgres::create_tenant(&mut tx, new_id).await?;
-        elastic::create_tenant(&self.elastic, new_id).await?;
+        postgres::create_tenant(&mut tx, &tenant_id).await?;
+        elastic::create_tenant(&self.elastic, &tenant_id).await?;
         tx.commit().await?;
-        Ok(())
+        Ok(Tenant {
+            tenant_id,
+            is_legacy,
+        })
     }
 
-    pub async fn delete_tenant(&self, tenant_id: &TenantId) -> Result<(), Error> {
+    pub async fn delete_tenant(&self, tenant_id: TenantId) -> Result<Option<Tenant>, Error> {
         let mut tx = self.postgres.begin().await?;
-        postgres::delete_tenant(&mut tx, tenant_id).await?;
-        elastic::delete_tenant(&self.elastic, tenant_id).await?;
+        let deleted_tenant = postgres::delete_tenant(&mut tx, tenant_id).await?;
+        if let Some(tenant) = &deleted_tenant {
+            elastic::delete_tenant(&self.elastic, &tenant.tenant_id).await?;
+        }
         tx.commit().await?;
-        Ok(())
+        Ok(deleted_tenant)
+    }
+
+    pub async fn run_operations(
+        &self,
+        initialize: bool,
+        ops: impl IntoIterator<Item = Operation>,
+    ) -> Result<Vec<OperationResult>, Error> {
+        if initialize {
+            self.initialize().await?;
+        }
+
+        let mut results = Vec::new();
+        for op in ops {
+            results.push(self.run_operation(op).await);
+        }
+        Ok(results)
+    }
+
+    async fn run_operation(&self, op: Operation) -> OperationResult {
+        Ok(match op {
+            Operation::ListTenants => {
+                let tenants = self.list_tenants().await?;
+                OperationSucceeded::ListTenants { tenants }
+            }
+            Operation::CreateTenant {
+                tenant_id,
+                is_legacy,
+            } => {
+                let tenant = self.create_tenant(tenant_id, is_legacy).await?;
+                OperationSucceeded::CreateTenant { tenant }
+            }
+            Operation::DeleteTenant { tenant_id } => {
+                let tenant = self.delete_tenant(tenant_id).await?;
+                OperationSucceeded::DeleteTenant { tenant }
+            }
+        })
     }
 
     pub fn postgres_config(&self) -> &PgConfig {
@@ -101,4 +148,31 @@ impl Silo {
     pub fn elastic_config(&self) -> &EsConfig {
         &self.elastic_config
     }
+}
+
+#[derive(Deserialize)]
+pub enum Operation {
+    ListTenants,
+    CreateTenant {
+        tenant_id: TenantId,
+        is_legacy: bool,
+    },
+    DeleteTenant {
+        tenant_id: TenantId,
+    },
+}
+
+#[derive(Serialize)]
+pub enum OperationSucceeded {
+    ListTenants { tenants: Vec<Tenant> },
+    CreateTenant { tenant: Tenant },
+    DeleteTenant { tenant: Option<Tenant> },
+}
+
+pub type OperationResult = Result<OperationSucceeded, Error>;
+
+#[derive(Serialize, Deserialize)]
+pub struct Tenant {
+    pub tenant_id: TenantId,
+    pub is_legacy: bool,
 }

--- a/web-api-db-ctrl/src/postgres.rs
+++ b/web-api-db-ctrl/src/postgres.rs
@@ -294,12 +294,12 @@ pub(super) async fn create_tenant(
     tenant_id: &TenantId,
     is_legacy_tenant: bool,
 ) -> Result<(), Error> {
-    let legcy_hint = if is_legacy_tenant {
+    let legacy_hint = if is_legacy_tenant {
         LegacyHint::NewSchema
     } else {
         LegacyHint::NotLegacy
     };
-    create_tenant_role_and_schema(tx, tenant_id, legcy_hint).await?;
+    create_tenant_role_and_schema(tx, tenant_id, legacy_hint).await?;
     run_db_migration_for(tx, tenant_id, true).await?;
     Ok(())
 }

--- a/web-api-db-ctrl/src/postgres.rs
+++ b/web-api-db-ctrl/src/postgres.rs
@@ -297,7 +297,7 @@ pub(super) async fn create_tenant(
     let legcy_hint = if is_legacy_tenant {
         LegacyHint::NewSchema
     } else {
-        LegacyHint::Not
+        LegacyHint::NotLegacy
     };
     create_tenant_role_and_schema(tx, tenant_id, legcy_hint).await?;
     run_db_migration_for(tx, tenant_id, true).await?;
@@ -306,7 +306,7 @@ pub(super) async fn create_tenant(
 
 #[derive(Clone, Copy, Debug)]
 enum LegacyHint {
-    Not,
+    NotLegacy,
     MigrateSchema,
     NewSchema,
 }

--- a/web-api-db-ctrl/src/postgres.rs
+++ b/web-api-db-ctrl/src/postgres.rs
@@ -244,9 +244,9 @@ pub(super) async fn list_tenants(pool: &Pool<Postgres>) -> Result<Vec<Tenant>, E
     .fetch_all(pool)
     .await?
     .into_iter()
-    .map(|(tenant_id, is_legacy)| Tenant {
+    .map(|(tenant_id, is_legacy_tenant)| Tenant {
         tenant_id,
-        is_legacy,
+        is_legacy_tenant,
     })
     .collect())
 }
@@ -261,14 +261,14 @@ pub(super) async fn delete_tenant(
     let deleted_tenant = sqlx::query_as::<_, (bool,)>(
         "DELETE FROM management.tenant
            WHERE tenant_id = $1
-           RETURNING is_legacy;",
+           RETURNING is_legacy_tenant;",
     )
     .bind(&tenant_id)
     .fetch_optional(&mut *tx)
     .await?
-    .map(|(is_legacy,)| Tenant {
+    .map(|(is_legacy_tenant,)| Tenant {
         tenant_id,
-        is_legacy,
+        is_legacy_tenant,
     });
 
     if deleted_tenant.is_none() {

--- a/web-api-shared/src/request.rs
+++ b/web-api-shared/src/request.rs
@@ -12,7 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{str, sync::Arc};
+use std::{
+    str::{self, FromStr},
+    sync::Arc,
+};
 
 use derive_more::{AsRef, From};
 use once_cell::sync::Lazy;
@@ -64,6 +67,14 @@ impl TenantId {
                 hint: String::from_utf8_lossy(ascii).into_owned(),
             })
         }
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = InvalidTenantId;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        TenantId::try_parse_ascii(s.as_bytes())
     }
 }
 

--- a/web-api/src/app/state.rs
+++ b/web-api/src/app/state.rs
@@ -64,8 +64,7 @@ where
     pub(super) async fn create(config: A::Config) -> Result<Self, SetupError> {
         let extension = A::create_extension(&config)?;
         let (silo, legacy_tenant) = initialize_silo(config.as_ref(), config.as_ref()).await?;
-        let storage_builder =
-            Arc::new(Storage::builder(config.as_ref(), &silo, legacy_tenant).await?);
+        let storage_builder = Arc::new(Storage::builder(config.as_ref(), legacy_tenant).await?);
         Ok(Self {
             config,
             extension,

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -25,6 +25,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 use tokio::time::Instant;
 use tracing::{debug, error, info, instrument};
 use xayn_summarizer::{summarize, Config, Source, Summarizer};
+use xayn_web_api_db_ctrl::{Operation, Silo};
 
 use super::AppState;
 use crate::{

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -568,15 +568,7 @@ async fn silo_management_api(
     silo: Data<Silo>,
 ) -> Result<impl Responder, Error> {
     let results = silo.run_operations(false, request.operations).await?;
-    let results: Vec<_> = results
-        .into_iter()
-        .map(|res| -> Result<_, Error> {
-            Ok(match res {
-                Ok(out) => serde_json::to_value(&out)?,
-                Err(error) => json!({"error": error.to_string()}),
-            })
-        })
-        .try_collect()?;
+    let results: Vec<_> = results.iter().map(serde_json::to_value).try_collect()?;
 
     Ok(Json(json!({ "results": results })))
 }

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -22,6 +22,7 @@ use actix_web::{
 use anyhow::bail;
 use itertools::{Either, Itertools};
 use serde::{de, Deserialize, Deserializer, Serialize};
+use serde_json::json;
 use tokio::time::Instant;
 use tracing::{debug, error, info, instrument};
 use xayn_summarizer::{summarize, Config, Source, Summarizer};
@@ -74,7 +75,8 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
                 .route(web::get().to(get_document_property))
                 .route(web::put().to(put_document_property))
                 .route(web::delete().to(delete_document_property)),
-        );
+        )
+        .service(web::resource("/_silo_management_api").route(web::post().to(silo_management_api)));
 }
 
 fn deserialize_string_not_empty_or_zero_bytes<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -553,6 +555,30 @@ async fn delete_document_property(
         .ok_or(DocumentPropertyNotFound)?;
 
     Ok(HttpResponse::NoContent())
+}
+
+#[derive(Deserialize, Debug)]
+struct ManagementRequest {
+    operations: Vec<Operation>,
+}
+
+#[instrument(skip(silo))]
+async fn silo_management_api(
+    Json(request): Json<ManagementRequest>,
+    silo: Data<Silo>,
+) -> Result<impl Responder, Error> {
+    let results = silo.run_operations(false, request.operations).await?;
+    let results: Vec<_> = results
+        .into_iter()
+        .map(|res| -> Result<_, Error> {
+            Ok(match res {
+                Ok(out) => serde_json::to_value(&out)?,
+                Err(error) => json!({"error": error.to_string()}),
+            })
+        })
+        .try_collect()?;
+
+    Ok(Json(json!({ "results": results })))
 }
 
 #[cfg(test)]

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -239,7 +239,6 @@ pub(crate) struct Storage {
 impl Storage {
     pub(crate) async fn builder(
         config: &Config,
-        silo: &Silo,
         legacy_tenant: Option<TenantId>,
     ) -> Result<StorageBuilder, SetupError> {
         Ok(StorageBuilder {

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -256,7 +256,7 @@ pub(crate) async fn initialize_silo(
     tenant_config: &tenants::Config,
 ) -> Result<(Silo, Option<TenantId>), SetupError> {
     let silo = Silo::new(
-        &config.postgres,
+        config.postgres.clone(),
         config.elastic.clone(),
         tenant_config
             .enable_legacy_tenant

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -239,41 +239,41 @@ pub(crate) struct Storage {
 impl Storage {
     pub(crate) async fn builder(
         config: &Config,
-        tenant_config: &tenants::Config,
+        silo: &Silo,
+        legacy_tenant: Option<TenantId>,
     ) -> Result<StorageBuilder, SetupError> {
-        let legacy_tenant = Self::initialize(config, tenant_config).await?;
-
         Ok(StorageBuilder {
             elastic: elastic::Client::builder(config.elastic.clone())?,
             postgres: postgres::Database::builder(&config.postgres, legacy_tenant).await?,
         })
     }
+}
 
-    // FIXME: long term this should be run by the control plane,
-    //        in a different binary/lambda or similar before we
-    //        start updating the instances.
-    async fn initialize(
-        config: &Config,
-        tenant_config: &tenants::Config,
-    ) -> Result<Option<TenantId>, SetupError> {
-        let silo = Silo::new(
-            config.postgres.clone(),
-            config.elastic.clone(),
-            tenant_config
-                .enable_legacy_tenant
-                .then(|| LegacyTenantInfo {
-                    es_index: config.elastic.index_name.clone(),
-                }),
-        )
-        .await?;
+// FIXME: long term this should be run by the control plane,
+//        in a different binary/lambda or similar before we
+//        start updating the instances.
+pub(crate) async fn initialize_silo(
+    config: &Config,
+    tenant_config: &tenants::Config,
+) -> Result<(Silo, Option<TenantId>), SetupError> {
+    let silo = Silo::new(
+        &config.postgres,
+        config.elastic.clone(),
+        tenant_config
+            .enable_legacy_tenant
+            .then(|| LegacyTenantInfo {
+                es_index: config.elastic.index_name.clone(),
+            }),
+    )
+    .await?;
 
-        // FIXME: remove this once we have a proper separation between
-        //        a admin pg user owning the db structure and a web-api-mt
-        //        user which can only use tables but nothing more.
-        silo.admin_as_mt_user_hack().await?;
+    // FIXME: remove this once we have a proper separation between
+    //        a admin pg user owning the db structure and a web-api-mt
+    //        user which can only use tables but nothing more.
+    silo.admin_as_mt_user_hack().await?;
 
-        silo.initialize().await
-    }
+    let legacy_tenant = silo.initialize().await?;
+    Ok((silo, legacy_tenant))
 }
 
 #[derive(Clone)]

--- a/web-api/tests/silo_management_api.rs
+++ b/web-api/tests/silo_management_api.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use toml::toml;
+use xayn_integration_tests::{send_assert_json, test_app};
+use xayn_web_api::Ingestion;
+use xayn_web_api_db_ctrl::{OperationResult, Tenant};
+use xayn_web_api_shared::request::TenantId;
+
+#[derive(Deserialize)]
+struct ManagementResponse {
+    results: Vec<OperationResult>,
+}
+
+#[tokio::test]
+async fn test_tenants_can_be_created() {
+    test_app::<Ingestion, _>(
+        Some(toml! {
+            [tenants]
+            enable_legacy_tenant = false
+        }),
+        |client, url, services| async move {
+            let test_id = services.test_id.as_str();
+            let make_id = |suffix| format!("{test_id}_{suffix}").parse::<TenantId>();
+            let ManagementResponse { results } = send_assert_json(
+                &client,
+                client.post(url.join("_silo_management_api")?).json(&json!({
+                    "operations": [
+                        { "CreateTenant": { "tenant_id": make_id("1")? }},
+                        { "CreateTenant": { "tenant_id": make_id("3")?, "is_legacy_tenant": true }},
+                        { "CreateTenant": { "tenant_id": make_id("1")? }},
+                        { "ListTenants": {} },
+                        { "DeleteTenant": { "tenant_id": make_id("3")? }},
+                        { "ListTenants": {} },
+                        { "DeleteTenant": { "tenant_id": make_id("3")? }},
+                    ]
+                })).build()?,
+                StatusCode::OK,
+            )
+            .await;
+
+            let mut results = results.into_iter();
+
+            assert_eq!(
+                results.next().unwrap(),
+                OperationResult::CreateTenant {
+                    tenant: Tenant {
+                        tenant_id: make_id("1")?,
+                        is_legacy_tenant: false,
+                    }
+                }
+            );
+            assert_eq!(
+                results.next().unwrap(),
+                OperationResult::CreateTenant {
+                    tenant: Tenant {
+                        tenant_id: make_id("3")?,
+                        is_legacy_tenant: true,
+                    }
+                }
+            );
+            assert!(matches!(
+                &results.next().unwrap(),
+                OperationResult::Error { .. }
+            ));
+            let OperationResult::ListTenants { tenants } = results.next().unwrap() else {
+                panic!("failed ot list tenants");
+            };
+            assert_eq!(
+                tenants.iter().collect::<HashSet<_>>(),
+                [
+                    services.tenant.clone(),
+                    Tenant {
+                        tenant_id: make_id("1")?,
+                        is_legacy_tenant: false,
+                    },
+                    Tenant {
+                        tenant_id: make_id("3")?,
+                        is_legacy_tenant: true,
+                    }
+                ]
+                .iter()
+                .collect::<HashSet<_>>()
+            );
+            assert_eq!(
+                results.next().unwrap(),
+                OperationResult::DeleteTenant {
+                    tenant: Some(Tenant {
+                        tenant_id: make_id("3")?,
+                        is_legacy_tenant: true,
+                    })
+                }
+            );
+            let OperationResult::ListTenants { tenants } = results.next().unwrap() else {
+                panic!("failed ot list tenants");
+            };
+            assert_eq!(
+                tenants.iter().collect::<HashSet<_>>(),
+                [
+                    services.tenant.clone(),
+                    Tenant {
+                        tenant_id: make_id("1")?,
+                        is_legacy_tenant: false,
+                    },
+                ]
+                .iter()
+                .collect::<HashSet<_>>()
+            );
+            assert_eq!(
+                results.next().unwrap(),
+                OperationResult::DeleteTenant { tenant: None }
+            );
+
+            assert_eq!(results.next(), None);
+            Ok(())
+        },
+    )
+    .await;
+}

--- a/web-api/tests/silo_management_api.rs
+++ b/web-api/tests/silo_management_api.rs
@@ -40,7 +40,7 @@ async fn test_tenants_can_be_created() {
             let make_id = |suffix| format!("{test_id}_{suffix}").parse::<TenantId>();
             let ManagementResponse { results } = send_assert_json(
                 &client,
-                client.post(url.join("_silo_management_api")?).json(&json!({
+                client.post(url.join("_silo_management")?).json(&json!({
                     "operations": [
                         { "CreateTenant": { "tenant_id": make_id("1")? }},
                         { "CreateTenant": { "tenant_id": make_id("3")?, "is_legacy_tenant": true }},
@@ -80,7 +80,7 @@ async fn test_tenants_can_be_created() {
                 OperationResult::Error { .. }
             ));
             let OperationResult::ListTenants { tenants } = results.next().unwrap() else {
-                panic!("failed ot list tenants");
+                panic!("failed to list tenants");
             };
             assert_eq!(
                 tenants.iter().collect::<HashSet<_>>(),
@@ -108,7 +108,7 @@ async fn test_tenants_can_be_created() {
                 }
             );
             let OperationResult::ListTenants { tenants } = results.next().unwrap() else {
-                panic!("failed ot list tenants");
+                panic!("failed to list tenants");
             };
             assert_eq!(
                 tenants.iter().collect::<HashSet<_>>(),
@@ -120,7 +120,7 @@ async fn test_tenants_can_be_created() {
                     },
                 ]
                 .iter()
-                .collect::<HashSet<_>>()
+                .collect()
             );
             assert_eq!(
                 results.next().unwrap(),


### PR DESCRIPTION
- [x] added a `Silo.run_operations()`  and `enum Operation`
- [x] added `/_silo_management_api` to which you can post a sequence of json serialized `Operation`  
- [x] test if we can create, list and delete tenants

**References:**

- issue [ET-4295]
- story [ET-4344]
- based on #907  

[ET-4295]: https://xainag.atlassian.net/browse/ET-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4344]: https://xainag.atlassian.net/browse/ET-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ