### PR TITLE
ET-4563 remove hybrid search from personalized documents endpoint

### DIFF
--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -138,7 +138,6 @@ impl PersonalizeBy<'_> {
         Self::KnnSearch {
             count,
             published_after: None,
-            query: None,
         }
     }
 }

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -28,18 +28,17 @@ use crate::{
 };
 
 /// KNN search based on Centers of Interest.
-pub(super) struct CoiSearch<'a, I, J> {
+pub(super) struct CoiSearch<I, J> {
     pub(super) interests: I,
     pub(super) excluded: J,
     pub(super) horizon: Duration,
     pub(super) max_cois: usize,
     pub(super) count: usize,
     pub(super) published_after: Option<DateTime<Utc>>,
-    pub(super) query: Option<&'a str>,
     pub(super) time: DateTime<Utc>,
 }
 
-impl<'a, I, J> CoiSearch<'a, I, J>
+impl<'a, I, J> CoiSearch<I, J>
 where
     I: IntoIterator,
     <I as IntoIterator>::IntoIter: Clone + Iterator<Item = &'a PositiveCoi>,
@@ -86,7 +85,7 @@ where
                         num_candidates,
                         published_after: self.published_after,
                         min_similarity: None,
-                        query: self.query,
+                        query: None,
                         time: self.time,
                     },
                 )
@@ -151,7 +150,6 @@ mod tests {
             max_cois: PersonalizationConfig::default().max_cois_for_knn,
             count: 10,
             published_after: None,
-            query: None,
             time: Utc::now(),
         }
         .run_on(&storage)


### PR DESCRIPTION
**Reference**

- [ET-4563]

**Summary**

- remove hybrid search option from `/users/{id}/personalized_document` endpoint
