### PR TITLE
Fix migration unchanged check

### DIFF
--- a/justfile
+++ b/justfile
@@ -238,13 +238,17 @@ validate-openapi:
 
 validate-migrations-unchanged cmp_ref:
     #!/usr/bin/env -S bash -eu -o pipefail
-    if ! git rev-list "{{ cmp_ref }}".."{{ cmp_ref }}"; then
-        git fetch --depth=1 "$(git remote get-url origin)" "{{ cmp_ref }}"
+    if ! git rev-parse --verify "{{cmp_ref}}"; then
+        git fetch --depth=1 origin "{{cmp_ref}}:{{cmp_ref}}"
+        if ! git rev-parse --verify "{{cmp_ref}}"; then
+          echo "ref '{{cmp_ref}}' dosen't exists after fetch"
+          exit 1
+        fi
     fi
 
     changed_migrations=( $(\
         git diff --name-only "{{ cmp_ref }}" | \
-        grep -E "^web-api/migrations/.*" \
+        grep -E "^web-api-db-ctrl/postgres/.*" \
     ) ) || true
 
     if [ "${#changed_migrations[@]}" -gt 0 ]; then


### PR DESCRIPTION
Try to fix the check of unchanged migrations.
Fix the path to the migrations.
If an empty ref is passed it fails.
`git fetch` creates a local name that is usable from `git diff` or it fails. Previously fetch didn't create a local name and `git diff` was failing because of it but ok was returned.

Pending problem:
If a new migration is added it fails. See #970.
