### PR TITLE
ET-4634 don't clip document count silently

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -108,6 +108,16 @@ pub(crate) struct InvalidDocumentSnippet {
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);
 
+/// Malsized document count.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct InvalidDocumentCount {
+    pub(crate) count: usize,
+    pub(crate) min: usize,
+    pub(crate) max: usize,
+}
+
+impl_application_error!(InvalidDocumentCount => BAD_REQUEST, INFO);
+
 /// Failed to delete some documents.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct FailedToDeleteSomeDocuments {


### PR DESCRIPTION
**Reference**

- [ET-4634]

**Summary**

- don't clip the document count in front office requests silently, but return a bad request instead


[ET-4634]: https://xainag.atlassian.net/browse/ET-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ