### PR TITLE
ET-4628 move candidates endpoint

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -1,6 +1,6 @@
 const ibmCloudValidationRules = require('@ibm-cloud/openapi-ruleset');
-const { enumCaseConvention, operationIdCaseConvention } = require('@ibm-cloud/openapi-ruleset/src/functions');
-const { schemas } = require('@ibm-cloud/openapi-ruleset/src/collections');
+const { enumCaseConvention, pathSegmentCaseConvention } = require('@ibm-cloud/openapi-ruleset/src/functions');
+const { paths, schemas } = require('@ibm-cloud/openapi-ruleset/src/collections');
 
 module.exports = {
   extends: ibmCloudValidationRules,
@@ -28,6 +28,23 @@ module.exports = {
         function: enumCaseConvention,
         functionOptions: {
           type: 'pascal',
+        },
+      },
+    },
+    'path-segment-case-convention': {
+      description: 'Path segments must be snake case',
+      message: '{{error}}',
+      resolved: true,
+      given: paths,
+      severity: 'error',
+      then: {
+        function: pathSegmentCaseConvention,
+        functionOptions: {
+          type: 'snake',
+          separator: {
+            char: '_',
+            allowLeading: true
+          }
         },
       },
     },

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -93,14 +93,13 @@ paths:
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
-  /documents/candidates:
+  /documents/_candidates:
     get:
       tags:
         - back office
-      deprecated: true
-      operationId: listDocumentCandidatesDeprecated
       summary: Get the documents considered for recommendations.
       description: Get the documents considered for recommendations.
+      operationId: listDocumentCandidates
       responses:
         '200':
           description: successful operation
@@ -113,10 +112,9 @@ paths:
     put:
       tags:
         - back office
-      deprecated: true
-      operationId: replaceDocumentCandidatesDeprecated
       summary: Set the documents considered for recommendations.
       description: Set the documents considered for recommendations.
+      operationId: replaceDocumentCandidates
       requestBody:
         required: true
         content:
@@ -239,40 +237,6 @@ paths:
       summary: Delete a document property
       description: Deletes the property of the document.
       operationId: deleteDocumentProperty
-      responses:
-        '204':
-          description: successful operation
-        '400':
-          $ref: './responses/generic.yml#/BadRequest'
-
-  /candidates:
-    get:
-      tags:
-        - back office
-      summary: Get the documents considered for recommendations.
-      description: Get the documents considered for recommendations.
-      operationId: listDocumentCandidates
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DocumentCandidatesResponse'
-        '400':
-          $ref: './responses/generic.yml#/BadRequest'
-    put:
-      tags:
-        - back office
-      summary: Set the documents considered for recommendations.
-      description: Set the documents considered for recommendations.
-      operationId: replaceDocumentCandidates
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DocumentCandidatesRequest'
       responses:
         '204':
           description: successful operation

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -58,17 +58,12 @@ use crate::{
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     config
         .service(
-            web::resource("/candidates")
-                .route(web::get().to(get_document_candidates))
-                .route(web::put().to(set_document_candidates)),
-        )
-        .service(
             web::resource("/documents")
                 .route(web::post().to(upsert_documents))
                 .route(web::delete().to(delete_documents)),
         )
         .service(
-            web::resource("/documents/candidates")
+            web::resource("/documents/_candidates")
                 .route(web::get().to(get_document_candidates))
                 .route(web::put().to(set_document_candidates)),
         )
@@ -84,6 +79,17 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
                 .route(web::get().to(get_document_property))
                 .route(web::put().to(put_document_property))
                 .route(web::delete().to(delete_document_property)),
+        )
+        // all routes below are deprecated and undocumented and will be removed in the future
+        .service(
+            web::resource("/candidates")
+                .route(web::get().to(get_document_candidates))
+                .route(web::put().to(set_document_candidates)),
+        )
+        .service(
+            web::resource("/documents/candidates")
+                .route(web::get().to(get_document_candidates))
+                .route(web::put().to(set_document_candidates)),
         );
 }
 

--- a/web-api/tests/document_candidates.rs
+++ b/web-api/tests/document_candidates.rs
@@ -53,7 +53,7 @@ impl DocumentCandidatesResponse {
 }
 
 async fn get(client: &Client, url: &Url) -> Result<DocumentCandidatesResponse, Error> {
-    let request = client.get(url.join("/documents/candidates")?).build()?;
+    let request = client.get(url.join("/documents/_candidates")?).build()?;
     let response = send_assert_json(client, request, StatusCode::OK).await;
 
     Ok(response)
@@ -61,7 +61,7 @@ async fn get(client: &Client, url: &Url) -> Result<DocumentCandidatesResponse, E
 
 async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) -> Result<(), Error> {
     let request = client
-        .put(url.join("/documents/candidates")?)
+        .put(url.join("/documents/_candidates")?)
         .json(&json!({ "documents": ids.into_iter().map(|id| json!({ "id": id })).collect_vec() }))
         .build()?;
     send_assert(client, request, StatusCode::NO_CONTENT).await;
@@ -159,7 +159,7 @@ fn test_candidates_warning() {
         let error = send_assert_json::<ServerError>(
             &client,
             client
-                .put(url.join("/documents/candidates")?)
+                .put(url.join("/documents/_candidates")?)
                 .json(&json!({
                     "documents": [
                         { "id": "d1" },

--- a/web-api/tests/health.rs
+++ b/web-api/tests/health.rs
@@ -19,7 +19,7 @@ use xayn_integration_tests::{send_assert, test_app, UNCHANGED_CONFIG};
 use xayn_web_api::Ingestion;
 
 #[test]
-fn test_candidates_all() {
+fn test_health() {
     test_app::<Ingestion, _>(UNCHANGED_CONFIG, |_client, url, _| async move {
         // make sure not to use any presets from `test_app`, like e.g. the
         // X-Xayn-Tenant-Id header.


### PR DESCRIPTION
**Reference**

- [ET-4628]

**Summary**

- move candidates endpoint to `/documents/_candidates`
- remove spec for deprecated endpoints to avoid visibility for new customers
- add deprecation header to the response for deprecated endpoints


[ET-4628]: https://xainag.atlassian.net/browse/ET-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ