### PR TITLE
[Merged by Bors] - ET-4486 per integration test logging

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -135,26 +135,24 @@ where
 
 /// Initialize logging in tests.
 pub fn initialize_test_logging_fallback() {
-    // TODO[pmk/now] enable fallback logging again
-    // static ONCE: Once = Once::new();
-    // ONCE.call_once(|| {
-    //     logging::initialize_global(&logging::Config {
-    //         file: Some("/tmp/test_global.delme".into()),
-    //         level: LevelFilter::WARN,
-    //         // FIXME If we have json logging do fix the panic logging hook
-    //         //       to also log the backtrace instead of disabling the
-    //         //       panic hook.
-    //         install_panic_hook: false,
-    //     })
-    //     .unwrap();
-    // });
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        logging::initialize_global(&logging::Config {
+            file: None,
+            level: LevelFilter::WARN,
+            // FIXME If we have json logging do fix the panic logging hook
+            //       to also log the backtrace instead of disabling the
+            //       panic hook.
+            install_panic_hook: false,
+        })
+        .unwrap();
+    });
 }
 
-pub fn initialize_local_test_logging(test_id: &str) -> Dispatch {
+pub fn initialize_local_test_logging() -> Dispatch {
     initialize_test_logging_fallback();
     logging::create_trace_dispatch(&logging::Config {
-        // TODO[pmk/now] disable file logging
-        file: Some(format!("/tmp/log_${test_id}.delme").as_str().into()),
+        file: None,
         level: LevelFilter::INFO,
         install_panic_hook: false,
     })
@@ -164,7 +162,7 @@ pub fn run_async_with_test_logger<F>(test_id: &str, body: F) -> F::Output
 where
     F: Future,
 {
-    let subscriber = initialize_local_test_logging(test_id);
+    let subscriber = initialize_local_test_logging();
     let body = async move {
         // Hint: the `error_span` must be created _inside_ of the future or else it
         //       would mix references of the global and local logging in a way which doesn't work

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -43,7 +43,7 @@ use tracing::{dispatcher, error_span, instrument, Dispatch, Instrument};
 use tracing_subscriber::fmt::TestWriter;
 use xayn_test_utils::{env::clear_env, error::Panic};
 use xayn_web_api::{config, start, AppHandle, Application};
-use xayn_web_api_db_ctrl::{LegacyTenantInfo, Silo};
+use xayn_web_api_db_ctrl::{Silo, Tenant};
 use xayn_web_api_shared::{
     elastic,
     postgres::{self, QuotedIdentifier},
@@ -391,17 +391,7 @@ pub fn build_test_config_from_parts(
 
     extend_config(&mut config, configure);
 
-    let args = &[
-        "integration-test",
-        "--bind-to",
-        "127.0.0.1:0",
-        "--config",
-        &format!("inline:{config}"),
-    ];
-
-    let config = config::load_with_args([0u8; 0], args);
-
-    start::<A>(config).await.unwrap()
+    config
 }
 
 /// Generates an ID for the test.

--- a/test-utils/src/env.rs
+++ b/test-utils/src/env.rs
@@ -38,7 +38,8 @@ use regex::Regex;
 /// - `DOCKER*`
 /// - `PODMAN*`
 /// - `XDG*`
-/// - `GITHUB_`
+/// - `GITHUB_*`
+/// - `XAYN_TEST_*`
 pub fn clear_env() {
     static ONCE: Once = Once::new();
     // We need to make sure we only do it once as this doesn't execute concurrently
@@ -74,6 +75,7 @@ static ENV_PRUNE_EXCEPTIONS: Lazy<Regex> = Lazy::new(|| {
         |(?:^PODMAN)
         |(?:^XDG)
         |(?:^GITHUB_)
+        |(?:^XAYN_TEST_)
         "#,
     )
     .unwrap()

--- a/web-api/src/bin/ingestion.rs
+++ b/web-api/src/bin/ingestion.rs
@@ -21,7 +21,7 @@ type Config = <Ingestion as Application>::Config;
 #[instrument(err)]
 async fn main() -> Result<(), anyhow::Error> {
     let config: Config = config::load(application_names!());
-    logging::initialize(config.as_ref())?;
+    logging::initialize_global(config.as_ref())?;
     start::<Ingestion>(config)
         .await?
         .wait_for_termination()

--- a/web-api/src/bin/personalization.rs
+++ b/web-api/src/bin/personalization.rs
@@ -21,7 +21,7 @@ type Config = <Personalization as Application>::Config;
 #[instrument(err)]
 async fn main() -> Result<(), anyhow::Error> {
     let config: Config = config::load(application_names!());
-    logging::initialize(config.as_ref())?;
+    logging::initialize_global(config.as_ref())?;
     start::<Personalization>(config)
         .await?
         .wait_for_termination()

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -14,7 +14,7 @@
 
 //! Setup tracing on different platforms.
 
-use std::fs::OpenOptions;
+use std::{fs::OpenOptions, path::Path};
 
 use serde::{Deserialize, Serialize};
 use tracing::{error, Dispatch, Level};
@@ -78,33 +78,35 @@ impl Default for Config {
 ///
 /// Even though this returns an error if logging was already initialized you
 /// should only call this function when you expect it to succeed.
-pub fn initialize_global(log_config: &Config) -> Result<(), TryInitError> {
-    let dispatch = create_trace_dispatch(log_config);
+pub fn initialize_global(config: &Config) -> Result<(), TryInitError> {
+    let dispatch = create_trace_dispatch(
+        config.level,
+        config.file.as_ref().map(|f| f.relative()).as_deref(),
+    );
     dispatch.try_init()?;
-    if log_config.install_panic_hook {
+    if config.install_panic_hook {
         init_panic_logging();
     }
     Ok(())
 }
 
-pub fn create_trace_dispatch(log_config: &Config) -> Dispatch {
+pub fn create_trace_dispatch(level: LevelFilter, file: Option<&Path>) -> Dispatch {
     let subscriber = tracing_subscriber::registry();
 
     let stdout_log = tracing_subscriber::fmt::layer().with_ansi(false);
 
     let sqlx_query_no_info = Targets::new()
-        .with_default(log_config.level)
+        .with_default(level)
         .with_target("sqlx::query", Level::WARN);
 
-    let file_log = log_config
-        .file
+    let file_log = file
         .as_ref()
-        .map(|log_file| {
+        .map(|file| {
             OpenOptions::new()
                 .write(true)
                 .truncate(true)
                 .create(true)
-                .open(log_file.relative())
+                .open(file)
                 .map(|writer| {
                     tracing_subscriber::fmt::layer()
                         .with_writer(writer)
@@ -122,7 +124,7 @@ pub fn create_trace_dispatch(log_config: &Config) -> Dispatch {
         .with(stdout_log)
         .with(sqlx_query_no_info)
         .with(file_log)
-        .with(log_config.level)
+        .with(level)
         .into()
 }
 

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -90,7 +90,7 @@ pub fn initialize_global(config: &Config) -> Result<(), TryInitError> {
     Ok(())
 }
 
-pub fn create_trace_dispatch(level: LevelFilter, file: Option<&Path>) -> Dispatch {
+fn create_trace_dispatch(level: LevelFilter, file: Option<&Path>) -> Dispatch {
     let subscriber = tracing_subscriber::registry();
 
     let stdout_log = tracing_subscriber::fmt::layer().with_ansi(false);

--- a/web-api/src/middleware.rs
+++ b/web-api/src/middleware.rs
@@ -13,3 +13,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pub(crate) mod json_error;
 pub(crate) mod request_context;
+pub(crate) mod tracing;

--- a/web-api/src/middleware/tracing.rs
+++ b/web-api/src/middleware/tracing.rs
@@ -25,8 +25,8 @@
 // Hint: Making this a macro saves us very complex nightmare of type annotations (and also way less lines of code).
 macro_rules! new_http_server_with_subscriber {
     ($subscriber:expr, move || $factory:block) => {{
-        use actix_web::dev::Service;
-        use tracing::{dispatcher, instrument::WithSubscriber, Dispatch};
+        use ::actix_web::dev::Service;
+        use ::tracing::{dispatcher, instrument::WithSubscriber, Dispatch};
         let subscriber = Dispatch::from($subscriber);
         HttpServer::new(move || {
             // Hint: Makes sure the factory has the right dispatcher.

--- a/web-api/src/middleware/tracing.rs
+++ b/web-api/src/middleware/tracing.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use actix_web::{
+    body::MessageBody,
+    dev::{Service, ServiceRequest, ServiceResponse},
+};
+use futures_util::{future::LocalBoxFuture, FutureExt};
+use tracing::{dispatcher, instrument::WithSubscriber, Dispatch};
+
+/// Creates a wrapper which can be passed to `wrap_fn` which setup up local trace event dispatch.
+///
+/// When building a actix http server app apply this last, i.e. make it the
+/// "outer most" wrapper.
+///
+/// The wrapper will do two things:
+///
+/// 1. Sync wrap `service.call(request)` call to make sure future middleware
+///    has the right logging context when being called (e.g. more inner `wrap_fn`
+///    function calls).
+///
+/// 2. Async wrap the result of `service.call(request)` to make sure all  requests
+///     and wrapped post-request middleware handling hath the right logging context.
+pub(crate) fn create_wrapper_for_local_trace_event_dispatch<S, B>(
+    subscriber: impl Into<Dispatch>,
+) -> impl Fn(
+    ServiceRequest,
+    &S,
+) -> LocalBoxFuture<'static, Result<ServiceResponse<B>, actix_web::Error>>
+       + Clone
+       + 'static
+where
+    B: MessageBody,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+{
+    let subscriber = subscriber.into();
+    move |r, s| {
+        let fut = dispatcher::with_default(&subscriber, || s.call(r));
+        fut.with_subscriber(subscriber.clone()).boxed_local()
+    }
+}

--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -110,7 +110,7 @@ where
     // `spawn` it on the tokio runtime. This hands off the responsibility to poll the server to
     // tokio. At the same time we keep the `JoinHandle` so that we can wait for the server to
     // stop and get it's return value (we don't have to await `term_handle`).
-    // TODO[pmk/now] instrument appropriately
+    // TODO[pmk/now] instrument appropriately also add service name to right instrumentation
     let term_handle = tokio::spawn(server.with_current_subscriber());
     Ok(AppHandle {
         on_shutdown,

--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -110,7 +110,7 @@ where
     // `spawn` it on the tokio runtime. This hands off the responsibility to poll the server to
     // tokio. At the same time we keep the `JoinHandle` so that we can wait for the server to
     // stop and get it's return value (we don't have to await `term_handle`).
-    // TODO[pmk/now] instrument appropriately also add service name to right instrumentation
+    // FIXME: instrument with service name, do same for all requests
     let term_handle = tokio::spawn(server.with_current_subscriber());
     Ok(AppHandle {
         on_shutdown,

--- a/web-api/tests/document_candidates.rs
+++ b/web-api/tests/document_candidates.rs
@@ -69,8 +69,8 @@ async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) ->
     Ok(())
 }
 
-#[tokio::test]
-async fn test_candidates_all() {
+#[test]
+fn test_candidates_all() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
@@ -78,12 +78,11 @@ async fn test_candidates_all() {
         set(&client, &url, ["d1", "d2", "d3"]).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2", "d3"].into());
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_candidates_some() {
+#[test]
+fn test_candidates_some() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
@@ -91,12 +90,11 @@ async fn test_candidates_some() {
         set(&client, &url, ["d1", "d3"]).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d3"].into());
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_candidates_none() {
+#[test]
+fn test_candidates_none() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
@@ -104,12 +102,11 @@ async fn test_candidates_none() {
         set(&client, &url, None).await?;
         assert!(get(&client, &url).await?.ids().is_empty());
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_candidates_not_default() {
+#[test]
+fn test_candidates_not_default() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         send_assert(
@@ -132,8 +129,7 @@ async fn test_candidates_not_default() {
         set(&client, &url, ["d2", "d3"]).await?;
         assert_eq!(get(&client, &url).await?.ids(), ["d2", "d3"].into());
         Ok(())
-    })
-    .await;
+    });
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -154,8 +150,8 @@ struct Error {
     details: Details,
 }
 
-#[tokio::test]
-async fn test_candidates_warning() {
+#[test]
+fn test_candidates_warning() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         ingest(&client, &url).await?;
@@ -178,12 +174,11 @@ async fn test_candidates_warning() {
         assert_eq!(error.details, Details::Set(json!([ { "id": "d4" } ])));
         assert_eq!(get(&client, &url).await?.ids(), ["d1"].into());
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_candidates_reingestion() {
+#[test]
+fn test_candidates_reingestion() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         assert!(get(&client, &url).await?.ids().is_empty());
         send_assert(
@@ -225,6 +220,5 @@ async fn test_candidates_reingestion() {
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d4", "d6"].into());
 
         Ok(())
-    })
-    .await;
+    });
 }

--- a/web-api/tests/document_properties.rs
+++ b/web-api/tests/document_properties.rs
@@ -32,7 +32,7 @@ enum Error {
     DocumentPropertyNotFound,
 }
 
-async fn document_properties(is_candidate: bool) {
+fn document_properties(is_candidate: bool) {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
@@ -123,18 +123,17 @@ async fn document_properties(is_candidate: bool) {
         assert!(properties.is_empty());
 
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_document_properties_candidate() {
-    document_properties(true).await;
+#[test]
+fn test_document_properties_candidate() {
+    document_properties(true);
 }
 
-#[tokio::test]
-async fn test_document_properties_noncandidate() {
-    document_properties(false).await;
+#[test]
+fn test_document_properties_noncandidate() {
+    document_properties(false);
 }
 
 #[derive(Debug, Deserialize)]
@@ -142,7 +141,7 @@ struct DocumentPropertyResponse {
     property: Value,
 }
 
-async fn document_property(is_candidate: bool) {
+fn document_property(is_candidate: bool) {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
@@ -233,16 +232,15 @@ async fn document_property(is_candidate: bool) {
         assert_eq!(error, Error::DocumentNotFound);
 
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_document_property_candidate() {
-    document_property(true).await;
+#[test]
+fn test_document_property_candidate() {
+    document_property(true);
 }
 
-#[tokio::test]
-async fn test_document_property_noncandidate() {
-    document_property(false).await;
+#[test]
+fn test_document_property_noncandidate() {
+    document_property(false);
 }

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -66,8 +66,8 @@ struct Error {
     details: Option<Details>,
 }
 
-#[tokio::test]
-async fn test_ingestion_created() {
+#[test]
+fn test_ingestion_created() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         ingest(&client, &url).await?;
         send_assert(
@@ -91,12 +91,11 @@ async fn test_ingestion_created() {
         assert_eq!(error.kind, Kind::DocumentNotFound);
         assert!(error.details.is_none());
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_ingestion_bad_request() {
+#[test]
+fn test_ingestion_bad_request() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         let error = send_assert_json::<Error>(
             &client,
@@ -124,12 +123,11 @@ async fn test_ingestion_bad_request() {
         )
         .await;
         Ok(())
-    })
-    .await;
+    });
 }
 
-#[tokio::test]
-async fn test_deletion() {
+#[test]
+fn test_deletion() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         ingest(&client, &url).await?;
         send_assert(
@@ -153,8 +151,7 @@ async fn test_deletion() {
             Details::Delete(json!([ { "id": "d1" } ])),
         );
         Ok(())
-    })
-    .await;
+    });
 }
 
 #[derive(Deserialize)]
@@ -167,8 +164,8 @@ struct SemanticSearchResponse {
     documents: Vec<PersonalizedDocumentData>,
 }
 
-#[tokio::test]
-async fn test_reingestion_candidates() {
+#[test]
+fn test_reingestion_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -247,15 +244,14 @@ async fn test_reingestion_candidates() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
 // currently there is no endpoint to actually check the changed snippets/embeddings, but we can at
 // least run the test to see if something crashes and manually check with log level `info` how many
 // new and changed documents have been logged and manually check the databases
-#[tokio::test]
-async fn test_reingestion_snippets() {
+#[test]
+fn test_reingestion_snippets() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
         send_assert(
             &client,
@@ -291,6 +287,5 @@ async fn test_reingestion_snippets() {
         .await;
 
         Ok(())
-    })
-    .await;
+    });
 }

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -44,7 +44,7 @@ use xayn_web_api_shared::{
 
 async fn legacy_test_setup(test_id: &str) -> Result<(postgres::Config, elastic::Config), Error> {
     clear_env();
-    start_test_service_containers()?;
+    start_test_service_containers();
 
     let (pg_config, es_config) = db_configs_for_testing(test_id);
 

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -27,7 +27,6 @@ use xayn_integration_tests::{
     create_db,
     db_configs_for_testing,
     generate_test_id,
-    initialize_test_logging_fallback,
     run_async_with_test_logger,
     send_assert,
     send_assert_json,
@@ -45,7 +44,6 @@ use xayn_web_api_shared::{
 
 async fn legacy_test_setup(test_id: &str) -> Result<(postgres::Config, elastic::Config), Error> {
     clear_env();
-    initialize_test_logging_fallback();
     start_test_service_containers()?;
 
     let (pg_config, es_config) = db_configs_for_testing(test_id);

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -27,7 +27,7 @@ use xayn_integration_tests::{
     create_db,
     db_configs_for_testing,
     generate_test_id,
-    initialize_test_logging,
+    initialize_test_logging_fallback,
     send_assert,
     send_assert_json,
     start_test_service_containers,
@@ -44,7 +44,7 @@ use xayn_web_api_shared::{
 
 async fn legacy_test_setup() -> Result<(postgres::Config, elastic::Config), Error> {
     clear_env();
-    initialize_test_logging();
+    initialize_test_logging_fallback();
     start_test_service_containers()?;
 
     let test_id = generate_test_id();

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -171,8 +171,8 @@ macro_rules! assert_order {
     };
 }
 
-#[tokio::test]
-async fn test_personalization_all_dates() {
+#[test]
+fn test_personalization_all_dates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -186,12 +186,11 @@ async fn test_personalization_all_dates() {
             );
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_personalization_limited_dates() {
+#[test]
+fn test_personalization_limited_dates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -211,12 +210,11 @@ async fn test_personalization_limited_dates() {
             );
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_personalization_with_query() {
+#[test]
+fn test_personalization_with_query() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -236,12 +234,11 @@ async fn test_personalization_with_query() {
             );
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_personalization_with_tags() {
+#[test]
+fn test_personalization_with_tags() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -255,6 +252,5 @@ async fn test_personalization_with_tags() {
             );
             Ok(())
         },
-    )
-    .await;
+    );
 }

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -97,8 +97,8 @@ macro_rules! assert_order {
     };
 }
 
-#[tokio::test]
-async fn test_full_personalization() {
+#[test]
+fn test_full_personalization() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         Some(toml! {
@@ -168,12 +168,11 @@ async fn test_full_personalization() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_subtle_personalization() {
+#[test]
+fn test_subtle_personalization() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         Some(toml! {
@@ -205,12 +204,11 @@ async fn test_subtle_personalization() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_full_personalization_with_inline_history() {
+#[test]
+fn test_full_personalization_with_inline_history() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         Some(toml! {
@@ -278,6 +276,5 @@ async fn test_full_personalization_with_inline_history() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -57,8 +57,8 @@ struct SemanticSearchResponse {
     documents: Vec<PersonalizedDocumentData>,
 }
 
-#[tokio::test]
-async fn test_semantic_search() {
+#[test]
+fn test_semantic_search() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -113,12 +113,11 @@ async fn test_semantic_search() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_semantic_search_min_similarity() {
+#[test]
+fn test_semantic_search_min_similarity() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -168,12 +167,11 @@ async fn test_semantic_search_min_similarity() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_semantic_search_with_query() {
+#[test]
+fn test_semantic_search_with_query() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -230,6 +228,5 @@ async fn test_semantic_search_with_query() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }

--- a/web-api/tests/silo_management_api.rs
+++ b/web-api/tests/silo_management_api.rs
@@ -28,8 +28,8 @@ struct ManagementResponse {
     results: Vec<OperationResult>,
 }
 
-#[tokio::test]
-async fn test_tenants_can_be_created() {
+#[test]
+fn test_tenants_can_be_created() {
     test_app::<Ingestion, _>(
         Some(toml! {
             [tenants]
@@ -130,6 +130,5 @@ async fn test_tenants_can_be_created() {
             assert_eq!(results.next(), None);
             Ok(())
         },
-    )
-    .await;
+    );
 }

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -31,7 +31,7 @@ struct PersonalizedDocumentsResponse {
     documents: Vec<PersonalizedDocumentData>,
 }
 
-async fn store_user_history(enabled: bool) {
+fn store_user_history(enabled: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         Some(toml! {
@@ -93,16 +93,15 @@ async fn store_user_history(enabled: bool) {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_store_user_history_enabled() {
-    store_user_history(true).await;
+#[test]
+fn test_store_user_history_enabled() {
+    store_user_history(true);
 }
 
-#[tokio::test]
-async fn test_store_user_history_disabled() {
-    store_user_history(false).await;
+#[test]
+fn test_store_user_history_disabled() {
+    store_user_history(false);
 }

--- a/web-api/tests/tenant_id_header.rs
+++ b/web-api/tests/tenant_id_header.rs
@@ -18,8 +18,8 @@ use toml::toml;
 use xayn_integration_tests::{send_assert, test_app};
 use xayn_web_api::Ingestion;
 
-#[tokio::test]
-async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
+#[test]
+fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
     test_app::<Ingestion, _>(
         Some(toml! {
             [tenants]
@@ -43,12 +43,11 @@ async fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
             .await;
             Ok(())
         },
-    )
-    .await;
+    );
 }
 
-#[tokio::test]
-async fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
+#[test]
+fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
     test_app::<Ingestion, _>(
         Some(toml! {
             [tenants]
@@ -73,6 +72,5 @@ async fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
 
             Ok(())
         },
-    )
-    .await;
+    );
 }


### PR DESCRIPTION
This PR does mainly two things:

-  use `TestWriter` to make log capturing work again
- use per-test non-global `Dispatch` 

As a side effect of this the creation of the async runtime is moved into the `test_app`/`test_two_app` scaffold, sadly this leads to ~3 line changes per integration test :sweat: 

**References:**

- task [ET-4486]
- story [ET-4485]
- followed by #950 

[ET-4486]: https://xainag.atlassian.net/browse/ET-4486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4485]: https://xainag.atlassian.net/browse/ET-4485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ