### PR TITLE
[Merged by Bors] - ET-4550 validate publication date

### DIFF
--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -180,7 +180,7 @@ impl UnvalidatedIngestedDocument {
                 .properties
                 .into_iter()
                 .map(|(id, property)| id.try_into().map(|id| (id, property)))
-                .try_collect::<_, HashMap<_, _>, _>()?;
+                .try_collect::<_, DocumentProperties, _>()?;
             if let Some(publication_date) = properties.get("publication_date") {
                 if let Some(publication_date) = publication_date.as_str() {
                     DateTime::parse_from_rfc3339(publication_date)?;

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -12,9 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use std::{borrow::Borrow, collections::HashMap};
 
-use derive_more::{AsRef, Display, Into};
+use derive_more::{AsRef, Deref, Display, Into};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -87,6 +87,12 @@ macro_rules! id_wrapper {
                     <String as PgHasArrayType>::array_type_info()
                 }
             }
+
+            impl Borrow<str> for $name {
+                fn borrow(&self) -> &str {
+                    self.as_ref()
+                }
+            }
         )*
     };
 }
@@ -110,7 +116,7 @@ id_wrapper! {
     pub(crate) DocumentTag, InvalidDocumentTag, is_valid_tag;
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deref, Deserialize, PartialEq, Serialize)]
 #[serde(transparent)]
 pub(crate) struct DocumentProperty(serde_json::Value);
 


### PR DESCRIPTION
**Reference**

- [ET-4550]

**Summary**

- if a `publication_date` is part of the ingested document properties, then validate it according to the spec


[ET-4550]: https://xainag.atlassian.net/browse/ET-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ