### PR TITLE
[Merged by Bors] - ET-4531 Use xaynia2 as default model

### DIFF
--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -51,6 +51,7 @@ if [ $# -gt 0 ]; then
     done
 else
     download xaynia v0002
+    download smbert v0003
     download smbert_mocked v0003
     download sjbert v0003
     download smroberta_tokenizer v0000

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -50,7 +50,7 @@ if [ $# -gt 0 ]; then
         shift 2
     done
 else
-    download smbert v0003
+    download xaynia v0002
     download smbert_mocked v0003
     download sjbert v0003
     download smroberta_tokenizer v0000

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -633,10 +633,11 @@ where
 /// Embedding size used by the `Embedder` used for testing.
 pub const TEST_EMBEDDING_SIZE: usize = 384;
 
-pub fn build_test_config_from_parts(
+pub fn build_test_config_from_parts_and_model(
     pg_config: &postgres::Config,
     es_config: &elastic::Config,
     configure: Table,
+    model_name: &str,
 ) -> Table {
     let pg_password = pg_config.password.expose_secret().as_str();
     let pg_config = Value::try_from(pg_config).unwrap();
@@ -645,7 +646,7 @@ pub fn build_test_config_from_parts(
     // Hint: Relative path doesn't work with `cargo flamegraph`
     let embedding_dir = PROJECT_ROOT
         .join("assets")
-        .join("xaynia_v0002")
+        .join(model_name)
         .display()
         .to_string();
 
@@ -670,6 +671,14 @@ pub fn build_test_config_from_parts(
     extend_config(&mut config, configure);
 
     config
+}
+
+pub fn build_test_config_from_parts(
+    pg_config: &postgres::Config,
+    es_config: &elastic::Config,
+    configure: Table,
+) -> Table {
+    build_test_config_from_parts_and_model(pg_config, es_config, configure, "xaynia_v0002")
 }
 
 #[derive(Clone, Debug, Display, Deref, AsRef)]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -631,7 +631,7 @@ where
 }
 
 /// Embedding size used by the `Embedder` used for testing.
-pub const TEST_EMBEDDING_SIZE: usize = 128;
+pub const TEST_EMBEDDING_SIZE: usize = 384;
 
 pub fn build_test_config_from_parts(
     pg_config: &postgres::Config,
@@ -645,7 +645,7 @@ pub fn build_test_config_from_parts(
     // Hint: Relative path doesn't work with `cargo flamegraph`
     let embedding_dir = PROJECT_ROOT
         .join("assets")
-        .join("smbert_v0003")
+        .join("xaynia_v0002")
         .display()
         .to_string();
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -582,7 +582,7 @@ fn build_client(services: &Services) -> Arc<Client> {
     Arc::new(
         Client::builder()
             .default_headers(default_headers)
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
             .build()
             .unwrap(),
     )

--- a/justfile
+++ b/justfile
@@ -146,9 +146,9 @@ web-dev-up:
         echo "web-dev composition is already running, SKIPPING STARTUP"
         exit 0
     fi
-    if [[ "$(ls -l web-api/assets | grep 'assets/smbert_v0003' | wc -l)" == "0" ]]; then
+    if [[ "$(ls -l web-api/assets | grep 'assets/xaynia_v0002' | wc -l)" == "0" ]]; then
         rm "./web-api/assets" || :
-        ln -s "./assets/smbert_v0003" "./web-api/assets"
+        ln -s "./assets/xaynia_v0002" "./web-api/assets"
     fi
     export HOST_PORT_SCOPE=30
     docker-compose -p "$PROJECT" -f "./web-api/compose.db.yml" up --detach --remove-orphans --build
@@ -190,7 +190,7 @@ build-ci-image $IMAGE_NAME $IMAGE_TAG:
       --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
       - < .github/docker/Dockerfile.ci-image
 
-compose-all-build $SMBERT="smbert_v0003":
+compose-all-build $SMBERT="xaynia_v0002":
     #!/usr/bin/env -S bash -eux -o pipefail
     {{just_executable()}} build-service-image web-api personalization
     {{just_executable()}} build-service-image web-api ingestion "assets/$SMBERT"

--- a/test-utils/src/asset.rs
+++ b/test-utils/src/asset.rs
@@ -38,7 +38,7 @@ fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
 
 /// Resolves the path to the smbert.
 pub fn smbert() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "smbert_v0003"])
+    resolve_path(&[DATA_DIR, "xaynia_v0002"])
 }
 
 /// Resolves the path to the mocked smbert.

--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -6,7 +6,7 @@
             },
             "embedding": {
                 "type": "dense_vector",
-                "dims": 128,
+                "dims": 384,
                 "index": true,
                 "similarity": "dot_product"
             },

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -44,7 +44,7 @@ pub(super) struct State {
 impl State {
     pub(super) fn new(storage: Storage, config: StateConfig) -> Result<Self, Panic> {
         let embedder = Embedder::load(&embedding::Config {
-            directory: "../assets/smbert_v0003".into(),
+            directory: "../assets/xaynia_v0002".into(),
             ..embedding::Config::default()
         })
         .map_err(|error| Panic::from(&*error))?;

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -23,7 +23,7 @@ use sqlx::{Connection, Executor, PgConnection};
 use toml::Table;
 use tracing::{info, instrument};
 use xayn_integration_tests::{
-    build_test_config_from_parts,
+    build_test_config_from_parts_and_model,
     create_db,
     db_configs_for_testing,
     run_async_test,
@@ -181,7 +181,12 @@ fn test_full_migration() {
         info!("entered async test");
 
         let (pg_config, es_config) = legacy_test_setup(&test_id).await?;
-        let config = build_test_config_from_parts(&pg_config, &es_config, Table::new());
+        let config = build_test_config_from_parts_and_model(
+            &pg_config,
+            &es_config,
+            Table::new(),
+            "smbert_v0003",
+        );
 
         info!("test setup done");
 

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -181,7 +181,7 @@ fn test_personalization_all_dates() {
             let documents = personalize(&client, &personalization_url, None, None).await?;
             assert_order!(
                 &documents,
-                ["d8", "d6", "d1", "d7", "d3"],
+                ["d8", "d6", "d1", "d3"],
                 "unexpected personalized documents: {documents:?}",
             );
             Ok(())
@@ -229,7 +229,7 @@ fn test_personalization_with_query() {
             .await?;
             assert_order!(
                 &documents,
-                ["d8", "d6", "d1", "d7"],
+                ["d8", "d6", "d1"],
                 "unexpected personalized documents: {documents:?}",
             );
             Ok(())
@@ -247,7 +247,7 @@ fn test_personalization_with_tags() {
             let documents = personalize(&client, &personalization_url, None, None).await?;
             assert_order!(
                 &documents,
-                ["d5", "d6", "d4", "d1", "d8"],
+                ["d5", "d6", "d1", "d8"],
                 "unexpected personalized documents: {documents:?}",
             );
             Ok(())

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -123,7 +123,7 @@ fn test_full_personalization() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d2", "d5", "d7"],
+                ["d6", "d4", "d2", "d5", "d8"],
                 "unexpected not enough interactions documents: {documents:?}",
             );
 
@@ -143,7 +143,7 @@ fn test_full_personalization() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d2", "d5", "d7"],
+                ["d6", "d4", "d2", "d5", "d8"],
                 "unexpected not personalized documents: {documents:?}",
             );
 
@@ -162,7 +162,7 @@ fn test_full_personalization() {
             .await;
             assert_order!(
                 documents,
-                ["d8", "d5", "d4", "d6", "d7"],
+                ["d8", "d6", "d5", "d4", "d7"],
                 "unexpected fully personalized documents: {documents:?}",
             );
 
@@ -198,7 +198,7 @@ fn test_subtle_personalization() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d5", "d7", "d8"],
+                ["d6", "d4", "d5", "d8", "d7"],
                 "unexpected subtle personalized documents: {documents:?}",
             );
 
@@ -233,7 +233,7 @@ fn test_full_personalization_with_inline_history() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d2", "d5", "d7"],
+                ["d6", "d4", "d2", "d5", "d8"],
                 "unexpected not enough interactions documents: {documents:?}",
             );
 
@@ -251,7 +251,7 @@ fn test_full_personalization_with_inline_history() {
             .await;
             assert_order!(
                 documents,
-                ["d6", "d4", "d2", "d5", "d7"],
+                ["d6", "d4", "d2", "d5", "d8"],
                 "unexpected not personalized documents: {documents:?}",
             );
 
@@ -270,7 +270,7 @@ fn test_full_personalization_with_inline_history() {
             .await;
             assert_order!(
                 documents,
-                ["d8", "d5", "d4", "d6", "d7"],
+                ["d8", "d6", "d5", "d4", "d7"],
                 "unexpected fully personalized documents: {documents:?}",
             );
 


### PR DESCRIPTION
Use Xaynia 2 as the default model of the model.
Unfortunately changing the token size will be a breaking change for some deployments so it cannot be done in this PR but we need to wait for each deployment to configure that explicitly. Later we should also remove defaults that can easily break backward compatibility.