### PR TITLE
Return original text if summarization fails

### DIFF
--- a/summarizer/src/lib.rs
+++ b/summarizer/src/lib.rs
@@ -59,11 +59,17 @@ mod summarizers;
 /// ```
 pub fn summarize(summarizer: &Summarizer, source: &Source, config: &Config) -> String {
     let text = source.to_readable_text();
-    match summarizer {
+    let summary = match summarizer {
         Summarizer::Naive => summarizers::naive::summarize(&text, config.num_sentences),
         Summarizer::RankBased => {
             summarizers::rank_based::summarize(&text, &[], config.num_sentences)
         }
+    };
+
+    if summary.is_empty() {
+        text
+    } else {
+        summary
     }
 }
 


### PR DESCRIPTION
If there isn't enough information, the summarizer returns an empty string, and we create an embedding for that.
If we can't summarize we return the original text.