### PR TITLE
ET-4632 only include properties if requested

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -39,8 +39,8 @@ paths:
       summary: Gets personalized documents for the user.
       description: |-
         Returns a list of documents personalized for the given `user_id`.
-        Each document contains the id, the score and the properties that are attached to the document.
-        The score is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
+        Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
+        The documents also contain their properties if this is requested and the properties are not empty.
         Documents that have been interacted with by the user are filtered out from the result.
         Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.
       operationId: getPersonalizedDocuments
@@ -49,10 +49,10 @@ paths:
         - name: count
           in: query
           description:
-            $ref: "#/components/schemas/Count/description"
+            $ref: '#/components/schemas/Count/description'
           required: false
           schema:
-            $ref: "#/components/schemas/Count"
+            $ref: '#/components/schemas/Count'
         - name: published_after
           in: query
           description:
@@ -60,6 +60,13 @@ paths:
           required: false
           schema:
             $ref: './schemas/time.yml#/PublishedAfter'
+        - name: include_properties
+          in: query
+          description:
+            $ref: '#/components/schemas/IncludeProperties/description'
+          required: false
+          schema:
+            $ref: '#/components/schemas/IncludeProperties'
       responses:
         '200':
           description: successful operation
@@ -111,8 +118,8 @@ paths:
       summary: Returns documents similar to the given document.
       description: |-
         Returns a list of documents that are semantically similar to the one given as input.
-        Each document contains the id, the score and the properties.
-        The score is a value between 0 and 1 where a higher value means that the document is more similar to the one in input
+        Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document is more similar to the one in input.
+        The documents also contain their properties if this is requested and the properties are not empty.
       operationId: getSimilarDocuments
       requestBody:
         required: true
@@ -142,6 +149,10 @@ components:
       minimum: 1
       maximum: 100
       default: 10
+    IncludeProperties:
+      description: Include the properties of each document in the response
+      type: boolean
+      default: true
     PersonalizedDocumentData:
       type: object
       required: [id, score]
@@ -180,6 +191,8 @@ components:
           $ref: '#/components/schemas/Count'
         published_after:
           $ref: './schemas/time.yml#/PublishedAfter'
+        include_properties:
+          $ref: '#/components/schemas/IncludeProperties'
         personalize:
           description: Personalize the ranking of candidates based on a users preferences.
           type: object

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -91,12 +91,15 @@ impl State {
         &self,
         embeddings: Vec<(DocumentId, NormalizedEmbedding)>,
     ) -> Result<(), Panic> {
-        let mut documents =
-            storage::Document::get_personalized(&self.storage, embeddings.iter().map(|(id, _)| id))
-                .await?
-                .into_iter()
-                .map(|document| (document.id.clone(), document))
-                .collect::<HashMap<_, _>>();
+        let mut documents = storage::Document::get_personalized(
+            &self.storage,
+            embeddings.iter().map(|(id, _)| id),
+            true,
+        )
+        .await?
+        .into_iter()
+        .map(|document| (document.id.clone(), document))
+        .collect::<HashMap<_, _>>();
         let snippet = DocumentSnippet::try_from("snippet" /* unused for in-memory db */)?;
         let documents = embeddings
             .into_iter()
@@ -150,6 +153,7 @@ impl State {
             &self.personalization,
             by,
             time,
+            false,
         )
         .await
         .map(|documents| {

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -36,6 +36,7 @@ pub(super) struct CoiSearch<'a, I> {
     pub(super) count: usize,
     pub(super) published_after: Option<DateTime<Utc>>,
     pub(super) time: DateTime<Utc>,
+    pub(super) include_properties: bool,
 }
 
 impl<'a, I> CoiSearch<'a, I>
@@ -82,6 +83,7 @@ where
                         num_candidates,
                         published_after: self.published_after,
                         strategy: SearchStrategy::Knn,
+                        include_properties: self.include_properties,
                     },
                 )
                 .await
@@ -146,6 +148,7 @@ mod tests {
             count: 10,
             published_after: None,
             time: Utc::now(),
+            include_properties: false,
         }
         .run_on(&storage)
         .await

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -131,7 +131,7 @@ pub(crate) async fn update_interactions(
     Ok(())
 }
 
-const fn default_true() -> bool {
+const fn default_include_properties() -> bool {
     true
 }
 
@@ -140,7 +140,7 @@ const fn default_true() -> bool {
 struct PersonalizedDocumentsQuery {
     count: Option<usize>,
     published_after: Option<DateTime<Utc>>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_include_properties")]
     include_properties: bool,
 }
 
@@ -346,7 +346,7 @@ struct UnvalidatedSemanticSearchQuery {
     enable_hybrid_search: bool,
     #[serde(default, rename = "_dev")]
     dev: Option<DevOptions>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_include_properties")]
     include_properties: bool,
 }
 
@@ -459,9 +459,13 @@ impl UnvalidatedInputDocument {
     }
 }
 
+const fn default_exclude_seen() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize)]
 struct UnvalidatedPersonalize {
-    #[serde(default = "default_true")]
+    #[serde(default = "default_exclude_seen")]
     exclude_seen: bool,
     user: UnvalidatedInputUser,
 }

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -57,6 +57,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) num_candidates: usize,
     pub(crate) published_after: Option<DateTime<Utc>>,
     pub(super) strategy: SearchStrategy,
+    pub(super) include_properties: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -133,6 +134,7 @@ pub(crate) trait Document {
     async fn get_personalized(
         &self,
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        include_properties: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
     async fn get_excerpted(

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -12,11 +12,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
+
 use anyhow::Error;
 use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_web_api::{Ingestion, Personalization};
 
@@ -88,7 +90,7 @@ struct PersonalizedDocumentData {
     id: String,
     score: f32,
     #[serde(default)]
-    properties: serde_json::Value,
+    properties: HashMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -108,12 +110,16 @@ async fn personalize(
     client: &Client,
     personalization_url: &Url,
     published_after: Option<&str>,
+    include_properties: Option<bool>,
 ) -> Result<Vec<PersonalizedDocumentData>, Error> {
     let mut request = client
         .get(personalization_url.join("/users/u1/personalized_documents")?)
         .query(&[("count", "5")]);
     if let Some(published_after) = published_after {
         request = request.query(&[("published_after", published_after)]);
+    }
+    if let Some(include_properties) = include_properties {
+        request = request.query(&[("include_properties", &include_properties.to_string())]);
     }
     let request = request.build()?;
 
@@ -169,7 +175,7 @@ fn test_personalization_all_dates() {
         UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
-            let documents = personalize(&client, &personalization_url, None).await?;
+            let documents = personalize(&client, &personalization_url, None, None).await?;
             assert_order!(
                 &documents,
                 ["d8", "d6", "d1", "d5"],
@@ -187,8 +193,13 @@ fn test_personalization_limited_dates() {
         UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
-            let documents =
-                personalize(&client, &personalization_url, Some("2022-01-01T00:00:00Z")).await?;
+            let documents = personalize(
+                &client,
+                &personalization_url,
+                Some("2022-01-01T00:00:00Z"),
+                None,
+            )
+            .await?;
             assert_order!(
                 &documents,
                 ["d1", "d5", "d4", "d3"],
@@ -206,7 +217,7 @@ fn test_personalization_with_tags() {
         UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_tags(&client, &ingestion_url).await?;
-            let documents = personalize(&client, &personalization_url, None).await?;
+            let documents = personalize(&client, &personalization_url, None, None).await?;
             assert_order!(
                 &documents,
                 ["d5", "d6", "d1", "d8"],
@@ -215,4 +226,41 @@ fn test_personalization_with_tags() {
             Ok(())
         },
     );
+}
+
+fn personalization_include_properties(include_properties: bool) {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest_with_dates(&client, &ingestion_url).await?;
+            let documents = personalize(
+                &client,
+                &personalization_url,
+                None,
+                Some(include_properties),
+            )
+            .await?;
+            let is_empty = documents
+                .iter()
+                .map(|document| document.properties.is_empty())
+                .collect_vec();
+            if include_properties {
+                assert_eq!(is_empty, [true, false, false, false]);
+            } else {
+                assert_eq!(is_empty, [true, true, true, true]);
+            }
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_personalization_include_properties() {
+    personalization_include_properties(true);
+}
+
+#[test]
+fn test_personalization_exclude_properties() {
+    personalization_include_properties(false);
 }

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -63,9 +63,6 @@ async fn interact(client: &Client, personalization_url: &Url) -> Result<(), Erro
 struct PersonalizedDocumentData {
     id: String,
     score: f32,
-    #[allow(dead_code)]
-    #[serde(default)]
-    properties: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize)]

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -151,7 +151,8 @@ fn test_semantic_search_with_query() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "this is one sentence" },
-                        "enable_hybrid_search": true
+                        "enable_hybrid_search": true,
+                        "include_properties": true
                     }))
                     .build()?,
                 StatusCode::OK,


### PR DESCRIPTION
**Reference**

- [ET-4632]

**Summary**

- only include document properties in the fronoffice responses if they are requested via the `include_properties` flag
- default the flag to `true` for now, it will be changed to false after some time


[ET-4632]: https://xainag.atlassian.net/browse/ET-4632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ