### PR TITLE
ET-4719 handle property validation for making candidates

### DIFF
--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -18,7 +18,8 @@
                 "dynamic": false,
                 "properties": {
                     "publication_date": {
-                        "type": "date"
+                        "type": "date",
+                        "ignore_malformed": true
                     }
                 }
             }

--- a/web-api-db-ctrl/src/elastic.rs
+++ b/web-api-db-ctrl/src/elastic.rs
@@ -211,6 +211,9 @@ mod tests {
             .expect(
                 "path mappings.properties.properties.properties.publication_date must be given",
             );
-        assert_eq!(publication_date, &json!({ "type": "date" }));
+        assert_eq!(
+            publication_date,
+            &json!({ "type": "date", "ignore_malformed": true })
+        );
     }
 }

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -384,7 +384,10 @@ impl Client {
                 IndexedPropertyType::Keyword | IndexedPropertyType::KeywordArray => "keyword",
                 IndexedPropertyType::Date => "date",
             };
-            properties.insert(id.as_str().into(), json!({ "type": r#type }));
+            properties.insert(
+                id.as_str().into(),
+                json!({ "type": r#type, "ignore_malformed": true }),
+            );
         }
         let body = json!({
             "properties": {

--- a/web-api/tests/manage_indexed_properties.rs
+++ b/web-api/tests/manage_indexed_properties.rs
@@ -144,13 +144,16 @@ fn test_creating_indexed_properties() {
                 properties_mapping,
                 &json!({
                     "publication_date": {
-                        "type": "date"
+                        "type": "date",
+                        "ignore_malformed": true
                     },
                     "p1": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "ignore_malformed": true,
                     },
                     "p2": {
-                        "type": "double"
+                        "type": "double",
+                        "ignore_malformed": true,
                     },
                     "p3": {
                         "type": "keyword"
@@ -159,7 +162,8 @@ fn test_creating_indexed_properties() {
                         "type": "keyword"
                     },
                     "p5": {
-                        "type": "date"
+                        "type": "date",
+                        "ignore_malformed": true,
                     },
                     "p6": {
                         "type": "keyword"


### PR DESCRIPTION
If an document was ingested before a indexed property was configured it can contain a property which isn't compatible with the schema.

If that document is already an candidate and in turn uploaded to ES for various reasons we ignore such malformed documents (once we return a task with the status of the index update we can report how many documents failed, but not which).

But if that document isn't yet a candidate (or was made not a candidate and then a candidate again) we can no longer just push all it's properties to elasticsearch as this would lead to an internal server error.

There are two different solutions:

1. We filter properties when using add/set candidate.  This solution is more complicated to implement has more runtime overhead but only fixes that specific problem and touches nothing else.

2. We configure all indexed properties with `ignore_malformed`, that is rather easy but has the side effect that we won't get errors on malformed document.properties in any context (we still get them for e.g. embeddings).  Which is both good and bad:
  - good: It means if we end up with some out of sync ES schema our system will not fall over and continue working, just not for that specific property. Ending up in such a mess is sadly less likely then it should be due to not having joined transactions across PG/ES for schema updates 
  - bad: It not falling over means (in this case) no errors either, so we are less likely to notice when something went wrong (we can have a health endpoint/self check  testing if schemas are in sync, so it's probably not too bad, but still not grate) . 
     -  just to be clear this is only affecting `document.properties.*` but not ES fields like e.g. `snippet`, `tags` or similar
     - in some cases we anyway don't get an ES error, for example ES doesn't differentiate schema wise between any `type` and `type[]`
     - `keyword` in ES is for any exact match focused use case, i.e. you can have pretty much any JSON type as keyword value (kinda with ES object and array handling you never have such a value as long as you don't set up a special schema e.g. dense vector) . This means we won't get errors for any properties which have our types of `keyword` or `keyword[]`, which is currently all supported types....


**References:**

- story [ET-4602]
- issue [ET-4719]

[ET-4602]: https://xainag.atlassian.net/browse/ET-4602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ