### PR TITLE
ET-4674 save original snippet instead of summary

### DIFF
--- a/web-api-db-ctrl/postgres/tenant/20230628131800_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230628131800_document.sql
@@ -1,0 +1,16 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ALTER TABLE document
+    ADD COLUMN was_summarized BOOLEAN NULL;

--- a/web-api-db-ctrl/postgres/tenant/20230628131800_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230628131800_document.sql
@@ -13,4 +13,4 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ALTER TABLE document
-    ADD COLUMN was_summarized BOOLEAN NULL;
+    ADD COLUMN is_summarized BOOLEAN NOT NULL DEFAULT false;

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -221,7 +221,7 @@ impl UnvalidatedIngestedDocument {
                 &Config::default(),
             )
         });
-        
+
         let properties = validate_document_properties(&id, self.properties, storage).await?;
         let tags = self
             .tags

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -74,7 +74,7 @@ impl State {
                 Ok(IngestedDocument {
                     id: document.id,
                     snippet: document.snippet,
-                    was_summarized: false,
+                    is_summarized: false,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
                     embedding,
@@ -109,7 +109,7 @@ impl State {
                 IngestedDocument {
                     id,
                     snippet: snippet.clone(),
-                    was_summarized: false,
+                    is_summarized: false,
                     properties: document.properties,
                     tags: document.tags,
                     embedding,

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -74,7 +74,7 @@ impl State {
                 Ok(IngestedDocument {
                     id: document.id,
                     snippet: document.snippet,
-                    was_summarized: Some(false),
+                    was_summarized: false,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
                     embedding,
@@ -109,7 +109,7 @@ impl State {
                 IngestedDocument {
                     id,
                     snippet: snippet.clone(),
-                    was_summarized: Some(false),
+                    was_summarized: false,
                     properties: document.properties,
                     tags: document.tags,
                     embedding,

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -74,6 +74,7 @@ impl State {
                 Ok(IngestedDocument {
                     id: document.id,
                     snippet: document.snippet,
+                    was_summarized: Some(false),
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
                     embedding,
@@ -108,6 +109,7 @@ impl State {
                 IngestedDocument {
                     id,
                     snippet: snippet.clone(),
+                    was_summarized: Some(false),
                     properties: document.properties,
                     tags: document.tags,
                     embedding,

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -313,7 +313,7 @@ pub(crate) struct IngestedDocument {
     /// Snippet used to calculate embeddings for a document.
     pub(crate) snippet: DocumentSnippet,
 
-    /// Indicates weather the embedding was created using a summarizer.
+    /// Whether the embedding was computed on the summarized snippet.
     pub(crate) was_summarized: bool,
 
     /// Contents of the document properties.

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -314,7 +314,7 @@ pub(crate) struct IngestedDocument {
     pub(crate) snippet: DocumentSnippet,
 
     /// Whether the embedding was computed on the summarized snippet.
-    pub(crate) was_summarized: bool,
+    pub(crate) is_summarized: bool,
 
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
@@ -333,7 +333,7 @@ pub(crate) struct IngestedDocument {
 pub(crate) struct ExcerptedDocument {
     pub(crate) id: DocumentId,
     pub(crate) snippet: DocumentSnippet,
-    pub(crate) was_summarized: Option<bool>,
+    pub(crate) is_summarized: bool,
     pub(crate) properties: DocumentProperties,
     pub(crate) tags: DocumentTags,
     pub(crate) is_candidate: bool,

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -314,9 +314,7 @@ pub(crate) struct IngestedDocument {
     pub(crate) snippet: DocumentSnippet,
 
     /// Indicates weather the embedding was created using a summarizer.
-    ///
-    /// For now we don't always know this for all documents.
-    pub(crate) was_summarized: Option<bool>,
+    pub(crate) was_summarized: bool,
 
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -313,6 +313,11 @@ pub(crate) struct IngestedDocument {
     /// Snippet used to calculate embeddings for a document.
     pub(crate) snippet: DocumentSnippet,
 
+    /// Indicates weather the embedding was created using a summarizer.
+    ///
+    /// For now we don't always know this for all documents.
+    pub(crate) was_summarized: Option<bool>,
+
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
 
@@ -330,6 +335,7 @@ pub(crate) struct IngestedDocument {
 pub(crate) struct ExcerptedDocument {
     pub(crate) id: DocumentId,
     pub(crate) snippet: DocumentSnippet,
+    pub(crate) was_summarized: Option<bool>,
     pub(crate) properties: DocumentProperties,
     pub(crate) tags: DocumentTags,
     pub(crate) is_candidate: bool,

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -60,7 +60,7 @@ use crate::{
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Document {
     snippet: DocumentSnippet,
-    was_summarized: Option<bool>,
+    was_summarized: bool,
     properties: DocumentProperties,
     tags: DocumentTags,
     is_candidate: bool,
@@ -297,7 +297,7 @@ impl storage::Document for Storage {
                 documents.0.get(id).map(|document| ExcerptedDocument {
                     id: id.clone(),
                     snippet: document.snippet.clone(),
-                    was_summarized: document.was_summarized,
+                    was_summarized: Some(document.was_summarized),
                     properties: document.properties.clone(),
                     tags: document.tags.clone(),
                     is_candidate: document.is_candidate,
@@ -723,7 +723,7 @@ mod tests {
             .map(|(id, embedding)| IngestedDocument {
                 id: id.clone(),
                 snippet: "snippet".try_into().unwrap(),
-                was_summarized: Some(false),
+                was_summarized: false,
                 properties: DocumentProperties::default(),
                 tags: DocumentTags::default(),
                 embedding,
@@ -787,7 +787,7 @@ mod tests {
             vec![IngestedDocument {
                 id: doc_id.clone(),
                 snippet: snippet.clone(),
-                was_summarized: Some(false),
+                was_summarized: false,
                 properties: DocumentProperties::default(),
                 tags: tags.clone(),
                 embedding: embedding.clone(),

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -60,7 +60,7 @@ use crate::{
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Document {
     snippet: DocumentSnippet,
-    was_summarized: bool,
+    is_summarized: bool,
     properties: DocumentProperties,
     tags: DocumentTags,
     is_candidate: bool,
@@ -297,7 +297,7 @@ impl storage::Document for Storage {
                 documents.0.get(id).map(|document| ExcerptedDocument {
                     id: id.clone(),
                     snippet: document.snippet.clone(),
-                    was_summarized: Some(document.was_summarized),
+                    is_summarized: document.is_summarized,
                     properties: document.properties.clone(),
                     tags: document.tags.clone(),
                     is_candidate: document.is_candidate,
@@ -365,7 +365,7 @@ impl storage::Document for Storage {
                 document.id.clone(),
                 Document {
                     snippet: document.snippet,
-                    was_summarized: document.was_summarized,
+                    is_summarized: document.is_summarized,
                     properties: document.properties,
                     tags: document.tags,
                     is_candidate: document.is_candidate,
@@ -723,7 +723,7 @@ mod tests {
             .map(|(id, embedding)| IngestedDocument {
                 id: id.clone(),
                 snippet: "snippet".try_into().unwrap(),
-                was_summarized: false,
+                is_summarized: false,
                 properties: DocumentProperties::default(),
                 tags: DocumentTags::default(),
                 embedding,
@@ -787,7 +787,7 @@ mod tests {
             vec![IngestedDocument {
                 id: doc_id.clone(),
                 snippet: snippet.clone(),
-                was_summarized: false,
+                is_summarized: false,
                 properties: DocumentProperties::default(),
                 tags: tags.clone(),
                 embedding: embedding.clone(),

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -60,6 +60,7 @@ use crate::{
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct Document {
     snippet: DocumentSnippet,
+    was_summarized: Option<bool>,
     properties: DocumentProperties,
     tags: DocumentTags,
     is_candidate: bool,
@@ -296,6 +297,7 @@ impl storage::Document for Storage {
                 documents.0.get(id).map(|document| ExcerptedDocument {
                     id: id.clone(),
                     snippet: document.snippet.clone(),
+                    was_summarized: document.was_summarized,
                     properties: document.properties.clone(),
                     tags: document.tags.clone(),
                     is_candidate: document.is_candidate,
@@ -363,6 +365,7 @@ impl storage::Document for Storage {
                 document.id.clone(),
                 Document {
                     snippet: document.snippet,
+                    was_summarized: document.was_summarized,
                     properties: document.properties,
                     tags: document.tags,
                     is_candidate: document.is_candidate,
@@ -720,6 +723,7 @@ mod tests {
             .map(|(id, embedding)| IngestedDocument {
                 id: id.clone(),
                 snippet: "snippet".try_into().unwrap(),
+                was_summarized: Some(false),
                 properties: DocumentProperties::default(),
                 tags: DocumentTags::default(),
                 embedding,
@@ -783,6 +787,7 @@ mod tests {
             vec![IngestedDocument {
                 id: doc_id.clone(),
                 snippet: snippet.clone(),
+                was_summarized: Some(false),
                 properties: DocumentProperties::default(),
                 tags: tags.clone(),
                 embedding: embedding.clone(),

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -107,7 +107,7 @@ impl Database {
             "INSERT INTO document (
                 document_id,
                 snippet,
-                was_summarized,
+                is_summarized,
                 properties,
                 tags,
                 embedding,
@@ -124,7 +124,7 @@ impl Database {
                         builder
                             .push_bind(&document.id)
                             .push_bind(&document.snippet)
-                            .push_bind(document.was_summarized)
+                            .push_bind(document.is_summarized)
                             .push_bind(Json(&document.properties))
                             .push_bind(&document.tags)
                             .push_bind(&document.embedding)
@@ -308,7 +308,7 @@ impl Database {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error> {
         let mut builder = QueryBuilder::new(
-            "SELECT document_id, snippet, was_summarized, properties, tags, is_candidate
+            "SELECT document_id, snippet, is_summarized, properties, tags, is_candidate
             FROM document
             WHERE document_id IN ",
         );
@@ -321,12 +321,12 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, was_summarized, Json(properties), tags, is_candidate) =
+                        let (id, snippet, is_summarized, Json(properties), tags, is_candidate) =
                             FromRow::from_row(&row)?;
                         Ok(ExcerptedDocument {
                             id,
                             snippet,
-                            was_summarized,
+                            is_summarized,
                             properties,
                             tags,
                             is_candidate,
@@ -394,15 +394,15 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, was_summarized, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, is_summarized, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, was_summarized, Json(properties), tags, embedding) =
+                        let (id, snippet, is_summarized, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
-                            was_summarized,
+                            is_summarized,
                             properties,
                             tags,
                             embedding,
@@ -469,15 +469,15 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, was_summarized, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, is_summarized, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, was_summarized, Json(properties), tags, embedding) =
+                        let (id, snippet, is_summarized, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
-                            was_summarized,
+                            is_summarized,
                             properties,
                             tags,
                             embedding,

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -107,6 +107,7 @@ impl Database {
             "INSERT INTO document (
                 document_id,
                 snippet,
+                was_summarized,
                 properties,
                 tags,
                 embedding,
@@ -123,6 +124,7 @@ impl Database {
                         builder
                             .push_bind(&document.id)
                             .push_bind(&document.snippet)
+                            .push_bind(document.was_summarized)
                             .push_bind(Json(&document.properties))
                             .push_bind(&document.tags)
                             .push_bind(&document.embedding)
@@ -306,7 +308,7 @@ impl Database {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error> {
         let mut builder = QueryBuilder::new(
-            "SELECT document_id, snippet, properties, tags, is_candidate
+            "SELECT document_id, snippet, was_summarized, properties, tags, is_candidate
             FROM document
             WHERE document_id IN ",
         );
@@ -319,11 +321,12 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, Json(properties), tags, is_candidate) =
+                        let (id, snippet, was_summarized, Json(properties), tags, is_candidate) =
                             FromRow::from_row(&row)?;
                         Ok(ExcerptedDocument {
                             id,
                             snippet,
+                            was_summarized,
                             properties,
                             tags,
                             is_candidate,
@@ -391,14 +394,15 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, was_summarized, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, Json(properties), tags, embedding) =
+                        let (id, snippet, was_summarized, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
+                            was_summarized,
                             properties,
                             tags,
                             embedding,
@@ -465,14 +469,15 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, was_summarized, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, Json(properties), tags, embedding) =
+                        let (id, snippet, was_summarized, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
+                            was_summarized,
                             properties,
                             tags,
                             embedding,


### PR DESCRIPTION
- [x] save original snippet instead of summary
- [x] store if the summarizer was used for an document 

**Open Questions:**

- [x] for existing documents we don't know if they used the summarizer and it's unclear how to proceed when they get re-ingested:
  - ~always recompute embedding because the summerizer option might have changed~
    - ~this is the most reliable solution but also means next (after update) ingestion of customers using the set candidate API will be potentially noticeable more expensive~
  - ~never recompute the embedding assuming the summerizer option didn't change`~
-  the solution is that because we stored summaries earlier all documents which where summarized or have a changed snippet will be detected as having a changed snippet, in turn all documents which have the same snippet have not been summarized and only need to recalculate embedding if the state of weather or not they should be summarized changes


**References:**

- issue: [ET-4674]

[ET-4674]: https://xainag.atlassian.net/browse/ET-4674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ