### PR TITLE
ET-4599 array of strings filter

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -60,6 +60,7 @@ module.exports = {
       files: [
         "web-api/openapi/back_office.yaml#/components/schemas/DocumentCandidatesRequest",
         "web-api/openapi/back_office.yaml#/components/schemas/DocumentCandidatesResponse",
+        "web-api/openapi/schemas/document.yml#/DocumentPropertyArrayString",
       ],
       rules: {
         "ibm-array-attributes": "off",

--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add property filters to the `/users/{id}/personalized_documents` and `/semantic_search` endpoints:
     - string equality
+    - array of strings containment
 
 # 2.3.0 - 2023-06-28
 

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -170,6 +170,8 @@ components:
         properties:
           $eq:
             $ref: ./schemas/document.yml#/DocumentPropertyString
+          $in:
+            $ref: ./schemas/document.yml#/DocumentPropertyArrayString
         minProperties: 1
         maxProperties: 1
     Filter:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -81,7 +81,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PersonalizedDocumentsResponse'
         '400':
-           $ref: './responses/generic.yml#/BadRequest'
+          $ref: './responses/generic.yml#/BadRequest'
         '409':
           description: impossible to create a personalized list for the user.
           content:
@@ -145,7 +145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SemanticSearchResponse'
         '400':
-            $ref: './responses/generic.yml#/BadRequest'
+          $ref: './responses/generic.yml#/BadRequest'
 
 components:
   securitySchemes:
@@ -172,6 +172,7 @@ components:
             $ref: ./schemas/document.yml#/DocumentPropertyString
           $in:
             $ref: ./schemas/document.yml#/DocumentPropertyArrayString
+            maxItems: 10
         minProperties: 1
         maxProperties: 1
     Filter:
@@ -242,7 +243,10 @@ components:
           type: boolean
           default: false
         filter:
-          $ref: '#/components/schemas/Filter'
+          description:
+            $ref: '#/components/schemas/Filter/description'
+          oneOf:
+            - $ref: '#/components/schemas/FilterCompare'
     SemanticSearchResponse:
       type: object
       required: [documents]

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -23,6 +23,8 @@ DocumentPropertyArrayString:
   type: array
   items:
     $ref: '#/DocumentPropertyString'
+  minItems: 0
+  maxItems: 100
 
 DocumentProperty:
   description: |

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -19,9 +19,8 @@ DocumentPropertyString:
 
 DocumentPropertyArrayString:
   description: |
-    Array of non-null string.
+    Arbitrary array of strings property that can be attached to a document.
   type: array
-  minItems: 0
   items:
     $ref: '#/DocumentPropertyString'
 

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -20,6 +20,7 @@ DocumentPropertyString:
 DocumentPropertyArrayString:
   description: |
     Arbitrary array of strings property that can be attached to a document.
+    The item length constraints are in bytes, not characters.
   type: array
   items:
     $ref: '#/DocumentPropertyString'

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -93,6 +93,8 @@ pub(crate) enum InvalidDocumentPropertyReason {
     IncompatibleType { expected: IndexedPropertyType },
     /// string too long or contains invalid characters
     InvalidString,
+    /// array too long
+    InvalidArray,
 }
 
 impl_application_error!(InvalidDocumentProperty => BAD_REQUEST, INFO);

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -170,6 +170,14 @@ impl DocumentProperty {
                 }
             }
             Value::Array(array) => {
+                if array.len() > 100 {
+                    return Err(InvalidDocumentProperty {
+                        document: document_id.clone(),
+                        property: property_id.clone(),
+                        invalid_value: value.clone(),
+                        invalid_reason: InvalidDocumentPropertyReason::InvalidArray,
+                    });
+                }
                 for value in array {
                     let Value::String(ref mut string) = value else {
                         return Err(InvalidDocumentProperty {

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -26,6 +26,8 @@ use crate::models::{DocumentProperty, DocumentPropertyId};
 pub(crate) enum CompareOp {
     #[serde(rename = "$eq")]
     Eq,
+    #[serde(rename = "$in")]
+    In,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -68,6 +70,17 @@ impl<'de> Deserialize<'de> for CompareWith {
                         if !value.is_string() {
                             return Err(A::Error::invalid_type(
                                 Unexpected::Other("no string property"),
+                                &Self,
+                            ));
+                        }
+                    }
+                    CompareOp::In => {
+                        if value
+                            .as_array()
+                            .map_or(true, |value| value.iter().any(|value| !value.is_string()))
+                        {
+                            return Err(A::Error::invalid_type(
+                                Unexpected::Other("no array of strings property"),
                                 &Self,
                             ));
                         }
@@ -147,7 +160,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_compare_with() {
+    fn test_compare_with_string() {
         assert_eq!(
             serde_json::from_str::<CompareWith>(r#"{ "$eq": "test" }"#).unwrap(),
             CompareWith {
@@ -176,6 +189,37 @@ mod tests {
     }
 
     #[test]
+    fn test_compare_with_array_string() {
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(r#"{ "$in": ["test", "this"] }"#).unwrap(),
+            CompareWith {
+                operation: CompareOp::In,
+                value: json!(["test", "this"]).try_into().unwrap(),
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>("{}")
+                .unwrap_err()
+                .to_string(),
+            "invalid length 0, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 2",
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(
+                r#"{ "$in": ["test", "this"], "$in": ["test", "that"] }"#
+            )
+            .unwrap_err()
+            .to_string(),
+            "invalid length 2, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 52",
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(r#"{ "$in": "test" }"#)
+                .unwrap_err()
+                .to_string(),
+            "invalid type: no array of strings property, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 17",
+        );
+    }
+
+    #[test]
     fn test_compare() {
         assert_eq!(
             serde_json::from_str::<Compare>(r#"{ "prop": { "$eq": "test" } }"#).unwrap(),
@@ -186,6 +230,14 @@ mod tests {
             },
         );
         assert_eq!(
+            serde_json::from_str::<Compare>(r#"{ "prop": { "$in": ["test", "this"] } }"#).unwrap(),
+            Compare {
+                operation: CompareOp::In,
+                field: "prop".try_into().unwrap(),
+                value: json!(["test", "this"]).try_into().unwrap(),
+            },
+        );
+        assert_eq!(
             serde_json::from_str::<Compare>("{}")
                 .unwrap_err()
                 .to_string(),
@@ -193,11 +245,11 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_str::<Compare>(
-                r#"{ "prop1": { "$eq": "test" }, "prop2": { "$eq": "test" } }"#
+                r#"{ "prop1": { "$eq": "test" }, "prop2": { "$in": ["test", "this"] } }"#
             )
             .unwrap_err()
             .to_string(),
-            "invalid length 2, expected a json object with exactly one left comparison argument at line 1 column 58",
+            "invalid length 2, expected a json object with exactly one left comparison argument at line 1 column 68",
         );
     }
 }

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -84,6 +84,10 @@ impl<'de> Deserialize<'de> for CompareWith {
                                 &Self,
                             ));
                         }
+                        let len = value.as_array().unwrap(/* value is array */).len();
+                        if len > 10 {
+                            return Err(A::Error::invalid_length(len, &Self));
+                        }
                     }
                 }
 
@@ -216,6 +220,14 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "invalid type: no array of strings property, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 17",
+        );
+        assert_eq!(
+            serde_json::from_str::<CompareWith>(
+                r#"{ "$in": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"] }"#
+            )
+            .unwrap_err()
+            .to_string(),
+            "invalid length 11, expected a json object with exactly one right comparison argument and a matching type for the comparison operator at line 1 column 68",
         );
     }
 

--- a/web-api/tests/filter.rs
+++ b/web-api/tests/filter.rs
@@ -87,7 +87,7 @@ fn test_filter_string() {
             index(
                 &client,
                 &ingestion_url,
-                json!({ "p": { "type": "keyword" }, "q": { "type": "keyword" } }),
+                json!({ "p1": { "type": "keyword" }, "p2": { "type": "keyword" } }),
             )
             .await?;
             ingest(
@@ -95,8 +95,8 @@ fn test_filter_string() {
                 &ingestion_url,
                 json!([
                     { "id": "d1", "snippet": "one" },
-                    { "id": "d2", "snippet": "two", "properties": { "p": "this" } },
-                    { "id": "d3", "snippet": "three", "properties": { "p": "that" } }
+                    { "id": "d2", "snippet": "two", "properties": { "p1": "this" } },
+                    { "id": "d3", "snippet": "three", "properties": { "p1": "that" } }
                 ]),
             )
             .await?;
@@ -118,7 +118,7 @@ fn test_filter_string() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$eq": "this" } }
+                        "filter": { "p1": { "$eq": "this" } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -132,7 +132,7 @@ fn test_filter_string() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$eq": "other" } }
+                        "filter": { "p1": { "$eq": "other" } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -146,7 +146,7 @@ fn test_filter_string() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "q": { "$eq": "this" } }
+                        "filter": { "p2": { "$eq": "this" } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -168,7 +168,7 @@ fn test_filter_array_string_single() {
             index(
                 &client,
                 &ingestion_url,
-                json!({ "p": { "type": "keyword" }, "q": { "type": "keyword" } }),
+                json!({ "p1": { "type": "keyword" }, "p2": { "type": "keyword" } }),
             )
             .await?;
             ingest(
@@ -176,8 +176,8 @@ fn test_filter_array_string_single() {
                 &ingestion_url,
                 json!([
                     { "id": "d1", "snippet": "one" },
-                    { "id": "d2", "snippet": "two", "properties": { "p": "this" } },
-                    { "id": "d3", "snippet": "three", "properties": { "p": "that" } }
+                    { "id": "d2", "snippet": "two", "properties": { "p1": "this" } },
+                    { "id": "d3", "snippet": "three", "properties": { "p1": "that" } }
                 ]),
             )
             .await?;
@@ -199,7 +199,7 @@ fn test_filter_array_string_single() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["this"] } }
+                        "filter": { "p1": { "$in": ["this"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -213,7 +213,7 @@ fn test_filter_array_string_single() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["this", "that", "other"] } }
+                        "filter": { "p1": { "$in": ["this", "that", "other"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -227,7 +227,7 @@ fn test_filter_array_string_single() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": [] } }
+                        "filter": { "p1": { "$in": [] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -241,7 +241,7 @@ fn test_filter_array_string_single() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["other"] } }
+                        "filter": { "p1": { "$in": ["other"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -255,7 +255,7 @@ fn test_filter_array_string_single() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "q": { "$in": ["this", "that", "other"] } }
+                        "filter": { "p2": { "$in": ["this", "that", "other"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -277,7 +277,7 @@ fn test_filter_array_string_multiple() {
             index(
                 &client,
                 &ingestion_url,
-                json!({ "p": { "type": "keyword[]" }, "q": { "type": "keyword[]" } }),
+                json!({ "p1": { "type": "keyword[]" }, "p2": { "type": "keyword[]" } }),
             )
             .await?;
             ingest(
@@ -285,9 +285,9 @@ fn test_filter_array_string_multiple() {
                 &ingestion_url,
                 json!([
                     { "id": "d1", "snippet": "one" },
-                    { "id": "d2", "snippet": "two", "properties": { "p": ["this", "word"] } },
-                    { "id": "d3", "snippet": "three", "properties": { "p": ["that", "word"] } },
-                    { "id": "d4", "snippet": "four", "properties": { "p": ["other", "words"] } }
+                    { "id": "d2", "snippet": "two", "properties": { "p1": ["this", "word"] } },
+                    { "id": "d3", "snippet": "three", "properties": { "p1": ["that", "word"] } },
+                    { "id": "d4", "snippet": "four", "properties": { "p1": ["other", "words"] } }
                 ]),
             )
             .await?;
@@ -309,7 +309,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["the", "word"] } }
+                        "filter": { "p1": { "$in": ["the", "word"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -323,7 +323,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["some", "other", "words"] } }
+                        "filter": { "p1": { "$in": ["some", "other", "words"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -337,7 +337,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["this", "that", "other"] } }
+                        "filter": { "p1": { "$in": ["this", "that", "other"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -351,7 +351,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": [] } }
+                        "filter": { "p1": { "$in": [] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -365,7 +365,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "p": { "$in": ["some", "thing"] } }
+                        "filter": { "p1": { "$in": ["some", "thing"] } }
                     }))
                     .build()?,
                 StatusCode::OK,
@@ -379,7 +379,7 @@ fn test_filter_array_string_multiple() {
                     .post(personalization_url.join("/semantic_search")?)
                     .json(&json!({
                         "document": { "query": "zero" },
-                        "filter": { "q": { "$in": ["this", "that", "other"] } }
+                        "filter": { "p2": { "$in": ["this", "that", "other"] } }
                     }))
                     .build()?,
                 StatusCode::OK,


### PR DESCRIPTION
**Reference**

- [ET-4599]
- requires #1002
- followed by #1010

**Summary**

- declare array of strings filters in the spec & update changelog
- add containment operator to the compare filter serde
- update compare filter in elasticsearch calls


[ET-4599]: https://xainag.atlassian.net/browse/ET-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ