### PR TITLE
ET-4641 propagate schema changes to es mapping

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -651,6 +651,9 @@ pub fn build_test_config_from_parts_and_model(
         .to_string();
 
     let mut config = toml! {
+        [ingestion.index_update]
+        method = "danger_wait_for_completion"
+
         [storage]
         postgres = pg_config
         elastic = es_config

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -24,7 +24,7 @@ use crate::{
     embedding,
     logging,
     net,
-    storage,
+    storage::{self, elastic::IndexUpdateConfig},
     tenants,
 };
 
@@ -68,6 +68,7 @@ pub struct Config {
 pub struct IngestionConfig {
     pub(crate) max_document_batch_size: usize,
     pub(crate) max_indexed_properties: usize,
+    pub(crate) index_update: IndexUpdateConfig,
 }
 
 impl Default for IngestionConfig {
@@ -76,6 +77,7 @@ impl Default for IngestionConfig {
             max_document_batch_size: 100,
             // 10 + publication_date
             max_indexed_properties: 11,
+            index_update: IndexUpdateConfig::default(),
         }
     }
 }

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -629,8 +629,7 @@ async fn create_indexed_properties(
     Json(update): Json<IndexedPropertiesSchemaUpdate>,
     TenantState(storage): TenantState,
 ) -> Result<impl Responder, Error> {
-    let max_indexed_properties = state.config.ingestion.max_indexed_properties;
-    IndexedProperties::extend_schema(&storage, update, max_indexed_properties)
+    IndexedProperties::extend_schema(&storage, update, &state.config.ingestion)
         .await
         .map(|res| Json(res).customize().with_status(StatusCode::ACCEPTED))
 }

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -34,6 +34,7 @@ use xayn_web_api_shared::{postgres as postgres_shared, request::TenantId};
 use self::property_filter::{IndexedPropertiesSchema, IndexedPropertiesSchemaUpdate};
 use crate::{
     app::SetupError,
+    ingestion::IngestionConfig,
     models::{
         self,
         DocumentId,
@@ -273,7 +274,7 @@ pub(crate) trait IndexedProperties {
     async fn extend_schema(
         &self,
         update: IndexedPropertiesSchemaUpdate,
-        max_properties: usize,
+        ingestion_config: &IngestionConfig,
     ) -> Result<IndexedPropertiesSchema, Error>;
 }
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -390,7 +390,12 @@ impl Client {
             );
         }
         let body = json!({
-            "properties": properties
+            "properties": {
+                "properties": {
+                    // the properties of the field named properties in the properties of a document
+                    "properties": properties
+                }
+            }
         });
 
         let url = self.create_url(["_mapping"], []);

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -377,9 +377,9 @@ impl Client {
         let mut properties = JsonObject::new();
         for (id, definition) in updates {
             let r#type = match definition.r#type {
-                IndexedPropertyType::Bool => "boolean",
+                IndexedPropertyType::Boolean => "boolean",
                 IndexedPropertyType::Number => "double",
-                IndexedPropertyType::String | IndexedPropertyType::StringArray => "keyword",
+                IndexedPropertyType::Keyword | IndexedPropertyType::StringArray => "keyword",
                 IndexedPropertyType::Date => "date",
             };
             properties.insert(

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -367,14 +367,14 @@ impl Client {
             .map(|_| ()))
     }
 
-    pub(super) async fn extend_elasticsearch_mapping(
+    pub(super) async fn extend_mapping(
         &self,
         updates: &IndexedPropertiesSchemaUpdate,
     ) -> Result<(), Error> {
         if updates.len() == 0 {
             return Ok(());
         }
-        let mut properties = JsonObject::new();
+        let mut properties = JsonObject::with_capacity(updates.len());
         for (id, definition) in updates {
             let r#type = match definition.r#type {
                 IndexedPropertyType::Boolean => "boolean",
@@ -382,12 +382,7 @@ impl Client {
                 IndexedPropertyType::Keyword | IndexedPropertyType::StringArray => "keyword",
                 IndexedPropertyType::Date => "date",
             };
-            properties.insert(
-                id.as_str().into(),
-                json!({
-                    "type": r#type
-                }),
-            );
+            properties.insert(id.as_str().into(), json!({ "type": r#type }));
         }
         let body = json!({
             "properties": {
@@ -416,9 +411,7 @@ impl Client {
                 //      ES will return a task handle we can use for this.
                 ("wait_for_completion", Some("false")),
                 ("refresh", Some("true")),
-                //TODO make it configurable, currently it's 500_000 documents per second
-                //      (500 batch requests per second * 1000 documents per batch)
-                //     but I have no idea what a good value is
+                //TODO make it configurable, currently it's 500 documents per second
                 ("requests_per_second", Some("500")),
             ],
         );

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -30,7 +30,11 @@ use sqlx::{
         chrono::{DateTime, Utc},
         Json,
     },
-    Executor, FromRow, Postgres, QueryBuilder, Transaction,
+    Executor,
+    FromRow,
+    Postgres,
+    QueryBuilder,
+    Transaction,
 };
 use tracing::info;
 use xayn_ai_bert::NormalizedEmbedding;
@@ -38,16 +42,27 @@ use xayn_ai_coi::{Coi, CoiId, CoiStats};
 
 use super::{
     property_filter::{
-        IndexedPropertiesSchema, IndexedPropertiesSchemaUpdate, IndexedPropertyDefinition,
+        IndexedPropertiesSchema,
+        IndexedPropertiesSchemaUpdate,
+        IndexedPropertyDefinition,
         IndexedPropertyType,
     },
-    InteractionUpdateContext, TagWeights,
+    InteractionUpdateContext,
+    TagWeights,
 };
 use crate::{
     models::{
-        DocumentId, DocumentProperties, DocumentProperty, DocumentPropertyId, DocumentTag,
-        DocumentTags, ExcerptedDocument, IngestedDocument, InteractedDocument,
-        PersonalizedDocument, UserId,
+        DocumentId,
+        DocumentProperties,
+        DocumentProperty,
+        DocumentPropertyId,
+        DocumentTag,
+        DocumentTags,
+        ExcerptedDocument,
+        IngestedDocument,
+        InteractedDocument,
+        PersonalizedDocument,
+        UserId,
     },
     storage::{self, utils::SqlxPushTupleExt, KnnSearchParams, Storage, Warning},
     Error,

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -1291,7 +1291,7 @@ impl storage::IndexedProperties for Storage {
         let mut schema = Database::load_schema(&mut tx).await?;
         schema.update(update.clone(), max_properties)?;
         Database::extend_postgres_schema(&mut tx, &update).await?;
-        self.elastic.extend_elasticsearch_mapping(&update).await?;
+        self.elastic.extend_mapping(&update).await?;
         tx.commit().await?;
         Ok(schema)
     }

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -51,6 +51,7 @@ use super::{
     TagWeights,
 };
 use crate::{
+    ingestion::IngestionConfig,
     models::{
         DocumentId,
         DocumentProperties,
@@ -1285,13 +1286,15 @@ impl storage::IndexedProperties for Storage {
     async fn extend_schema(
         &self,
         update: IndexedPropertiesSchemaUpdate,
-        max_properties: usize,
+        ingestion_config: &IngestionConfig,
     ) -> Result<IndexedPropertiesSchema, Error> {
         let mut tx = self.postgres.begin().await?;
         let mut schema = Database::load_schema(&mut tx).await?;
-        schema.update(update.clone(), max_properties)?;
+        schema.update(update.clone(), ingestion_config.max_indexed_properties)?;
         Database::extend_postgres_schema(&mut tx, &update).await?;
-        self.elastic.extend_mapping(&update).await?;
+        self.elastic
+            .extend_mapping(&update, &ingestion_config.index_update)
+            .await?;
         tx.commit().await?;
         Ok(schema)
     }

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -1289,7 +1289,7 @@ impl storage::IndexedProperties for Storage {
     ) -> Result<IndexedPropertiesSchema, Error> {
         let mut tx = self.postgres.begin().await?;
         let mut schema = Database::load_schema(&mut tx).await?;
-        schema.update(&update, max_properties)?;
+        schema.update(update.clone(), max_properties)?;
         Database::extend_postgres_schema(&mut tx, &update).await?;
         self.elastic.extend_elasticsearch_mapping(&update).await?;
         tx.commit().await?;

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 999999,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 100,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 999999,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 100,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 999999,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -36,7 +36,11 @@ stdout = """
   },
   "ingestion": {
     "max_document_batch_size": 999999,
-    "max_indexed_properties": 11
+    "max_indexed_properties": 11,
+    "index_update": {
+      "requests_per_second": 500,
+      "method": "background"
+    }
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/manage_indexed_properties.rs
+++ b/web-api/tests/manage_indexed_properties.rs
@@ -30,16 +30,16 @@ fn test_creating_indexed_properties() {
                     .json(&json!({
                         "properties": {
                             "p1": {
-                                "type": "bool"
+                                "type": "boolean"
                             },
                             "p2": {
                                 "type": "number"
                             },
                             "p3": {
-                                "type": "string"
+                                "type": "keyword"
                             },
                             "p4": {
-                                "type": "string[]"
+                                "type": "keyword[]"
                             },
                             "p5": {
                                 "type": "date"
@@ -56,16 +56,16 @@ fn test_creating_indexed_properties() {
                 json!({
                     "properties": {
                         "p1": {
-                            "type": "bool"
+                            "type": "boolean"
                         },
                         "p2": {
                             "type": "number"
                         },
                         "p3": {
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "p4": {
-                            "type": "string[]"
+                            "type": "keyword[]"
                         },
                         "p5": {
                             "type": "date"
@@ -84,7 +84,7 @@ fn test_creating_indexed_properties() {
                     .json(&json!({
                         "properties": {
                             "p6": {
-                                "type": "string"
+                                "type": "keyword"
                             }
                         }
                     }))
@@ -98,22 +98,22 @@ fn test_creating_indexed_properties() {
                 json!({
                     "properties": {
                         "p1": {
-                            "type": "bool"
+                            "type": "boolean"
                         },
                         "p2": {
                             "type": "number"
                         },
                         "p3": {
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "p4": {
-                            "type": "string[]"
+                            "type": "keyword[]"
                         },
                         "p5": {
                             "type": "date"
                         },
                         "p6": {
-                            "type": "string"
+                            "type": "keyword"
                         },
                         "publication_date": {
                             "type": "date"

--- a/web-api/tests/manage_indexed_properties.rs
+++ b/web-api/tests/manage_indexed_properties.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use url::Url;
+use xayn_integration_tests::{send_assert_json, test_app, UNCHANGED_CONFIG};
+use xayn_web_api::Ingestion;
+
+#[test]
+fn test_creating_indexed_properties() {
+    test_app::<Ingestion, _>(
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, services| async move {
+            let res = send_assert_json::<Value>(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents/_indexed_properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "p1": {
+                                "type": "bool"
+                            },
+                            "p2": {
+                                "type": "number"
+                            },
+                            "p3": {
+                                "type": "string"
+                            },
+                            "p4": {
+                                "type": "string[]"
+                            },
+                            "p5": {
+                                "type": "date"
+                            }
+                        }
+                    }))
+                    .build()?,
+                StatusCode::ACCEPTED,
+            )
+            .await;
+
+            assert_eq!(
+                res,
+                json!({
+                    "properties": {
+                        "p1": {
+                            "type": "bool"
+                        },
+                        "p2": {
+                            "type": "number"
+                        },
+                        "p3": {
+                            "type": "string"
+                        },
+                        "p4": {
+                            "type": "string[]"
+                        },
+                        "p5": {
+                            "type": "date"
+                        },
+                        "publication_date": {
+                            "type": "date"
+                        }
+                    }
+                })
+            );
+
+            let res = send_assert_json::<Value>(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents/_indexed_properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "p6": {
+                                "type": "string"
+                            }
+                        }
+                    }))
+                    .build()?,
+                StatusCode::ACCEPTED,
+            )
+            .await;
+
+            assert_eq!(
+                res,
+                json!({
+                    "properties": {
+                        "p1": {
+                            "type": "bool"
+                        },
+                        "p2": {
+                            "type": "number"
+                        },
+                        "p3": {
+                            "type": "string"
+                        },
+                        "p4": {
+                            "type": "string[]"
+                        },
+                        "p5": {
+                            "type": "date"
+                        },
+                        "p6": {
+                            "type": "string"
+                        },
+                        "publication_date": {
+                            "type": "date"
+                        }
+                    }
+                })
+            );
+
+            let res2 = send_assert_json::<Value>(
+                &client,
+                client
+                    .get(ingestion_url.join("/documents/_indexed_properties")?)
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+
+            assert_eq!(res, res2);
+
+            let es = services.silo.elastic_config();
+            let url = es.url.parse::<Url>()?.join("_mapping")?;
+            let res =
+                send_assert_json::<Value>(&client, client.get(url).build()?, StatusCode::OK).await;
+            let properties_mapping = &res[services.test_id.as_str()]["mappings"]["properties"]
+                ["properties"]["properties"];
+            assert_eq!(
+                properties_mapping,
+                &json!({
+                    "publication_date": {
+                        "type": "date"
+                    },
+                    "p1": {
+                        "type": "boolean"
+                    },
+                    "p2": {
+                        "type": "double"
+                    },
+                    "p3": {
+                        "type": "keyword"
+                    },
+                    "p4": {
+                        "type": "keyword"
+                    },
+                    "p5": {
+                        "type": "date"
+                    },
+                    "p6": {
+                        "type": "keyword"
+                    }
+                })
+            );
+
+            Ok(())
+        },
+    );
+}


### PR DESCRIPTION
- propagate schema updates as property mapping updates to elasticsearch
- run a background job to update the indices

**References:**

- [ET-4641]

[ET-4641]: https://xainag.atlassian.net/browse/ET-4641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ