### PR TITLE
[Merged by Bors] - ET-4535 error on update during ingestion

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -56,7 +56,7 @@ paths:
         **Important note:** Currently we allow up to a maximum of 100 documents per batch size. If you need to add more, then
         please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
 
-        **Important note:** If a document id appears multiple times, only the first document with that id is retained.
+        **Important note:** If a document id appears multiple times, only the last document with that id is retained.
 
         **Important note:** Documents which have no `publication_date` are not included when using the `published_after` filter.
       operationId: createDocuments

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -56,6 +56,8 @@ paths:
         **Important note:** Currently we allow up to a maximum of 100 documents per batch size. If you need to add more, then
         please split up the total amount of documents in separate calls, where each call contains at maximum 100 documents.
 
+        **Important note:** If a document id appears multiple times, only the first document with that id is retained.
+
         **Important note:** Documents which have no `publication_date` are not included when using the `published_after` filter.
       operationId: createDocuments
       requestBody:

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -304,8 +304,8 @@ fn test_ingestion_same_id() {
                 .json(&json!({
                     "documents": [
                         { "id": "d1", "snippet": "snippet 1", "properties": { "order": 1 } },
-                        { "id": "d1", "snippet": "snippet 2", "properties": { "order": 2 } },
-                        { "id": "d2", "snippet": "snippet 3", "properties": { "order": 3 } }
+                        { "id": "d2", "snippet": "snippet 2", "properties": { "order": 2 } },
+                        { "id": "d1", "snippet": "snippet 3", "properties": { "order": 3 } }
                     ]
                 }))
                 .build()?,
@@ -320,7 +320,7 @@ fn test_ingestion_same_id() {
             StatusCode::OK,
         )
         .await;
-        assert_eq!(property, 1);
+        assert_eq!(property, 3);
         let OrderPropertyResponse { property } = send_assert_json(
             &client,
             client
@@ -329,7 +329,7 @@ fn test_ingestion_same_id() {
             StatusCode::OK,
         )
         .await;
-        assert_eq!(property, 3);
+        assert_eq!(property, 2);
         Ok(())
     });
 }


### PR DESCRIPTION
**Reference**

- [ET-4535]

**Summary**

- only retain the ~first~ last of identical ids during ingestion
- update backoffice docs
- add a regression test


[ET-4535]: https://xainag.atlassian.net/browse/ET-4535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ