### PR TITLE
[Merged by Bors] - ET-4487 flame graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ target/
 .env.db.dev
 .tmp
 
+test-artifacts/
+
 # discovery_engine_api_tests
 discovery_engine_api_tests/venv/
 discovery_engine_api_tests/**/__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,6 +3655,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4367,6 +4378,7 @@ dependencies = [
  "tokio",
  "toml 0.7.3",
  "tracing",
+ "tracing-flame",
  "tracing-log",
  "tracing-subscriber",
  "uuid",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -22,6 +22,7 @@ temp-dir = "0.1.11"
 tokio = { workspace = true, features = ["macros"] }
 toml = { workspace = true }
 tracing = { workspace = true }
+tracing-flame = "0.2.0"
 tracing-log = "0.1.3"
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -420,19 +420,20 @@ where
         span.in_scope(|| {
             let body = test(test_id);
 
-        // more or less what #[tokio::test] does
-        // Hint: If we use a "non-current-thread" runtime in the future
-        //       make sure to attach the subscriber to the body future
-        //       using `WithSubscriber.with_current_subscriber()`.
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed building the Runtime")
-            .block_on(body)
-            .unwrap();
+            // more or less what #[tokio::test] does
+            // Hint: If we use a "non-current-thread" runtime in the future
+            //       make sure to attach the subscriber to the body future
+            //       using `WithSubscriber.with_current_subscriber()`.
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed building the Runtime")
+                .block_on(body)
+                .unwrap();
 
-        drop(guard);
-    });
+            drop(guard);
+        });
+    })
 }
 
 struct DeleteTempDirIfNoPanic {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -636,13 +636,20 @@ pub fn build_test_config_from_parts(
     let pg_config = Value::try_from(pg_config).unwrap();
     let es_config = Value::try_from(es_config).unwrap();
 
+    // Hint: Relative path doesn't work with `cargo flamegraph`
+    let embedding_dir = PROJECT_ROOT
+        .join("assets")
+        .join("smbert_v0003")
+        .display()
+        .to_string();
+
     let mut config = toml! {
         [storage]
         postgres = pg_config
         elastic = es_config
 
         [embedding]
-        directory = "../assets/smbert_v0003"
+        directory = embedding_dir
     };
 
     //the password was serialized as REDACTED in to_toml_value

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -202,6 +202,7 @@ pub fn just(args: &[&str]) -> Result<String, Error> {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn send_assert(client: &Client, req: Request, expected: StatusCode) -> Response {
     let method = req.method().clone();
     let target = req.url().clone();
@@ -217,6 +218,7 @@ pub async fn send_assert(client: &Client, req: Request, expected: StatusCode) ->
     response
 }
 
+#[instrument(skip_all)]
 pub async fn send_assert_json<O>(client: &Client, req: Request, expected: StatusCode) -> O
 where
     O: DeserializeOwned,

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -408,7 +408,7 @@ where
     F: Future<Output = Result<(), Error>>,
 {
     let test_id = TestId::generate();
-    let (subscriber, _guard) = initialize_local_test_logging(&test_id);
+    let (subscriber, flame_guard) = initialize_local_test_logging(&test_id);
 
     dispatcher::with_default(&subscriber, || {
         let guard = DeleteTempDirIfNoPanic {
@@ -433,7 +433,9 @@ where
 
             drop(guard);
         });
-    })
+    });
+
+    drop(flame_guard);
 }
 
 struct DeleteTempDirIfNoPanic {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -118,7 +118,7 @@ mod env_vars {
     /// Defaults to `"NONE"`.
     pub(super) const XAYN_TEST_FILE_LOG_SPAN_EVENTS: &str = "XAYN_TEST_FILE_LOG_SPAN_EVENTS";
 
-    /// The [`EnvFilter`] directives used for creating a flame graph.
+    /// The [`EnvFilter`](tracing_subscriber::EnvFilter) directives used for creating a flame graph.
     ///
     /// If set to `"true"` then [`XAYN_TEST_LOG`] is used.
     ///

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -417,7 +417,8 @@ where
         };
 
         let span = error_span!(parent: None, "test", %test_id);
-        let body = test(test_id).instrument(span);
+        span.in_scope(|| {
+            let body = test(test_id);
 
         // more or less what #[tokio::test] does
         // Hint: If we use a "non-current-thread" runtime in the future

--- a/justfile
+++ b/justfile
@@ -259,7 +259,7 @@ mind-benchmark kind:
     cargo test --package xayn-web-api --release --lib \
         -- --nocapture --include-ignored --exact mind::run_{{kind}}_benchmark
 
-flamegraph *args:
+tracing-flamegraph *args:
     #!/usr/bin/env -S bash -eu -o pipefail
     export XAYN_TEST_FLAME_LOG="${XAYN_TEST_FLAME_LOG:-info}"
     cargo test -- {{args}}
@@ -271,6 +271,17 @@ flamegraph *args:
             echo "Flamegraph stored at: $d/tracing.flamechart.svg"
         fi
     done
+
+perf-flamegraph integration_test_bin:
+    #!/usr/bin/env -S bash -eu -o pipefail
+    export CARGO_PROFILE_BENCH_DEBUG=true
+    OUT_DIR="./test-artifacts/{{integration_test_bin}}"
+    mkdir -p "$OUT_DIR"
+    cargo flamegraph -o "$OUT_DIR/flamegraph.svg"  --test {{integration_test_bin}}
+    if [ -e "$OUT_DIR/perf.data" ]; then
+        mv "$OUT_DIR/perf.data" "$OUT_DIR/perf.data.old"
+    fi
+    mv "perf.data" "$OUT_DIR/perf.data"
 
 aws-login:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -259,6 +259,17 @@ mind-benchmark kind:
     cargo test --package xayn-web-api --release --lib \
         -- --nocapture --include-ignored --exact mind::run_{{kind}}_benchmark
 
+flamegraph *args:
+    #!/usr/bin/env -S bash -eu -o pipefail
+    export XAYN_TEST_FLAME_LOG="${XAYN_TEST_FLAME_LOG:-info}"
+    cargo test -- {{args}}
+    for d in ./test-artifacts/*; do
+        if [ -e "$d/tracing.folded" ]; then
+            inferno-flamegraph "$d/tracing.folded" > "$d/tracing.flamegraph.svg"
+            echo "Flamegraph stored at: $d/tracing.flamegraph.svg"
+        fi
+    done
+
 aws-login:
     #!/usr/bin/env bash
     {{ if env_var_or_default("CI", "false") == "false" { "export AWS_PROFILE=\"S3BucketsDeveloperAccess-690046978283\"" } else { "" } }}

--- a/justfile
+++ b/justfile
@@ -264,9 +264,11 @@ flamegraph *args:
     export XAYN_TEST_FLAME_LOG="${XAYN_TEST_FLAME_LOG:-info}"
     cargo test -- {{args}}
     for d in ./test-artifacts/*; do
-        if [ -e "$d/tracing.folded" ]; then
+        if [[ -e "$d/tracing.folded" && ! -e "$d/tracing.flamegraph.svg" ]]; then
             inferno-flamegraph "$d/tracing.folded" > "$d/tracing.flamegraph.svg"
             echo "Flamegraph stored at: $d/tracing.flamegraph.svg"
+            inferno-flamegraph --flamechart  "$d/tracing.folded" > "$d/tracing.flamechart.svg"
+            echo "Flamegraph stored at: $d/tracing.flamechart.svg"
         fi
     done
 

--- a/web-api/src/app.rs
+++ b/web-api/src/app.rs
@@ -20,7 +20,7 @@ use actix_web::{web::ServiceConfig, App};
 use async_trait::async_trait;
 use futures_util::FutureExt;
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::info;
+use tracing::{info, instrument};
 
 pub(crate) use self::state::{AppState, TenantState};
 use crate::{
@@ -64,6 +64,7 @@ pub type SetupError = anyhow::Error;
 /// Run the server with using given endpoint configuration functions.
 ///
 /// The return value is the exit code which should be used.
+#[instrument(skip_all)]
 pub async fn start<A>(config: A::Config) -> Result<AppHandle, SetupError>
 where
     A: Application + 'static,

--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -33,7 +33,6 @@ use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use tracing::{
     dispatcher,
-    error,
     info,
     info_span,
     instrument,
@@ -168,7 +167,7 @@ impl AppHandle {
     }
 
     /// Stops the app gracefully and escalates to non-graceful stopping on timeout, then awaits the apps result.
-    #[instrument]
+    #[instrument(skip(self))]
     pub async fn stop_and_wait(self) -> Result<(), anyhow::Error> {
         //FIXME find out why graceful shutdown on a idle actix server is broken
         self.stop().await;
@@ -188,7 +187,7 @@ impl AppHandle {
     /// Waits for the server/app to have stopped and returns it's return value.
     ///
     /// It is recommended but not required to call this.
-    #[instrument(skip_all)]
+    #[instrument(skip(self))]
     pub async fn wait_for_termination(self) -> Result<(), anyhow::Error> {
         self.term_handle
             .instrument(info_span!("awaiting termination"))

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use sqlx::{Connection, Executor, PgConnection};
 use toml::Table;
-use tracing::info;
+use tracing::{info, instrument};
 use xayn_integration_tests::{
     build_test_config_from_parts,
     create_db,
@@ -42,6 +42,7 @@ use xayn_web_api_shared::{
     request::TenantId,
 };
 
+#[instrument(skip_all)]
 async fn legacy_test_setup(test_id: &TestId) -> Result<(postgres::Config, elastic::Config), Error> {
     clear_env();
     start_test_service_containers();


### PR DESCRIPTION
Adds support to collect flamegraphs and flamecharts when running integration tests.

**References:**

- issue: [ET-4487]
- sotry: [ET-4485]
- based on #950 

[ET-4487]: https://xainag.atlassian.net/browse/ET-4487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4485]: https://xainag.atlassian.net/browse/ET-4485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ