### PR TITLE
[Merged by Bors] - ET-4501 document hybrid search api

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -182,14 +182,14 @@ components:
         published_after:
           $ref: './schemas/time.yml#/PublicationDate'
         min_similarity:
-          description: "Minimal similarity of a document to consider it as search candidate."
+          description: Minimal similarity of a document to consider it as search candidate.
           type: number
           format: float
           minimum: 0
           maximum: 1
           default: 0
         personalize:
-          description: Personalize the ranking of candidates based on a users preferences
+          description: Personalize the ranking of candidates based on a users preferences.
           type: object
           required: [user]
           properties:
@@ -204,6 +204,10 @@ components:
                 This option is incompatible with not specifying a user.
             user:
               $ref: './schemas/user.yml#/InputUser'
+        enable_hybrid_search:
+          description: Enable the hybrid search mode.
+          type: boolean
+          default: false
     SemanticSearchResponse:
       type: object
       required: [documents]


### PR DESCRIPTION
**Reference**

- [ET-4501]

**Summary**

- document optional `enable_hybrid_search` flag on the `semantic_search` endpoint


[ET-4501]: https://xainag.atlassian.net/browse/ET-4501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ