### PR TITLE
ET-4630-fix-dynamic-setting

### DIFF
--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -11,6 +11,9 @@
                 "index": true,
                 "similarity": "dot_product"
             },
+            "tags": {
+                "type": "keyword"
+            },
             "properties": {
                 "dynamic": false,
                 "properties": {

--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -12,7 +12,7 @@
                 "similarity": "dot_product"
             },
             "properties": {
-                "dynamic": "runtime",
+                "dynamic": false,
                 "properties": {
                     "publication_date": {
                         "type": "date"

--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -1,5 +1,6 @@
 {
     "mappings": {
+        "dynamic": "strict",
         "properties": {
             "snippet": {
                 "type": "text"
@@ -11,7 +12,7 @@
                 "similarity": "dot_product"
             },
             "properties": {
-                "dynamic": false,
+                "dynamic": "runtime",
                 "properties": {
                     "publication_date": {
                         "type": "date"


### PR DESCRIPTION
This PR does two things:

- set `dynamic` to `strict` for the outer most object as it allows us to find bugs in our code 
  - add a definition for `tags` to the `mapping` 
- ~set `dynamic` to `runtime` for property fields so that they can be indexed in the future, this is fixing problems with a new filter by properties functionality~

**References:** 

- [ET-4630]

[ET-4630]: https://xainag.atlassian.net/browse/ET-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ