### PR TITLE
ET-4598 string filter

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -67,7 +67,7 @@ module.exports = {
     },
     {
       files: [
-        "web-api/openapi/front_office.yaml#/components/schemas/FilterString/additionalProperties/properties",
+        "web-api/openapi/front_office.yaml#/components/schemas/FilterCompare/additionalProperties/properties",
       ],
       rules: {
         "ibm-property-casing-convention": "off",

--- a/.spectral.js
+++ b/.spectral.js
@@ -65,5 +65,13 @@ module.exports = {
         "ibm-array-attributes": "off",
       },
     },
+    {
+      files: [
+        "web-api/openapi/front_office.yaml#/components/schemas/FilterString/additionalProperties/properties",
+      ],
+      rules: {
+        "ibm-property-casing-convention": "off",
+      },
+    },
   ],
 };

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -520,13 +520,13 @@ pub fn test_two_apps<A1, A2, F>(
     A2: Application + 'static,
 {
     run_async_test(|test_id| async move {
-        let (configure_first, first_wit_legacy) =
+        let (configure_first, first_with_legacy) =
             configure_with_enable_legacy_tenant_for_test(configure_first.unwrap_or_default());
         let (configure_second, second_with_legacy) =
             configure_with_enable_legacy_tenant_for_test(configure_second.unwrap_or_default());
-        assert_eq!(first_wit_legacy, second_with_legacy);
+        assert_eq!(first_with_legacy, second_with_legacy);
 
-        let services = setup_web_dev_services(&test_id, first_wit_legacy).await?;
+        let services = setup_web_dev_services(&test_id, first_with_legacy).await?;
         let first_handle = start_test_application::<A1>(&services, configure_first).await;
         let second_handle = start_test_application::<A2>(&services, configure_second).await;
 

--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -1,13 +1,20 @@
+# 2.4.0 - 2023-06-29
+
+- Add property filters to the `/users/{id}/personalized_documents` and `/semantic_search` endpoints:
+    - string equality
+
 # 2.3.0 - 2023-06-28
 
 - added endpoints for retrieving and extending the
   indexed property schema
 
 # 2.2.0 - 2023-06-26
+
 - Allow empty string for properties
 - Do not trim string properties
 
 # 2.1.0 - 2023-06-22
+
 - Allow empty array and null value for properties
 
 # 2.0.0 - 2023-06-19

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Back Office API
-  version: 2.3.0
+  version: 2.4.0
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Front Office API
-  version: 2.3.0
+  version: 2.4.0
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.
@@ -66,6 +66,13 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/IncludeProperties'
+        - name: filter
+          in: query
+          description:
+            $ref: '#/components/schemas/Filter/description'
+          required: false
+          schema:
+            $ref: '#/components/schemas/Filter'
       responses:
         '200':
           description: successful operation
@@ -156,6 +163,21 @@ components:
       description: Include the properties of each document in the response
       type: boolean
       default: true
+    FilterString:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          $eq:
+            $ref: ./schemas/document.yml#/DocumentPropertyString
+        minProperties: 1
+        maxProperties: 1
+    Filter:
+      description: Filter the documents wrt their properties. A key must be a valid `DocumentPropertyId`.
+      oneOf:
+        - $ref: '#/components/schemas/FilterString'
+      minProperties: 1
+      maxProperties: 1
     PersonalizedDocumentData:
       type: object
       required: [id, score]
@@ -216,6 +238,8 @@ components:
           description: Enable the hybrid search mode.
           type: boolean
           default: false
+        filter:
+          $ref: '#/components/schemas/Filter'
     SemanticSearchResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -163,7 +163,7 @@ components:
       description: Include the properties of each document in the response
       type: boolean
       default: true
-    FilterString:
+    FilterCompare:
       type: object
       additionalProperties:
         type: object
@@ -173,11 +173,12 @@ components:
         minProperties: 1
         maxProperties: 1
     Filter:
-      description: Filter the documents wrt their properties. A key must be a valid `DocumentPropertyId`.
+      description: |
+        Filter the documents wrt their properties.
+        A key must be a valid `DocumentPropertyId`.
+        The `DocumentProperty` type corresponding to the `DocumentPropertyId` must support the filter operation.
       oneOf:
-        - $ref: '#/components/schemas/FilterString'
-      minProperties: 1
-      maxProperties: 1
+        - $ref: '#/components/schemas/FilterCompare'
     PersonalizedDocumentData:
       type: object
       required: [id, score]

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -138,6 +138,7 @@ impl PersonalizeBy<'_> {
         Self::KnnSearch {
             count,
             published_after: None,
+            filter: None,
         }
     }
 }

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -339,6 +339,18 @@ pub(crate) struct ExcerptedDocument {
 mod tests {
     use super::*;
 
+    impl TryFrom<Value> for DocumentProperty {
+        type Error = InvalidDocumentProperty;
+
+        fn try_from(value: Value) -> Result<Self, Self::Error> {
+            DocumentProperty::try_from_value(
+                &"d".try_into().unwrap(),
+                &"p".try_into().unwrap(),
+                value,
+            )
+        }
+    }
+
     #[test]
     fn test_is_valid_id() {
         assert!(is_valid_id("abcdefghijklmnopqrstruvwxyz"));

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -10,7 +10,9 @@
 // GNU Affero General Public License for more details.
 //
 // You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pub(crate) mod filter;
 mod knn;
 mod rerank;
 pub(crate) mod routes;

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -1,0 +1,203 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt;
+
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    Deserialize,
+    Deserializer,
+};
+
+use crate::models::{DocumentProperty, DocumentPropertyId};
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub(crate) enum CompareOp {
+    #[serde(rename = "$eq")]
+    Eq,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct CompareWith {
+    operation: CompareOp,
+    value: DocumentProperty,
+}
+
+impl<'de> Deserialize<'de> for CompareWith {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CompareWithVisitor;
+
+        impl<'de> Visitor<'de> for CompareWithVisitor {
+            type Value = CompareWith;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a json object with exactly one right comparison argument and a matching type for the comparison operator")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                if let Some(size) = map.size_hint() {
+                    if size != 1 {
+                        return Err(A::Error::invalid_length(size, &Self));
+                    }
+                }
+                let Some((operation, value)) = map.next_entry::<_, DocumentProperty>()? else {
+                    return Err(A::Error::invalid_length(0, &Self));
+                };
+                if map.next_entry::<CompareOp, DocumentProperty>()?.is_some() {
+                    return Err(A::Error::invalid_length(2, &Self));
+                }
+                match operation {
+                    CompareOp::Eq => {
+                        if !value.is_string() {
+                            return Err(A::Error::invalid_type(
+                                Unexpected::Other("no string property"),
+                                &Self,
+                            ));
+                        }
+                    }
+                }
+
+                Ok(CompareWith { operation, value })
+            }
+        }
+
+        deserializer.deserialize_map(CompareWithVisitor)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Compare {
+    pub(crate) operation: CompareOp,
+    pub(crate) field: DocumentPropertyId,
+    pub(crate) value: DocumentProperty,
+}
+
+impl<'de> Deserialize<'de> for Compare {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CompareVisitor;
+
+        impl<'de> Visitor<'de> for CompareVisitor {
+            type Value = Compare;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a json object with exactly one left comparison argument")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                if let Some(size) = map.size_hint() {
+                    if size != 1 {
+                        return Err(A::Error::invalid_length(size, &Self));
+                    }
+                }
+                let Some((field, compare_with)) = map.next_entry::<_, CompareWith>()? else {
+                    return Err(A::Error::invalid_length(0, &Self));
+                };
+                if map
+                    .next_entry::<DocumentPropertyId, CompareWith>()?
+                    .is_some()
+                {
+                    return Err(A::Error::invalid_length(2, &Self));
+                }
+
+                Ok(Compare {
+                    operation: compare_with.operation,
+                    field,
+                    value: compare_with.value,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(CompareVisitor)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub(crate) enum Filter {
+    Compare(Compare),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_compare_with() {
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(r#"{ "$eq": "test" }"#).unwrap(),
+            CompareWith {
+                operation: CompareOp::Eq,
+                value: json!("test").try_into().unwrap(),
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>("{}")
+                .unwrap_err()
+                .to_string(),
+            "invalid length 0, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 2",
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(r#"{ "$eq": "test1", "$eq": "test2" }"#)
+                .unwrap_err()
+                .to_string(),
+            "invalid length 2, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 34",
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(r#"{ "$eq": 42 }"#)
+                .unwrap_err()
+                .to_string(),
+            "invalid type: no string property, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 13",
+        );
+    }
+
+    #[test]
+    fn test_compare() {
+        assert_eq!(
+            serde_json::from_str::<Compare>(r#"{ "prop": { "$eq": "test" } }"#).unwrap(),
+            Compare {
+                operation: CompareOp::Eq,
+                field: "prop".try_into().unwrap(),
+                value: json!("test").try_into().unwrap(),
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<Compare>("{}")
+                .unwrap_err()
+                .to_string(),
+            "invalid length 0, expected a json object with exactly one left comparison argument at line 1 column 2",
+        );
+        assert_eq!(
+            serde_json::from_str::<Compare>(
+                r#"{ "prop1": { "$eq": "test" }, "prop2": { "$eq": "test" } }"#
+            )
+            .unwrap_err()
+            .to_string(),
+            "invalid length 2, expected a json object with exactly one left comparison argument at line 1 column 58",
+        );
+    }
+}

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -23,6 +23,7 @@ use xayn_ai_coi::{compute_coi_weights, Coi};
 use crate::{
     error::common::InternalError,
     models::{DocumentId, PersonalizedDocument},
+    personalization::filter::Filter,
     storage::{self, KnnSearchParams, SearchStrategy},
     Error,
 };
@@ -37,6 +38,7 @@ pub(super) struct CoiSearch<'a, I> {
     pub(super) published_after: Option<DateTime<Utc>>,
     pub(super) time: DateTime<Utc>,
     pub(super) include_properties: bool,
+    pub(super) filter: Option<&'a Filter>,
 }
 
 impl<'a, I> CoiSearch<'a, I>
@@ -84,6 +86,7 @@ where
                         published_after: self.published_after,
                         strategy: SearchStrategy::Knn,
                         include_properties: self.include_properties,
+                        filter: self.filter,
                     },
                 )
                 .await
@@ -149,6 +152,7 @@ mod tests {
             published_after: None,
             time: Utc::now(),
             include_properties: false,
+            filter: None,
         }
         .run_on(&storage)
         .await

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -47,6 +47,7 @@ use crate::{
         PersonalizedDocument,
         UserId,
     },
+    personalization::filter::Filter,
     tenants,
     Error,
 };
@@ -61,6 +62,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) published_after: Option<DateTime<Utc>>,
     pub(super) strategy: SearchStrategy,
     pub(super) include_properties: bool,
+    pub(super) filter: Option<&'a Filter>,
 }
 
 #[derive(Clone, Debug)]

--- a/web-api/src/storage/elastic/filter.rs
+++ b/web-api/src/storage/elastic/filter.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use serde_json::{json, Value};
+use xayn_web_api_shared::serde::JsonObject;
+
+use crate::{
+    personalization::filter::{CompareOp, Filter},
+    storage::KnnSearchParams,
+};
+
+fn extend_filter(filter: &mut JsonObject, clause: &Filter) {
+    let clause = match clause {
+        Filter::Compare(compare) => match compare.operation {
+            CompareOp::Eq => {
+                json!({ "term": { format!("properties.{}", compare.field): compare.value } })
+            }
+        },
+    };
+    if let Some(filter) = filter.get_mut("filter") {
+        match filter {
+            Value::Object(_) => {
+                *filter = json!([filter.take(), clause]);
+            }
+            Value::Array(filter) => filter.push(clause),
+            _ => unreachable!(/* filter is object or array */),
+        }
+    } else {
+        filter.insert("filter".to_string(), clause);
+    }
+}
+
+impl KnnSearchParams<'_> {
+    pub(super) fn create_search_filter(&self) -> JsonObject {
+        let mut filter = JsonObject::new();
+        if !self.excluded.is_empty() {
+            // existing documents are not filtered in the query to avoid too much work for a cold
+            // path, filtering them afterwards can occasionally lead to less than k results though
+            filter.insert(
+                "must_not".to_string(),
+                json!({ "ids": { "values": self.excluded } }),
+            );
+        }
+        if let Some(published_after) = self.published_after {
+            // published_after != null && published_after <= publication_date
+            let published_after = published_after.to_rfc3339();
+            filter.insert(
+                "filter".to_string(),
+                json!({ "range": { "properties.publication_date": { "gte": published_after } } }),
+            );
+        }
+        if let Some(opt_filter) = self.filter {
+            extend_filter(&mut filter, opt_filter);
+        }
+
+        filter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use xayn_web_api_shared::serde::json_object;
+
+    use super::*;
+
+    #[test]
+    fn test_extend_filter_compare() {
+        let clause = &serde_json::from_str(r#"{ "a": { "$eq": "b" } }"#).unwrap();
+        let term = json_object!({ "term": { "properties.a": "b" } });
+
+        let mut filter = JsonObject::new();
+        extend_filter(&mut filter, clause);
+        assert_eq!(filter, json_object!({ "filter": term }));
+
+        let mut filter = json_object!({ "filter": {} });
+        extend_filter(&mut filter, clause);
+        assert_eq!(filter, json_object!({ "filter": [{}, term] }));
+
+        let mut filter = json_object!({ "filter": [{}, {}] });
+        extend_filter(&mut filter, clause);
+        assert_eq!(filter, json_object!({ "filter": [{}, {}, term] }));
+    }
+}

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -742,6 +742,7 @@ mod tests {
                 published_after: None,
                 strategy: SearchStrategy::Knn,
                 include_properties: false,
+                filter: None,
             },
         )
         .await
@@ -761,6 +762,7 @@ mod tests {
                 published_after: None,
                 strategy: SearchStrategy::Knn,
                 include_properties: false,
+                filter: None,
             },
         )
         .await

--- a/web-api/tests/filter.rs
+++ b/web-api/tests/filter.rs
@@ -1,0 +1,153 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use anyhow::Error;
+use reqwest::{Client, StatusCode, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
+use xayn_web_api::{Ingestion, Personalization};
+
+#[derive(Serialize)]
+struct IngestedDocument {
+    id: String,
+    snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<serde_json::Value>,
+}
+
+async fn ingest(client: &Client, base_url: &Url, documents: &Value) -> Result<(), Error> {
+    send_assert(
+        client,
+        client
+            .post(base_url.join("/documents")?)
+            .json(&json!({ "documents": documents }))
+            .build()?,
+        StatusCode::CREATED,
+    )
+    .await;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct PersonalizedDocumentData {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct SemanticSearchResponse {
+    documents: Vec<PersonalizedDocumentData>,
+}
+
+impl SemanticSearchResponse {
+    fn ids(&self) -> HashSet<&str> {
+        self.documents
+            .iter()
+            .map(|document| document.id.as_str())
+            .collect()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.documents.is_empty()
+    }
+}
+
+#[test]
+fn test_filter_string() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            send_assert(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents/_indexed_properties")?)
+                    .json(&json!({
+                        "properties": { "p": { "type": "keyword" }, "q": { "type": "keyword" } }
+                    }))
+                    .build()?,
+                StatusCode::ACCEPTED,
+            )
+            .await;
+
+            ingest(
+                &client,
+                &ingestion_url,
+                &json!([
+                    { "id": "d1", "snippet": "one" },
+                    { "id": "d2", "snippet": "two", "properties": { "p": "this" } },
+                    { "id": "d3", "snippet": "three", "properties": { "p": "that" } }
+                ]),
+            )
+            .await?;
+
+            let documents = send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({ "document": { "query": "zero" } }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+            assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
+
+            let documents = send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "zero" },
+                        "filter": { "p": { "$eq": "this" } }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+            assert_eq!(documents.ids(), ["d2"].into());
+
+            let documents = send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "zero" },
+                        "filter": { "p": { "$eq": "other" } }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+            assert!(documents.is_empty());
+
+            let documents = send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "zero" },
+                        "filter": { "q": { "$eq": "this" } }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+            assert!(documents.is_empty());
+
+            Ok(())
+        },
+    );
+}


### PR DESCRIPTION
**Reference**

- [ET-4598]
- followed by #1003

**Summary**

- declare string filters in the spec & update changelog
- impl compare filter serde & add them in personalization routes
- add compare filter in elasticsearch calls


[ET-4598]: https://xainag.atlassian.net/browse/ET-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ