### PR TITLE
ET-4689-check-es-index-on-startup

### DIFF
--- a/web-api-db-ctrl/src/elastic.rs
+++ b/web-api-db-ctrl/src/elastic.rs
@@ -91,12 +91,16 @@ pub(crate) async fn migrate_tenant_index(
     Ok(())
 }
 
+const MAPPINGS: &str = "mappings";
+const PROPERTIES: &str = "properties";
+const EMBEDDING: &str = "embedding";
+
 fn check_mapping_compatibility(
     existing_mapping: &Value,
     base_mapping: &Value,
 ) -> Result<(), Error> {
-    let existing_embeddings = &existing_mapping["mappings"]["properties"]["embedding"];
-    let expected_embeddings = &base_mapping["mappings"]["properties"]["embedding"];
+    let existing_embeddings = &existing_mapping[MAPPINGS][PROPERTIES][EMBEDDING];
+    let expected_embeddings = &base_mapping[MAPPINGS][PROPERTIES][EMBEDDING];
     if existing_embeddings != expected_embeddings {
         error!({ %existing_embeddings, %expected_embeddings }, "mappings in ES have incompatible embedding definition");
         bail!("incompatible existing elasticsearch index");


### PR DESCRIPTION
- [X] on startup check the ES index, mainly check if the embedding length is as expected
- [X] make sure that in a single tenant setup a bad tenant migration will kill the whole service
  - this is  already the current behavior, :pushpin: we need to handle this better for multi tenant

**References:**

- issue: [ET-4689]

[ET-4689]: https://xainag.atlassian.net/browse/ET-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ