### PR TITLE
ET-4670 limit snippet and property strings to max 2KB

### DIFF
--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -3,6 +3,7 @@
 - trim whitespace around ids, snippets, tags and string properties
 - disallow underscore prefixes in all ids and dots in property ids
 - limit properties to boolean, number, string or array of strings and a total size of 2.5KB
+- limit snippets and string properties to a total size of 2KB each
 - remove the `min_similarity` request option from the `/semantic_search` endpoint
 - move the candidates endpoint to `/documents/_candidates` and deprecate the old endpoints
 - add `include_properties` request option to the `/users/{id}/personalized_documents` and `/semantic_search` endpoints and include the document properties in the response accordingly

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -286,10 +286,11 @@ components:
           description: |
             Text that will be used to match the document against the user interests.
             Enclosing whitespace will be trimmed.
+            The length constraints are in bytes, not characters.
             If `summarize` is enabled, then the length applies to the summarized instead of the original snippet.
           type: string
           minLength: 1
-          maxLength: 1024
+          maxLength: 2048
           pattern: '^[^\x00]+$'
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -12,10 +12,11 @@ DocumentPropertyString:
   description: |
     Arbitrary string property that can be attached to a document.
     Enclosing whitespace will be trimmed.
+    The length constraints are in bytes, not characters.
   type: string
   pattern: '^[^\x00]+$'
   minLength: 1
-  maxLength: 256
+  maxLength: 2048
 
 DocumentProperty:
   description: Arbitrary property that can be attached to a document.
@@ -48,6 +49,7 @@ DocumentTag:
   description: |
     A tag of a document can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
     Enclosing whitespace will be trimmed.
+    The length constraints are in bytes, not characters.
   type: string
   pattern: '^[^\x00]+$'
   minLength: 1
@@ -55,7 +57,9 @@ DocumentTag:
   example: "tag"
 
 DocumentSearchQuery:
-  description: A search query can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
+  description: |
+    A search query can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
+    The length constraints are in bytes, not characters.
   type: string
   pattern: ".+"
   minLength: 1

--- a/web-api/openapi/schemas/id.yml
+++ b/web-api/openapi/schemas/id.yml
@@ -2,6 +2,7 @@ Id:
   description: |-
     An id can be any non-empty string that consist of arabic digits, latin letters, hyphens, colons,
     @s, dots or underscores (except as the first character).
+    The length constraints are in bytes, not characters.
   type: string
   pattern: '^[a-zA-Z0-9\-:@.][a-zA-Z0-9\-:@._]*$'
   minLength: 1
@@ -12,6 +13,7 @@ IdNoDot:
   description: |-
     An id can be any non-empty string that consist of arabic digits, latin letters, hyphens, colons,
     @s or underscores (except as the first character).
+    The length constraints are in bytes, not characters.
   type: string
   pattern: '^[a-zA-Z0-9\-:@][a-zA-Z0-9\-:@_]*$'
   minLength: 1

--- a/web-api/openapi/schemas/time.yml
+++ b/web-api/openapi/schemas/time.yml
@@ -12,6 +12,8 @@ PublicationDate:
     - will be converted to and then stored as UTC
     - sub-second resolution is not guaranteed
 
+    The length constraints are in bytes, not characters.
+
 PublishedAfter:
   type:
     $ref: '#/PublicationDate/type'
@@ -32,6 +34,8 @@ PublishedAfter:
     - will be converted to and then stored as UTC
     - sub-second resolution is not guaranteed
 
+    The length constraints are in bytes, not characters.
+
 Timestamp:
   type: string
   format: date-time
@@ -46,3 +50,5 @@ Timestamp:
     - can be in the future
     - will be converted to and then stored as UTC
     - sub-second resolution is not guaranteed
+
+    The length constraints are in bytes, not characters.

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -132,7 +132,7 @@ string_wrapper! {
     /// A unique user identifier.
     pub(crate) UserId, InvalidUserId, is_valid_id;
     /// A document snippet.
-    pub(crate) DocumentSnippet, InvalidDocumentSnippet, |value| is_valid_string(value, 1024);
+    pub(crate) DocumentSnippet, InvalidDocumentSnippet, |value| is_valid_string(value, 2_048);
     /// A document tag.
     pub(crate) DocumentTag, InvalidDocumentTag, |value| is_valid_string(value, 256);
 }
@@ -149,7 +149,7 @@ impl TryFrom<Value> for DocumentProperty {
             Value::Bool(_) | Value::Number(_) => {}
             Value::String(string) => {
                 trim(string);
-                if !is_valid_string(string, 256) {
+                if !is_valid_string(string, 2_048) {
                     return Err(InvalidDocumentProperty { value: property });
                 }
             }
@@ -162,7 +162,7 @@ impl TryFrom<Value> for DocumentProperty {
                         return Err(InvalidDocumentProperty { value: property });
                     };
                     trim(string);
-                    if !is_valid_string(string, 256) {
+                    if !is_valid_string(string, 2_048) {
                         return Err(InvalidDocumentProperty { value: property });
                     }
                 }


### PR DESCRIPTION
**Reference**

- [ET-4670]

**Summary**

- limit snippet and string properties to max 2KB each
- clarify that string length constraints are in bytes and not characters: we've been treating the limit as bytes all the time but the openapi spec actually treats it as characters because it derives it's string definition from json. a character can be anything from one to four bytes though, which makes it impractical to use. unfortunately i haven't found a way to express this in openapi on the type level.

[ET-4670]: https://xainag.atlassian.net/browse/ET-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ