### PR TITLE
Use env to execute bash

### DIFF
--- a/.github/scripts/build_ci_image.sh
+++ b/.github/scripts/build_ci_image.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/usr/bin/env -S bash -e
 
 source .env
 RUST_VERSION=$(perl -ne 'print $1 if /channel = \"(.*)\"/' rust-toolchain.toml)

--- a/.github/scripts/copyright.sh
+++ b/.github/scripts/copyright.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/usr/bin/env -S bash -e
 
 files_to_check() {
     find . \

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -eu -o pipefail
+#!/usr/bin/env -S bash -eu -o pipefail
 
 realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"

--- a/.github/scripts/wait_for_it.sh
+++ b/.github/scripts/wait_for_it.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-curl -s https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh \
-    | bash -s ${@:1}


### PR DESCRIPTION
Use `env` to execute bash to better support systems where bash is not in `/bin` (like my nixos).
We are already doing this in the justfile.

`wait_for_it.sh` is not used anywhere so is removed. Was probably used in the compose file or docker image.