### PR TITLE
[Merged by Bors] - ET-4520 infer dimensionality for es mapping

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -567,6 +567,9 @@ where
         .unwrap()
 }
 
+/// Embedding size used by the `Embedder` used for testing.
+pub const TEST_EMBEDDING_SIZE: usize = 128;
+
 pub fn build_test_config_from_parts(
     pg_config: &postgres::Config,
     es_config: &elastic::Config,
@@ -674,10 +677,12 @@ async fn setup_web_dev_services(
     create_db(&pg_config, MANAGEMENT_DB).await?;
 
     let silo = Silo::new(
-        pg_config, es_config,
+        pg_config,
+        es_config,
         // we create the legacy tenant using the silo API,
         // there are separate tests for the testing the migration
-        None, 128,
+        None,
+        TEST_EMBEDDING_SIZE,
     )
     .await?;
     silo.admin_as_mt_user_hack().await?;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -677,7 +677,7 @@ async fn setup_web_dev_services(
         pg_config, es_config,
         // we create the legacy tenant using the silo API,
         // there are separate tests for the testing the migration
-        None,
+        None, 128,
     )
     .await?;
     silo.admin_as_mt_user_hack().await?;

--- a/web-api-db-ctrl/src/elastic.rs
+++ b/web-api-db-ctrl/src/elastic.rs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use anyhow::bail;
 use once_cell::sync::Lazy;
 use reqwest::{Method, StatusCode};
 use serde_json::{json, Value};
@@ -23,11 +24,16 @@ use crate::Error;
 static MAPPING_STR: &str = include_str!("../elasticsearch/mapping.json");
 static MAPPING: Lazy<Value> = Lazy::new(|| serde_json::from_str(MAPPING_STR).unwrap());
 
-pub async fn create_tenant_index(elastic: &Client, new_id: &TenantId) -> Result<(), Error> {
+pub async fn create_tenant_index(
+    elastic: &Client,
+    new_id: &TenantId,
+    embedding_size: usize,
+) -> Result<(), Error> {
+    let mapping = mapping_with_embedding_size(&MAPPING, embedding_size)?;
     elastic
         .with_index(new_id)
         .request(Method::PUT, [], [])
-        .json(&*MAPPING)
+        .json(&mapping)
         .send()
         .await?
         .error_for_status()?;
@@ -50,11 +56,12 @@ pub(crate) async fn setup_legacy_tenant(
     elastic: &Client,
     default_index: &str,
     tenant_id: &TenantId,
+    embedding_size: usize,
 ) -> Result<(), Error> {
     if does_tenant_index_exist(elastic, default_index).await? {
         create_index_alias(elastic, default_index, tenant_id).await?;
     } else {
-        create_tenant_index(elastic, tenant_id).await?;
+        create_tenant_index(elastic, tenant_id, embedding_size).await?;
     }
 
     Ok(())
@@ -63,13 +70,14 @@ pub(crate) async fn setup_legacy_tenant(
 pub(crate) async fn migrate_tenant_index(
     elastic: &Client,
     tenant_id: &TenantId,
+    embedding_size: usize,
 ) -> Result<(), Error> {
     if !does_tenant_index_exist(elastic, tenant_id).await? {
         error!(
             {%tenant_id},
             "index for tenant doesn't exist, creating a new index"
         );
-        create_tenant_index(elastic, tenant_id).await?;
+        create_tenant_index(elastic, tenant_id, embedding_size).await?;
     }
     //FIXME code to check if the index is a super-set of the expected index
     //FIXME code for allowing updates to the ES schema, at least if
@@ -120,4 +128,54 @@ async fn create_index_alias(
         .error_for_status()?;
     info!({%index, %alias}, "created ES alias");
     Ok(())
+}
+
+fn mapping_with_embedding_size(mapping: &Value, embedding_size: usize) -> Result<Value, Error> {
+    let mut mapping = mapping.clone();
+    if let Some(dims) = mapping
+        .get_mut("mappings")
+        .and_then(|obj| obj.get_mut("properties"))
+        .and_then(|obj| obj.get_mut("embedding"))
+        .and_then(|obj| obj.get_mut("dims"))
+    {
+        *dims = embedding_size.into();
+    } else {
+        bail!("unexpected ES mapping structure can't set embedding.dims")
+    }
+    Ok(mapping)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_setting_embedding_dims_works() {
+        assert_eq!(
+            mapping_with_embedding_size(&MAPPING, 4321).unwrap(),
+            json!({
+                "mappings": {
+                    "properties": {
+                        "snippet": {
+                            "type": "text"
+                        },
+                        "embedding": {
+                            "type": "dense_vector",
+                            "dims": 4321,
+                            "index": true,
+                            "similarity": "dot_product"
+                        },
+                        "properties": {
+                            "dynamic": false,
+                            "properties": {
+                                "publication_date": {
+                                    "type": "date"
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        )
+    }
 }

--- a/web-api/src/app.rs
+++ b/web-api/src/app.rs
@@ -24,6 +24,7 @@ use tracing::info;
 
 pub(crate) use self::state::{AppState, TenantState};
 use crate::{
+    embedding,
     logging,
     net::{self, AppHandle},
     storage,
@@ -38,6 +39,7 @@ pub trait Application: 'static {
         + AsRef<net::Config>
         + AsRef<storage::Config>
         + AsRef<tenants::Config>
+        + AsRef<embedding::Config>
         + DeserializeOwned
         + Serialize
         + Send

--- a/web-api/src/app/state.rs
+++ b/web-api/src/app/state.rs
@@ -28,6 +28,7 @@ use xayn_web_api_shared::request::TenantId;
 
 use crate::{
     app::{Application, SetupError},
+    embedding::Embedder,
     error::common::InternalError,
     middleware::request_context::RequestContext,
     storage::{initialize_silo, Storage, StorageBuilder},
@@ -41,6 +42,7 @@ where
 {
     #[as_ref(forward)]
     pub(crate) config: A::Config,
+    pub(crate) embedder: Embedder,
     #[deref]
     pub(crate) extension: A::Extension,
     storage_builder: Arc<StorageBuilder>,
@@ -63,12 +65,13 @@ where
 
     pub(super) async fn create(config: A::Config) -> Result<Self, SetupError> {
         let extension = A::create_extension(&config)?;
-        let embedding_size = 128; // TODO[pmk/now] get from emebedder by moving embedder out of extension
+        let embedder = Embedder::load(config.as_ref())?;
         let (silo, legacy_tenant) =
-            initialize_silo(config.as_ref(), config.as_ref(), embedding_size).await?;
+            initialize_silo(config.as_ref(), config.as_ref(), embedder.embedding_size()).await?;
         let storage_builder = Arc::new(Storage::builder(config.as_ref(), legacy_tenant).await?);
         Ok(Self {
             config,
+            embedder,
             extension,
             storage_builder,
             silo: Arc::new(silo),

--- a/web-api/src/app/state.rs
+++ b/web-api/src/app/state.rs
@@ -63,7 +63,9 @@ where
 
     pub(super) async fn create(config: A::Config) -> Result<Self, SetupError> {
         let extension = A::create_extension(&config)?;
-        let (silo, legacy_tenant) = initialize_silo(config.as_ref(), config.as_ref()).await?;
+        let embedding_size = 128; // TODO[pmk/now] get from emebedder by moving embedder out of extension
+        let (silo, legacy_tenant) =
+            initialize_silo(config.as_ref(), config.as_ref(), embedding_size).await?;
         let storage_builder = Arc::new(Storage::builder(config.as_ref(), legacy_tenant).await?);
         Ok(Self {
             config,

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -76,4 +76,8 @@ impl Embedder {
 
         Ok(Embedder { bert })
     }
+
+    fn embedding_size(&self) -> usize {
+        self.bert.embedding_size()
+    }
 }

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -77,7 +77,7 @@ impl Embedder {
         Ok(Embedder { bert })
     }
 
-    fn embedding_size(&self) -> usize {
+    pub(crate) fn embedding_size(&self) -> usize {
         self.bert.embedding_size()
     }
 }

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     app::{self, Application, SetupError},
-    embedding::{self, Embedder},
+    embedding,
     logging,
     net,
     storage,
@@ -41,10 +41,8 @@ impl Application for Ingestion {
         routes::configure_service(config);
     }
 
-    fn create_extension(config: &Self::Config) -> Result<Self::Extension, SetupError> {
-        Ok(Extension {
-            embedder: Embedder::load(&config.embedding)?,
-        })
+    fn create_extension(_config: &Self::Config) -> Result<Self::Extension, SetupError> {
+        Ok(Extension {})
     }
 }
 
@@ -76,6 +74,4 @@ impl Default for IngestionConfig {
 }
 
 #[derive(AsRef)]
-pub struct Extension {
-    pub(crate) embedder: Embedder,
-}
+pub struct Extension {}

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -25,7 +25,7 @@ use xayn_ai_coi::{CoiConfig, CoiSystem};
 pub use self::{rerank::bench_rerank, stateless::bench_derive_interests};
 use crate::{
     app::{self, Application, SetupError},
-    embedding::{self, Embedder},
+    embedding,
     logging,
     net,
     storage,
@@ -48,7 +48,6 @@ impl Application for Personalization {
     fn create_extension(config: &Self::Config) -> Result<Self::Extension, SetupError> {
         Ok(Extension {
             coi: config.coi.clone().build(),
-            embedder: Embedder::load(&config.embedding)?,
         })
     }
 }
@@ -135,5 +134,4 @@ impl Default for SemanticSearchConfig {
 #[derive(AsRef)]
 pub struct Extension {
     pub(crate) coi: CoiSystem,
-    pub(crate) embedder: Embedder,
 }

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -254,6 +254,7 @@ impl Storage {
 pub(crate) async fn initialize_silo(
     config: &Config,
     tenant_config: &tenants::Config,
+    embedding_size: usize,
 ) -> Result<(Silo, Option<TenantId>), SetupError> {
     let silo = Silo::new(
         config.postgres.clone(),
@@ -263,6 +264,7 @@ pub(crate) async fn initialize_silo(
             .then(|| LegacyTenantInfo {
                 es_index: config.elastic.index_name.clone(),
             }),
+        embedding_size,
     )
     .await?;
 

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -32,6 +32,7 @@ use xayn_integration_tests::{
     start_test_service_containers,
     TestId,
     MANAGEMENT_DB,
+    TEST_EMBEDDING_SIZE,
 };
 use xayn_test_utils::env::clear_env;
 use xayn_web_api::{config, start, Ingestion, Personalization};
@@ -69,7 +70,12 @@ fn test_if_the_initializations_work_correctly_for_legacy_tenants() {
         let es_client = elastic::Client::new(es_config.clone())?;
         let legacy_elastic_index_as_tenant_id =
             TenantId::try_parse_ascii(es_config.index_name.as_bytes())?;
-        elastic_create_tenant(&es_client, &legacy_elastic_index_as_tenant_id, 128).await?;
+        elastic_create_tenant(
+            &es_client,
+            &legacy_elastic_index_as_tenant_id,
+            TEST_EMBEDDING_SIZE,
+        )
+        .await?;
 
         let user_id = "foo_boar";
         let last_seen = Utc.with_ymd_and_hms(2023, 2, 2, 3, 3, 3).unwrap();
@@ -89,7 +95,7 @@ fn test_if_the_initializations_work_correctly_for_legacy_tenants() {
             Some(LegacyTenantInfo {
                 es_index: default_es_index,
             }),
-            128,
+            TEST_EMBEDDING_SIZE,
         )
         .await?;
         silo.admin_as_mt_user_hack().await?;
@@ -125,7 +131,7 @@ fn test_if_the_initializations_work_correctly_for_not_setup_legacy_tenants() {
             Some(LegacyTenantInfo {
                 es_index: default_es_index,
             }),
-            128,
+            TEST_EMBEDDING_SIZE,
         )
         .await?;
         silo.admin_as_mt_user_hack().await?;

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -69,7 +69,7 @@ fn test_if_the_initializations_work_correctly_for_legacy_tenants() {
         let es_client = elastic::Client::new(es_config.clone())?;
         let legacy_elastic_index_as_tenant_id =
             TenantId::try_parse_ascii(es_config.index_name.as_bytes())?;
-        elastic_create_tenant(&es_client, &legacy_elastic_index_as_tenant_id).await?;
+        elastic_create_tenant(&es_client, &legacy_elastic_index_as_tenant_id, 128).await?;
 
         let user_id = "foo_boar";
         let last_seen = Utc.with_ymd_and_hms(2023, 2, 2, 3, 3, 3).unwrap();
@@ -89,6 +89,7 @@ fn test_if_the_initializations_work_correctly_for_legacy_tenants() {
             Some(LegacyTenantInfo {
                 es_index: default_es_index,
             }),
+            128,
         )
         .await?;
         silo.admin_as_mt_user_hack().await?;
@@ -124,6 +125,7 @@ fn test_if_the_initializations_work_correctly_for_not_setup_legacy_tenants() {
             Some(LegacyTenantInfo {
                 es_index: default_es_index,
             }),
+            128,
         )
         .await?;
         silo.admin_as_mt_user_hack().await?;


### PR DESCRIPTION
 - move `Embedder` from extension to app state
 - use `Embedder.embedding_size()` as `dims` value in the ES mapping

**References:**

- issue [ET-4520]

[ET-4520]: https://xainag.atlassian.net/browse/ET-4520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ