### PR TITLE
ET-4504 retry es once for network error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-retry-policies"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b016aa1fb364e3e0753a28bf65d59cbe377f49473fdfcac98aa870982cd100"
+dependencies = [
+ "chrono",
+ "pin-project",
+ "retry-policies",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2946,17 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
 ]
 
 [[package]]
@@ -4840,8 +4864,10 @@ name = "xayn-web-api-shared"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "derive_more",
  "displaydoc",
+ "futures-retry-policies",
  "once_cell",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ toml = "0.7.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 uuid = { version = "1.3.4", features = ["serde", "v4"] }
+futures-retry-policies = { version = "0.2.3", features = [ "tokio" ] }
 
 [profile.dev.package.tract-core]
 opt-level = 3

--- a/web-api-db-ctrl/src/elastic.rs
+++ b/web-api-db-ctrl/src/elastic.rs
@@ -16,10 +16,13 @@ use std::fmt::Debug;
 
 use anyhow::bail;
 use once_cell::sync::Lazy;
-use reqwest::{Method, StatusCode};
+use reqwest::Method;
 use serde_json::{json, Value};
 use tracing::{error, info, instrument};
-use xayn_web_api_shared::{elastic::Client, request::TenantId};
+use xayn_web_api_shared::{
+    elastic::{Client, DiscardResponse, NotFoundAsOptionExt},
+    request::TenantId,
+};
 
 use crate::Error;
 
@@ -32,26 +35,25 @@ pub async fn create_tenant_index(
     new_id: &TenantId,
     embedding_size: usize,
 ) -> Result<(), Error> {
+    let elastic = elastic.with_index(new_id);
     let mapping = mapping_with_embedding_size(&MAPPING, embedding_size)?;
     elastic
-        .with_index(new_id)
-        .request(Method::PUT, [], [])
-        .json(&mapping)
-        .send()
-        .await?
-        .error_for_status()?;
+        .query_with_json::<_, DiscardResponse>(
+            Method::PUT,
+            elastic.create_url([], []),
+            Some(&mapping),
+        )
+        .await?;
     info!({tenant_id = %new_id}, "created ES index");
     Ok(())
 }
 
 #[instrument(skip(elastic))]
 pub(super) async fn delete_tenant(elastic: &Client, tenant_id: &TenantId) -> Result<(), Error> {
+    let elastic = elastic.with_index(tenant_id);
     elastic
-        .with_index(tenant_id)
-        .request(Method::DELETE, [], [])
-        .send()
-        .await?
-        .error_for_status()?;
+        .query_with_bytes::<DiscardResponse>(Method::DELETE, elastic.create_url([], []), None)
+        .await?;
     info!({%tenant_id}, "deleted ES index");
     Ok(())
 }
@@ -125,19 +127,13 @@ async fn does_tenant_index_exist(
     elastic: &Client,
     tenant_id: impl AsRef<str> + Debug,
 ) -> Result<bool, Error> {
+    let elastic = elastic.with_index(tenant_id);
     let response = elastic
-        .with_index(tenant_id)
-        .request(Method::HEAD, [], [])
-        .send()
-        .await?;
-
-    let status = response.status();
-    if status == StatusCode::NOT_FOUND {
-        Ok(false)
-    } else {
-        response.error_for_status()?;
-        Ok(true)
-    }
+        //TODO this doesn't work as the response isn't json
+        .query_with_bytes::<DiscardResponse>(Method::HEAD, elastic.create_url([], []), None)
+        .await
+        .not_found_as_option()?;
+    Ok(response.is_some())
 }
 
 #[instrument(skip(elastic))]
@@ -170,23 +166,24 @@ async fn create_index_alias(
     index: &str,
     alias: impl AsRef<str> + Debug,
 ) -> Result<(), Error> {
+    let elastic = elastic.with_index("_aliases");
     let alias = alias.as_ref();
     elastic
-        .with_index("_aliases")
-        .request(Method::POST, [], [])
-        .json(&json!({
-            "actions": [
-            {
-                "add": {
-                "index": index,
-                "alias": alias,
+        .query_with_json::<_, DiscardResponse>(
+            Method::POST,
+            elastic.create_url([], []),
+            Some(&json!({
+                "actions": [
+                {
+                    "add": {
+                    "index": index,
+                    "alias": alias,
+                    }
                 }
-            }
-            ]
-        }))
-        .send()
-        .await?
-        .error_for_status()?;
+                ]
+            })),
+        )
+        .await?;
     info!({%index, %alias}, "created ES alias");
     Ok(())
 }

--- a/web-api-db-ctrl/src/elastic.rs
+++ b/web-api-db-ctrl/src/elastic.rs
@@ -129,8 +129,9 @@ async fn does_tenant_index_exist(
 ) -> Result<bool, Error> {
     let elastic = elastic.with_index(tenant_id);
     let response = elastic
-        //TODO this doesn't work as the response isn't json
-        .query_with_bytes::<DiscardResponse>(Method::HEAD, elastic.create_url([], []), None)
+        // Hint: Using HEAD here will fall over as HEAD requests still have
+        //       a Content-Type/Size but no content.
+        .query_with_bytes::<DiscardResponse>(Method::GET, elastic.create_url([], []), None)
         .await
         .not_found_as_option()?;
     Ok(response.is_some())

--- a/web-api-shared/Cargo.toml
+++ b/web-api-shared/Cargo.toml
@@ -8,8 +8,10 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = "1.4.0"
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
+futures-retry-policies = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -379,7 +379,8 @@ impl Client {
             let error = String::from_utf8_lossy(&body).into_owned();
             Err(Error::Status { status, url, error })
         } else {
-            Ok(response.json().await?)
+            let body = response.bytes().await?;
+            Ok(serde_json::from_slice(&body)?)
         }
     }
 

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -70,8 +70,8 @@ impl Default for Config {
             index_name: "test_index".into(),
             timeout: Duration::from_secs(2),
             retry_policy: ExponentialJitterRetryPolicyConfig {
-                max_retries: 2,
-                step_size: Duration::from_millis(150),
+                max_retries: 3,
+                step_size: Duration::from_millis(300),
                 max_backoff: Duration::from_millis(1000),
             },
         }

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -372,7 +372,7 @@ impl Client {
 
         let status = response.status();
         if status == StatusCode::NOT_FOUND {
-            Err(Error::EndpointNotFound(path))
+            Err(Error::ResourceNotFound(path))
         } else if !status.is_success() {
             let url = response.url().clone();
             let body = response.bytes().await?;
@@ -420,7 +420,7 @@ pub enum Error {
     /// Failed to serialize a requests or deserialize a response.
     Serialization(serde_json::Error),
     /// Given endpoint was not found: {0}
-    EndpointNotFound(String),
+    ResourceNotFound(String),
 }
 
 pub trait NotFoundAsOptionExt<T> {
@@ -430,7 +430,7 @@ pub trait NotFoundAsOptionExt<T> {
 impl<T> NotFoundAsOptionExt<T> for Result<T, Error> {
     fn not_found_as_option(self) -> Result<Option<T>, Error> {
         match self {
-            Err(Error::EndpointNotFound(_)) => Ok(None),
+            Err(Error::ResourceNotFound(_)) => Ok(None),
             Ok(value) => Ok(Some(value)),
             Err(error) => Err(error),
         }

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -126,6 +126,7 @@ impl Client {
     ) -> Result<T, E>
     where
         F: Future<Output = Result<T, E>>,
+        E: Display,
     {
         let policy = ExponentialJitterRetryPolicy::new(self.retry_policy.clone())
             .with_retry_filter(error_filter);

--- a/web-api-shared/src/lib.rs
+++ b/web-api-shared/src/lib.rs
@@ -19,6 +19,7 @@
 //! a per-schema db lock.
 
 pub mod elastic;
+pub mod net;
 pub mod postgres;
 pub mod request;
 pub mod serde;

--- a/web-api-shared/src/net.rs
+++ b/web-api-shared/src/net.rs
@@ -22,11 +22,16 @@ use std::{
 use derive_more::Deref;
 use futures_retry_policies::RetryPolicy;
 use rand::random;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+use crate::serde::serde_duration_in_config;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExponentialJitterRetryPolicyConfig {
     pub max_retries: u8,
+    #[serde(with = "serde_duration_in_config")]
     pub step_size: Duration,
+    #[serde(with = "serde_duration_in_config")]
     pub max_backoff: Duration,
 }
 

--- a/web-api-shared/src/net.rs
+++ b/web-api-shared/src/net.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Networking related utilities.
+
+use std::{
+    ops::{ControlFlow, Mul},
+    time::Duration,
+};
+
+use derive_more::Deref;
+use futures_retry_policies::RetryPolicy;
+use rand::random;
+
+#[derive(Debug, Clone)]
+pub struct ExponentialJitterRetryPolicyConfig {
+    pub max_retries: u8,
+    pub step_size: Duration,
+    pub max_backoff: Duration,
+}
+
+#[derive(Deref)]
+pub struct ExponentialJitterRetryPolicy<F> {
+    #[deref]
+    config: ExponentialJitterRetryPolicyConfig,
+    retry_filter: F,
+    retry_count: u8,
+}
+
+impl ExponentialJitterRetryPolicy<fn(&'_ anyhow::Error) -> bool> {
+    pub fn new(config: ExponentialJitterRetryPolicyConfig) -> Self {
+        Self {
+            config,
+            retry_count: 0,
+            retry_filter: |_err| true,
+        }
+    }
+}
+
+impl<F> ExponentialJitterRetryPolicy<F> {
+    pub fn with_retry_filter<F2, R>(self, retry_filter: F2) -> ExponentialJitterRetryPolicy<F2>
+    where
+        F2: Fn(&R) -> bool,
+    {
+        ExponentialJitterRetryPolicy {
+            config: self.config,
+            retry_count: self.retry_count,
+            retry_filter,
+        }
+    }
+
+    fn register_pending_retry(&mut self) -> Option<Duration> {
+        if self.retry_count >= self.max_retries {
+            return None;
+        }
+
+        let duration = self
+            .step_size
+            // exponential backoff
+            .mul(2u32.saturating_pow(self.retry_count as u32))
+            // upper limit for backoff sleep time
+            .min(self.max_backoff)
+            // jitter
+            .mul_f32(random());
+        self.retry_count += 1;
+        Some(duration)
+    }
+}
+
+impl<F, T, E> RetryPolicy<Result<T, E>> for ExponentialJitterRetryPolicy<F>
+where
+    F: FnMut(&E) -> bool,
+{
+    fn should_retry(&mut self, result: Result<T, E>) -> ControlFlow<Result<T, E>, Duration> {
+        if matches!(&result, Err(err) if (self.retry_filter)(err)) {
+            if let Some(backoff) = self.register_pending_retry() {
+                return ControlFlow::Continue(backoff);
+            }
+        }
+        ControlFlow::Break(result)
+    }
+}

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -24,6 +24,7 @@ use actix_web::{
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 use xayn_ai_coi::{CoiConfig, CoiSystem};
 
 use super::{
@@ -568,6 +569,7 @@ struct SemanticSearchResponse {
     documents: Vec<PersonalizedDocumentData>,
 }
 
+#[instrument(skip(state, storage))]
 async fn semantic_search(
     state: Data<AppState>,
     Json(query): Json<UnvalidatedSemanticSearchQuery>,

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -26,7 +26,7 @@ use tracing::info;
 use xayn_ai_bert::NormalizedEmbedding;
 pub(crate) use xayn_web_api_shared::elastic::{BulkInstruction, Config};
 use xayn_web_api_shared::{
-    elastic::{DiscardResponse, NotFoundAsOptionExt},
+    elastic::{NotFoundAsOptionExt, SerdeDiscard},
     serde::{json_object, merge_json_objects, JsonObject},
 };
 
@@ -243,7 +243,7 @@ impl Client {
                 }
             }
         });
-        self.query_with_json::<_, DiscardResponse>(Method::POST, url, Some(body))
+        self.query_with_json::<_, SerdeDiscard>(Method::POST, url, Some(body))
             .await?;
 
         Ok(())
@@ -267,7 +267,7 @@ impl Client {
         }));
 
         Ok(self
-            .query_with_json::<_, DiscardResponse>(Method::POST, url, body)
+            .query_with_json::<_, SerdeDiscard>(Method::POST, url, body)
             .await
             .not_found_as_option()?
             .map(|_| ()))
@@ -290,7 +290,7 @@ impl Client {
         }));
 
         Ok(self
-            .query_with_json::<_, DiscardResponse>(Method::POST, url, body)
+            .query_with_json::<_, SerdeDiscard>(Method::POST, url, body)
             .await
             .not_found_as_option()?
             .map(|_| ()))
@@ -316,7 +316,7 @@ impl Client {
         }));
 
         Ok(self
-            .query_with_json::<_, DiscardResponse>(Method::POST, url, body)
+            .query_with_json::<_, SerdeDiscard>(Method::POST, url, body)
             .await
             .not_found_as_option()?
             .map(|_| ()))
@@ -340,7 +340,7 @@ impl Client {
         }));
 
         Ok(self
-            .query_with_json::<_, DiscardResponse>(Method::POST, url, body)
+            .query_with_json::<_, SerdeDiscard>(Method::POST, url, body)
             .await
             .not_found_as_option()?
             .map(|_| Some(())))
@@ -364,7 +364,7 @@ impl Client {
         }));
 
         Ok(self
-            .query_with_json::<_, DiscardResponse>(Method::POST, url, body)
+            .query_with_json::<_, SerdeDiscard>(Method::POST, url, body)
             .await
             .not_found_as_option()?
             .map(|_| ()))
@@ -413,7 +413,7 @@ impl Client {
         });
 
         let url = self.create_url(["_mapping"], []);
-        self.query_with_json::<_, DiscardResponse>(Method::PUT, url, Some(body))
+        self.query_with_json::<_, SerdeDiscard>(Method::PUT, url, Some(body))
             .await?;
 
         info!("extended ES _mapping");
@@ -446,7 +446,7 @@ impl Client {
                 ),
             ],
         );
-        self.query_with_json::<(), DiscardResponse>(Method::POST, url, None)
+        self.query_with_json::<(), SerdeDiscard>(Method::POST, url, None)
             .await?;
 
         info!("started index update process");

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -36,7 +36,7 @@ use sqlx::{
     QueryBuilder,
     Transaction,
 };
-use tracing::info;
+use tracing::{info, instrument};
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiId, CoiStats};
 
@@ -790,6 +790,7 @@ impl storage::Document for Storage {
         Ok(documents)
     }
 
+    #[instrument(skip(self))]
     async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
         let mut tx = self.postgres.begin().await?;
         let embedding = Database::get_embedding(&mut tx, id).await?;

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "tic",
       "password": "[REDACTED]",
       "index_name": "other_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "other_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "test_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "elastic",
       "password": "[REDACTED]",
       "index_name": "test_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "test_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "elastic",
       "password": "[REDACTED]",
       "index_name": "test_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "tic",
       "password": "[REDACTED]",
       "index_name": "other_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "other_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "test_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "elastic",
       "password": "[REDACTED]",
       "index_name": "test_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "tic",
       "password": "[REDACTED]",
       "index_name": "other_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "other_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -20,7 +20,12 @@ stdout = """
       "user": "tic",
       "password": "[REDACTED]",
       "index_name": "other_index",
-      "timeout": 2
+      "timeout": 2,
+      "retry_policy": {
+        "max_retries": 2,
+        "step_size": "150ms",
+        "max_backoff": "1s"
+      }
     },
     "postgres": {
       "base_url": "postgres://user:pw@localhost:5432/xayn",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -22,8 +22,8 @@ stdout = """
       "index_name": "other_index",
       "timeout": 2,
       "retry_policy": {
-        "max_retries": 2,
-        "step_size": "150ms",
+        "max_retries": 3,
+        "step_size": "300ms",
         "max_backoff": "1s"
       }
     },


### PR DESCRIPTION
Add a retry police which is used when requests to elasticsearch fail due to network errors.

- [x] retry elasticsearch requests in web-api if they fail due to network errors
- [x] retry elasticsearch requests for silo api
- [x] check timeouts applies at higher level places

**References:**

- issue: [ET-4504]

[ET-4504]: https://xainag.atlassian.net/browse/ET-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ