### PR TITLE
ET-4591 no tenant middleware for silo management

### DIFF
--- a/web-api/src/app.rs
+++ b/web-api/src/app.rs
@@ -54,6 +54,13 @@ pub trait Application: 'static {
     /// application specific middleware.
     fn configure_service(config: &mut ServiceConfig);
 
+    /// Configures service(s) used by operations.
+    ///
+    /// Services defined here will not be wrapped in the normal
+    /// application middleware and will not be reachable using anything
+    /// which uses CORS.
+    fn configure_ops_service(_config: &mut ServiceConfig) {}
+
     /// Create an application specific extension to app state.
     //Design Note: We could handle this by adding `TyFrom<&Config<..>>` bounds
     //             to `Extension` but using this helper method is simpler
@@ -89,6 +96,8 @@ where
         net_config,
         legacy_tenant,
         move |service| app_state.clone().attach_to(service),
+        A::configure_service,
+        A::configure_ops_service,
         shutdown,
     )
 }

--- a/web-api/src/app/state.rs
+++ b/web-api/src/app/state.rs
@@ -56,8 +56,7 @@ where
         service
             .app_data(self.storage_builder.clone())
             .app_data(Data::from(self.silo.clone()))
-            .app_data(Data::from(self))
-            .configure(A::configure_service);
+            .app_data(Data::from(self));
     }
 
     pub(super) async fn create(config: A::Config) -> Result<Self, SetupError> {

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -41,6 +41,10 @@ impl Application for Ingestion {
         routes::configure_service(config);
     }
 
+    fn configure_ops_service(config: &mut ServiceConfig) {
+        routes::configure_ops_service(config);
+    }
+
     fn create_extension(_config: &Self::Config) -> Result<Self::Extension, SetupError> {
         Ok(Extension {})
     }

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -76,8 +76,11 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
                 .route(web::get().to(get_document_property))
                 .route(web::put().to(put_document_property))
                 .route(web::delete().to(delete_document_property)),
-        )
-        .service(web::resource("/_silo_management").route(web::post().to(silo_management)));
+        );
+}
+
+pub(super) fn configure_ops_service(config: &mut ServiceConfig) {
+    config.service(web::resource("/silo_management").route(web::post().to(silo_management)));
 }
 
 fn deserialize_string_not_empty_or_zero_bytes<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/web-api/tests/silo_management_api.rs
+++ b/web-api/tests/silo_management_api.rs
@@ -40,7 +40,7 @@ fn test_tenants_can_be_created() {
             let make_id = |suffix| format!("{test_id}_{suffix}").parse::<TenantId>();
             let ManagementResponse { results } = send_assert_json(
                 &client,
-                client.post(url.join("_silo_management")?).json(&json!({
+                client.post(url.join("/_ops/silo_management")?).json(&json!({
                     "operations": [
                         { "CreateTenant": { "tenant_id": make_id("1")? }},
                         { "CreateTenant": { "tenant_id": make_id("3")?, "is_legacy_tenant": true }},


### PR DESCRIPTION
Do not run tenant/app specific middleware for the silo management endpoint.

Mainly do not require the `X-Xayn-Tenant-Id` header.

**References:**

- [ET-4591]

[ET-4591]: https://xainag.atlassian.net/browse/ET-4591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ