### PR TITLE
ET-4772 improve generated docs

### DIFF
--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -1,4 +1,5 @@
 openapi: 3.1.0
+
 info:
   title: Back Office API
   version: 2.3.0
@@ -32,9 +33,35 @@ info:
     Properties are optional data for documents, which are usually needed to properly show the document back to the user, when it returns as a personalized document.
     If for example, you'd wish to integrate a type of carousel view, listing a total of 10 personalized documents in a "for you"-section, then you might choose to display each document as an image and title, with a url to link the user to when pressed.
     For this, you would need three document properties: `image`, `link` and `title`.
+  x-logo:
+    url: https://uploads-ssl.webflow.com/5ea197660b956f76d26f0026/637f7edd68c1ae2f12d4689e_Xayn%20Logo%202022%20-%20Footer.svg
+    altText: Xayn
 tags:
   - name: back office
     description: System management, including documents and properties.
+    x-traitTag: true
+  - name: documents
+    x-displayName: Documents
+  - name: candidates
+    x-displayName: Document candidates
+  - name: properties
+    x-displayName: Document properties
+  - name: property
+    x-displayName: Document property
+  - name: property indexing
+    x-displayName: Document property indexing
+x-tagGroups:
+  - name: Documents
+    tags:
+      - documents
+  - name: Document candidates
+    tags:
+      - candidates
+  - name: Document properties
+    tags:
+      - properties
+      - property
+      - property indexing
 
 security:
   - ApiKeyAuth: []
@@ -44,6 +71,7 @@ paths:
     post:
       tags:
         - back office
+        - documents
       summary: Add documents to the system.
       description: |
         Add documents to the system.
@@ -75,6 +103,7 @@ paths:
     delete:
       tags:
         - back office
+        - documents
       summary: Delete all listed documents.
       description: Delete all documents listed in the request body.
       operationId: deleteDocuments
@@ -94,6 +123,7 @@ paths:
     get:
       tags:
         - back office
+        - candidates
       summary: Get the documents considered for recommendations.
       description: Get the documents considered for recommendations.
       operationId: listDocumentCandidates
@@ -109,6 +139,7 @@ paths:
     put:
       tags:
         - back office
+        - candidates
       summary: Set the documents considered for recommendations.
       description: Set the documents considered for recommendations.
       operationId: replaceDocumentCandidates
@@ -128,6 +159,7 @@ paths:
     get:
       tags:
         - back office
+        - property indexing
       summary: Get the schema of all indexed properties.
       description: Get the schema of all indexed properties.
       operationId: getIndexedPropertiesSchema
@@ -141,6 +173,7 @@ paths:
     post:
       tags:
         - back office
+        - property indexing
       summary: Add additional indexed properties to the schema.
       description: |-
         Add additional indexed properties to the schema.
@@ -192,6 +225,7 @@ paths:
     delete:
       tags:
         - back office
+        - documents
       summary: Delete the document from the system.
       description: |-
         Permanently deletes the document from the system.
@@ -208,6 +242,7 @@ paths:
     get:
       tags:
         - back office
+        - properties
       summary: Get all document properties
       description: Gets all the properties of the document.
       operationId: listDocumentProperties
@@ -223,6 +258,7 @@ paths:
     put:
       tags:
         - back office
+        - properties
       summary: Set all document properties
       description: Sets or replaces all the properties of the document.
       operationId: replaceDocumentProperties
@@ -240,6 +276,7 @@ paths:
     delete:
       tags:
         - back office
+        - properties
       summary: Delete all document properties
       description: Deletes all the properties of the document.
       operationId: deleteDocumentProperties
@@ -261,6 +298,7 @@ paths:
     get:
       tags:
         - back office
+        - property
       summary: Get a document property
       description: Gets the property of the document.
       operationId: getDocumentProperty
@@ -276,6 +314,7 @@ paths:
     put:
       tags:
         - back office
+        - property
       summary: Set a document property
       description: Sets or replaces the property of the document.
       operationId: replaceDocumentProperty
@@ -293,6 +332,7 @@ paths:
     delete:
       tags:
         - back office
+        - property
       summary: Delete a document property
       description: Deletes the property of the document.
       operationId: deleteDocumentProperty

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -8,13 +8,13 @@ info:
     This API acts as a create/read/update/delete interface for anything related to documents.
 
     ## Format
-    All the request bodies in this API are JSON encoded and their `Content-Type` headers should be set to `application/json`.
+    All the request bodies in this API are JSON encoded and their `content-type` header should be set to `application/json`.
 
     ## Auth
     The API requires to set the `authorizationToken` header when used with the provided token.
 
     ## Document
-    By document, we refer to a cohesive text, for example a complete news article.
+    As a document we consider a cohesive text, for example a complete news article.
     However, we only require a simple representation for our system to work. Consisting just of a unique id, a text snippet, optional properties and optional tags.
     The text snippet is ideally a short, meaningful representation of the larger document, reduced to just one paragraph.
 
@@ -33,6 +33,10 @@ info:
     Properties are optional data for documents, which are usually needed to properly show the document back to the user, when it returns as a personalized document.
     If for example, you'd wish to integrate a type of carousel view, listing a total of 10 personalized documents in a "for you"-section, then you might choose to display each document as an image and title, with a url to link the user to when pressed.
     For this, you would need three document properties: `image`, `link` and `title`.
+
+    ### Tags
+    Tags are optional data for documents, which are used to improve the scoring in document searches. Each document can have multiple tags.
+    For example, tags can be categories which the documents can be assigned to.
   x-logo:
     url: https://uploads-ssl.webflow.com/5ea197660b956f76d26f0026/637f7edd68c1ae2f12d4689e_Xayn%20Logo%202022%20-%20Footer.svg
     altText: Xayn
@@ -72,11 +76,9 @@ paths:
       tags:
         - back office
         - documents
-      summary: Add documents to the system.
-      description: |
-        Add documents to the system.
-
-        The system will create a representation of the document that will be used to match it against the preferences of a user.
+      summary: Ingest documents
+      description: |-
+        Upsert documents to the system, which creates a representation of the document that will be used to match it against the preferences of a user.
 
         **Important note:** If you need to add more documents than the maximum batch size, then
         please split up the total amount of documents in separate calls.
@@ -93,9 +95,13 @@ paths:
         '201':
           $ref: './responses/generic.yml#/Created'
         '400':
-          $ref: './responses/generic.yml#/BadRequest'
+          description: Validation (partially) failed, see `details`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IngestionBadRequest'
         '500':
-          description: All or some of the documents were not successfully uploaded
+          description: Ingestion (partially) failed, see `details`.
           content:
             application/json:
               schema:
@@ -104,8 +110,8 @@ paths:
       tags:
         - back office
         - documents
-      summary: Delete all listed documents.
-      description: Delete all documents listed in the request body.
+      summary: Delete documents
+      description: Delete all listed documents.
       operationId: deleteDocuments
       requestBody:
         required: true
@@ -115,7 +121,7 @@ paths:
               $ref: '#/components/schemas/DeleteDocumentsRequest'
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
@@ -124,12 +130,12 @@ paths:
       tags:
         - back office
         - candidates
-      summary: Get the documents considered for recommendations.
+      summary: Get document candidates
       description: Get the documents considered for recommendations.
       operationId: listDocumentCandidates
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -140,7 +146,7 @@ paths:
       tags:
         - back office
         - candidates
-      summary: Set the documents considered for recommendations.
+      summary: Set document candidates
       description: Set the documents considered for recommendations.
       operationId: replaceDocumentCandidates
       requestBody:
@@ -151,7 +157,7 @@ paths:
               $ref: '#/components/schemas/DocumentCandidatesRequest'
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
@@ -160,12 +166,12 @@ paths:
       tags:
         - back office
         - property indexing
-      summary: Get the schema of all indexed properties.
+      summary: Get indexed properties
       description: Get the schema of all indexed properties.
       operationId: getIndexedPropertiesSchema
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -174,14 +180,14 @@ paths:
       tags:
         - back office
         - property indexing
-      summary: Add additional indexed properties to the schema.
+      summary: Add indexed properties
       description: |-
         Add additional indexed properties to the schema.
 
         The schema can have at most 11 properties in total, including the
         automatically created `publication_date` property.
 
-        If you plan to create multiple indexed properties it is strongly
+        If you plan to create multiple indexed properties, it is strongly
         recommended to do so with one request.
 
         For now it is not possible to modify or delete indexed properties
@@ -209,9 +215,10 @@ paths:
               $ref: '#/components/schemas/ExtendIndexedPropertiesRequest'
       responses:
         '202':
+          x-summary: Successful operation.
           description: |-
-            the new complete indexed property schema is returned,
-            through updating the index happens in a background job
+            The new complete indexed property schema is returned,
+            though updating the index happens in a background job.
           content:
             application/json:
               schema:
@@ -221,34 +228,33 @@ paths:
 
   /documents/{document_id}:
     parameters:
-      - $ref: './parameters/path/document_id.yml'
+      - $ref: './parameters/path/id.yml#/DocumentId'
     delete:
       tags:
         - back office
         - documents
-      summary: Delete the document from the system.
-      description: |-
-        Permanently deletes the document from the system.
+      summary: Delete document
+      description: Delete the listed document.
       operationId: deleteDocument
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
   /documents/{document_id}/properties:
     parameters:
-      - $ref: './parameters/path/document_id.yml'
+      - $ref: './parameters/path/id.yml#/DocumentId'
     get:
       tags:
         - back office
         - properties
-      summary: Get all document properties
-      description: Gets all the properties of the document.
+      summary: Get document properties
+      description: Get all the properties of the document.
       operationId: listDocumentProperties
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -259,8 +265,8 @@ paths:
       tags:
         - back office
         - properties
-      summary: Set all document properties
-      description: Sets or replaces all the properties of the document.
+      summary: Set document properties
+      description: Set or replace all the properties of the document.
       operationId: replaceDocumentProperties
       requestBody:
         required: true
@@ -270,41 +276,36 @@ paths:
               $ref: '#/components/schemas/DocumentPropertiesRequest'
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
     delete:
       tags:
         - back office
         - properties
-      summary: Delete all document properties
-      description: Deletes all the properties of the document.
+      summary: Delete document properties
+      description: Delete all the properties of the document.
       operationId: deleteDocumentProperties
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
   /documents/{document_id}/properties/{property_id}:
     parameters:
-      - $ref: './parameters/path/document_id.yml'
-      - name: property_id
-        in: path
-        description: Id of the document property
-        required: true
-        schema:
-          $ref: './schemas/document.yml#/DocumentPropertyId'
+      - $ref: './parameters/path/id.yml#/DocumentId'
+      - $ref: './parameters/path/id.yml#/DocumentPropertyId'
     get:
       tags:
         - back office
         - property
-      summary: Get a document property
-      description: Gets the property of the document.
+      summary: Get document property
+      description: Get the property of the document.
       operationId: getDocumentProperty
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -315,8 +316,8 @@ paths:
       tags:
         - back office
         - property
-      summary: Set a document property
-      description: Sets or replaces the property of the document.
+      summary: Set document property
+      description: Set or replace the property of the document.
       operationId: replaceDocumentProperty
       requestBody:
         required: true
@@ -326,19 +327,19 @@ paths:
               $ref: '#/components/schemas/DocumentPropertyRequest'
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
     delete:
       tags:
         - back office
         - property
-      summary: Delete a document property
-      description: Deletes the property of the document.
+      summary: Delete document property
+      description: Delete the property of the document.
       operationId: deleteDocumentProperty
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
           $ref: './responses/generic.yml#/BadRequest'
 
@@ -409,7 +410,7 @@ components:
         id:
           $ref: './schemas/document.yml#/DocumentId'
         snippet:
-          description: |
+          description: |-
             Text that will be used to match the document against the user interests.
             Enclosing whitespace will be trimmed.
             The length constraints are in bytes, not characters.
@@ -421,30 +422,31 @@ components:
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
         tags:
+          description:
+            $ref: './schemas/document.yml#/DocumentTag/description'
           type: array
           minItems: 0
           maxItems: 10
           items:
             $ref: './schemas/document.yml#/DocumentTag'
         is_candidate:
-          description: |
+          description: |-
             Indicates if the document is considered for recommendations.
+            Always overwrites any existing `is_candidate` value from a previous ingestion.
 
-            Always overwrite any existing `is_candidate` value from a previous ingestion.
-
-            Setting both this field and the `default_is_candidate` field will fail the request.
-
+            Setting both `is_candidate` and `default_is_candidate` is invalid.
             Setting neither will default to `is_candidate = true`.
           type: boolean
         default_is_candidate:
-          description: |
+          description: |-
             Behaves like `is_candidate` but will not overwrite any existing `is_candidate`
             value already stored in the database for this document.
 
-            Setting both this field and the `is_candidate` field will fail the request.
+            Setting both `is_candidate` and `default_is_candidate` is invalid.
+            Setting neither will default to `is_candidate = true`.
           type: boolean
         summarize:
-          description: Summarizes the document snippets before further processing.
+          description: Summarize the document snippets before further processing.
           type: boolean
           default: false
       example:
@@ -457,7 +459,6 @@ components:
           - tech
         is_candidate: true
         summarize: false
-
     IngestionRequest:
       type: object
       required: [documents]
@@ -486,6 +487,27 @@ components:
           - id: document_3
             snippet: quite a lot of lines of lorem ipsum delores
             summarize: true
+    IngestionBadRequest:
+      allOf:
+        - $ref: './schemas/error.yml#/GenericError'
+        - type: object
+          required: [details]
+          properties:
+            details:
+              type: object
+              required: [documents]
+              properties:
+                documents:
+                  description: Validation of these documents failed.
+                  type: array
+                  minItems: 0
+                  maxItems: 100
+                  items:
+                    type: object
+                    required: [id]
+                    properties:
+                      id:
+                        $ref: './schemas/document.yml#/DocumentId'
     IngestionError:
       allOf:
         - $ref: './schemas/error.yml#/GenericError'
@@ -497,6 +519,7 @@ components:
               required: [documents]
               properties:
                 documents:
+                  description: Ingestion of these documents failed.
                   type: array
                   minItems: 0
                   maxItems: 100
@@ -511,6 +534,8 @@ components:
       required: [documents]
       properties:
         documents:
+          description:
+            $ref: './schemas/document.yml#/DocumentId/description'
           type: array
           minItems: 1
           maxItems: 1000
@@ -536,6 +561,8 @@ components:
       required: [documents]
       properties:
         documents:
+          description:
+            $ref: './schemas/document.yml#/DocumentId/description'
           type: array
           minItems: 0
           items:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -6,16 +6,16 @@ info:
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.
-    With this API, you can handle interactions with documents and request a list of personalized documents.
+    With this API, you can handle interactions with documents and search for personalized documents.
 
     ## Format
-    All the request bodies in this API are JSON encoded and their `Content-Type` headers should be set to `application/json`.
+    All the request bodies in this API are JSON encoded and their `content-type` header should be set to `application/json`.
 
     ## Auth
     The API requires to set the `authorizationToken` header when used with the provided token.
 
     ## User
-    Each method requires a `user_id`.
+    Most methods require a `user_id`.
     From our perspective, a `user_id` is simply required to group interactions together. We don't need to know who that user is, so it is preferred to create this `user_id` in a privacy-preserving way.
     For example, create a hash method which transforms your user into an ID hash.
 
@@ -52,16 +52,16 @@ paths:
       tags:
         - front office
         - search
-      summary: Gets personalized documents for the user.
+      summary: Get personalized documents for the user
       description: |-
-        Returns a list of documents personalized for the given `user_id`.
+        Get a list of documents personalized for the given `user_id`.
         Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
         The documents also contain their properties if this is requested and the properties are not empty.
         Documents that have been interacted with by the user are filtered out from the result.
         Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.
       operationId: getPersonalizedDocuments
       parameters:
-        - $ref: './parameters/path/user_id.yml'
+        - $ref: './parameters/path/id.yml#/UserId'
         - name: count
           in: query
           description:
@@ -92,7 +92,7 @@ paths:
             $ref: '#/components/schemas/Filter'
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -100,7 +100,7 @@ paths:
         '400':
           $ref: './responses/generic.yml#/BadRequest'
         '409':
-          description: impossible to create a personalized list for the user.
+          description: Impossible to create a personalized documents for the user.
           content:
             application/json:
               schema:
@@ -111,14 +111,14 @@ paths:
       tags:
         - front office
         - interaction
-      summary: Adds an interaction between the user and the document.
+      summary: Add a document interaction for the user
       description: |-
-        Use this method to register an interaction between a user and a document.
+        Register an interaction between a user and a document.
         For web sites, consider triggering this method whenever a certain document url loads, preferably after the user spent some time on the page, in order to prevent false positives.
-        For apps, consider implementing a "like" button, where the on click then triggers this method.
+        For apps, consider implementing a "like" button, where the on-click triggers this method.
       operationId: updateUserInteractions
       parameters:
-        - $ref: './parameters/path/user_id.yml'
+        - $ref: './parameters/path/id.yml#/UserId'
       requestBody:
         required: true
         content:
@@ -127,9 +127,9 @@ paths:
               $ref: '#/components/schemas/UserInteractionRequest'
       responses:
         '204':
-          description: successful operation
+          description: Successful operation.
         '400':
-          description: invalid request. User or document id is invalid
+          description: User or document id is invalid.
           content:
             application/json:
               schema:
@@ -140,15 +140,15 @@ paths:
       tags:
         - front office
         - search
-      summary: Search through documents.
+      summary: Semantic search in documents
       description: |-
-        This endpoint allows you to search through the documents in different ways.
-        When a document id is used, the system will return documents that are similar to the one in input.
-        When a query is provided, the system will return documents that are similar to the query.
+        Semantically search through the documents in different ways.
+        When a document `id` is used, the system will return documents that are similar to the one in input.
+        When a `query` is provided, the system will return documents that are similar to the query.
         If `enable_hybrid_search` is passed, then the system will also perform keyword matching between the query and the documents.
         It is possible to personalize the result by passing a user id or history. In this case, the system will consider the user's interests to rank the documents.
-        Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document is more similar to the one in input.
-        The documents also contain their properties if this is requested and the properties are not empty.
+        Each document contains the `id` and the `score`, which is a value between 0 and 1 where a higher value means that the document is more similar to the input.
+        The documents also contain their `properties` if this is requested and the properties are not empty.
       operationId: getSimilarDocuments
       requestBody:
         required: true
@@ -158,7 +158,7 @@ paths:
               $ref: '#/components/schemas/SemanticSearchRequest'
       responses:
         '200':
-          description: successful operation
+          description: Successful operation.
           content:
             application/json:
               schema:
@@ -172,14 +172,14 @@ components:
       $ref: './securitySchemes/auth.yml#/ApiKeyAuth'
   schemas:
     Count:
-      description: Maximum number of personalized documents to return
+      description: Maximum number of documents to return.
       type: integer
       format: int32
       minimum: 1
       maximum: 100
       default: 10
     IncludeProperties:
-      description: Include the properties of each document in the response
+      description: Include the properties of each document in the response.
       type: boolean
       default: true
     FilterCompare:
@@ -188,18 +188,19 @@ components:
         type: object
         properties:
           $eq:
-            $ref: ./schemas/document.yml#/DocumentPropertyString
+            $ref: './schemas/document.yml#/DocumentPropertyString'
           $in:
-            $ref: ./schemas/document.yml#/DocumentPropertyArrayString
-            maxItems: 500
+            allOf:
+              - $ref: './schemas/document.yml#/DocumentPropertyArrayString'
+              - maxItems: 500
           $gt:
-            $ref: ./schemas/time.yml#/Timestamp
+            $ref: './schemas/time.yml#/Timestamp'
           $gte:
-            $ref: ./schemas/time.yml#/Timestamp
+            $ref: './schemas/time.yml#/Timestamp'
           $lt:
-            $ref: ./schemas/time.yml#/Timestamp
+            $ref: './schemas/time.yml#/Timestamp'
           $lte:
-            $ref: ./schemas/time.yml#/Timestamp
+            $ref: './schemas/time.yml#/Timestamp'
         minProperties: 1
         maxProperties: 1
         x-additionalPropertiesName: document property id
@@ -227,10 +228,14 @@ components:
       minProperties: 1
       maxProperties: 1
     Filter:
-      description: |
+      description: |-
         Filter the documents wrt their properties.
+
+        *Comparison:*
         A key must be a valid `DocumentPropertyId`.
         The `DocumentProperty` type corresponding to the `DocumentPropertyId` must support the filter operation.
+
+        *Combination:*
         Combinators may only be nested two times.
       oneOf:
         - $ref: '#/components/schemas/FilterCompare'
@@ -242,6 +247,7 @@ components:
         id:
           $ref: './schemas/document.yml#/DocumentId'
         score:
+          description: A number in the interval `[0, 1]` where higher means better.
           type: number
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
@@ -283,7 +289,7 @@ components:
             exclude_seen:
               type: boolean
               default: true
-              description: |
+              description: |-
                 If true do not include documents the user has already seen as search candidate.
 
                 A trimmed version of the users history might be used for this filter.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -1,4 +1,5 @@
 openapi: 3.1.0
+
 info:
   title: Front Office API
   version: 2.3.0
@@ -23,9 +24,24 @@ info:
     In order to display a document in an interface, it's preferred to use `properties`, which is an arbitrary collection of values.
     For example, it could contain an image url, a full article url, the publication date, the author or much more.
     The properties that were added when the document was submitted to us, are just mirrored here.
+  x-logo:
+    url: https://uploads-ssl.webflow.com/5ea197660b956f76d26f0026/637f7edd68c1ae2f12d4689e_Xayn%20Logo%202022%20-%20Footer.svg
+    altText: Xayn
 tags:
   - name: front office
     description: Handles interactions between users and documents and allows to fetch personalized documents per user.
+    x-traitTag: true
+  - name: interaction
+    x-displayName: Interaction
+  - name: search
+    x-displayName: Search
+x-tagGroups:
+  - name: Interaction
+    tags:
+      - interaction
+  - name: Search
+    tags:
+      - search
 
 security:
   - ApiKeyAuth: []
@@ -35,6 +51,7 @@ paths:
     get:
       tags:
         - front office
+        - search
       summary: Gets personalized documents for the user.
       description: |-
         Returns a list of documents personalized for the given `user_id`.
@@ -93,6 +110,7 @@ paths:
     patch:
       tags:
         - front office
+        - interaction
       summary: Adds an interaction between the user and the document.
       description: |-
         Use this method to register an interaction between a user and a document.
@@ -121,6 +139,7 @@ paths:
     post:
       tags:
         - front office
+        - search
       summary: Search through documents.
       description: |-
         This endpoint allows you to search through the documents in different ways.
@@ -181,6 +200,9 @@ components:
             $ref: ./schemas/time.yml#/Timestamp
           $lte:
             $ref: ./schemas/time.yml#/Timestamp
+        minProperties: 1
+        maxProperties: 1
+        x-additionalPropertiesName: document property id
       minProperties: 1
       maxProperties: 1
     FilterCombine:

--- a/web-api/openapi/parameters/path/document_id.yml
+++ b/web-api/openapi/parameters/path/document_id.yml
@@ -1,6 +1,0 @@
-name: document_id
-in: path
-description: Id of the document
-required: true
-schema:
-  $ref: '../../schemas/document.yml#/DocumentId'

--- a/web-api/openapi/parameters/path/id.yml
+++ b/web-api/openapi/parameters/path/id.yml
@@ -1,0 +1,26 @@
+DocumentId:
+  name: document_id
+  in: path
+  description:
+    $ref: '../../schemas/document.yml#/DocumentId/description'
+  required: true
+  schema:
+    $ref: '../../schemas/document.yml#/DocumentId'
+
+DocumentPropertyId:
+  name: property_id
+  in: path
+  description:
+    $ref: '../../schemas/document.yml#/DocumentPropertyId/description'
+  required: true
+  schema:
+    $ref: '../../schemas/document.yml#/DocumentPropertyId'
+
+UserId:
+  name: user_id
+  in: path
+  description:
+    $ref: '../../schemas/user.yml#/UserId/description'
+  required: true
+  schema:
+    $ref: '../../schemas/user.yml#/UserId'

--- a/web-api/openapi/parameters/path/user_id.yml
+++ b/web-api/openapi/parameters/path/user_id.yml
@@ -1,6 +1,0 @@
-name: user_id
-in: path
-description: Id of the user
-required: true
-schema:
-  $ref: '../../schemas/user.yml#/UserId'

--- a/web-api/openapi/responses/generic.yml
+++ b/web-api/openapi/responses/generic.yml
@@ -1,5 +1,5 @@
 Created:
-  description: Successful operation
+  description: Successful operation.
   content:
     application/json:
       schema:

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -1,15 +1,15 @@
 DocumentId:
-  description: Id of a document.
+  description:
+    $ref: './id.yml#/Id/description'
   $ref: './id.yml#/Id'
-  example: "document_id"
 
 DocumentPropertyId:
-  description: Id of a property of a document.
+  description:
+    $ref: './id.yml#/IdNoDot/description'
   $ref: './id.yml#/IdNoDot'
-  example: "title"
 
 DocumentPropertyString:
-  description: |
+  description: |-
     Arbitrary string property that can be attached to a document.
     The length constraints are in bytes, not characters.
   type: string
@@ -18,7 +18,7 @@ DocumentPropertyString:
   maxLength: 2048
 
 DocumentPropertyArrayString:
-  description: |
+  description: |-
     Arbitrary array of strings property that can be attached to a document.
     The item length constraints are in bytes, not characters.
   type: array
@@ -28,8 +28,8 @@ DocumentPropertyArrayString:
   maxItems: 100
 
 DocumentProperty:
-  description: |
-    Arbitrary data that can be attached to a document. A subset of JSON is supported.
+  description: |-
+    Mostly arbitrary data that can be attached to a document. A subset of JSON is supported.
     When a property is set to null or an empty array, it is treated as if that property had no values.
     This means that they won't appear in searches with filters on these properties.
   oneOf:
@@ -39,10 +39,9 @@ DocumentProperty:
     - $ref: '#/DocumentPropertyString'
     - $ref: '#/DocumentPropertyArrayString'
     - $ref: './time.yml#/Timestamp'
-  example: "News title"
 
 DocumentProperties:
-  description: |
+  description: |-
     Mostly arbitrary properties that can be attached to a document, up to 2.5KB in size.
     A key must be a valid `DocumentPropertyId`.
   type: object
@@ -52,13 +51,9 @@ DocumentProperties:
   additionalProperties:
     $ref: '#/DocumentProperty'
     x-additionalPropertiesName: document property id
-  example:
-    title: "News title"
-    image_url: "http://example.com/news_image.jpg"
-    link: "http://example.com/this_news"
 
 DocumentTag:
-  description: |
+  description: |-
     A tag of a document can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
     Enclosing whitespace will be trimmed.
     The length constraints are in bytes, not characters.
@@ -66,10 +61,9 @@ DocumentTag:
   pattern: '^[^\x00]+$'
   minLength: 1
   maxLength: 256
-  example: "tag"
 
 DocumentSearchQuery:
-  description: |
+  description: |-
     A search query can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
     The length constraints are in bytes, not characters.
   type: string
@@ -105,16 +99,18 @@ HistoryEntry:
       $ref: './time.yml#/Timestamp'
 
 InputDocument:
-  description: |
+  description: |-
     Information about a document provided as input for an search.
 
-    You can either include an existing Document's `id`, or use query which can hold arbitrary free text.
+    You can either include an existing document `id`, or use `query` which can hold arbitrary free text.
   type: object
   properties:
     id:
       $ref: '#/DocumentId'
     query:
       $ref: '#/DocumentSearchQuery'
+  minProperties: 1
+  maxProperties: 1
 
 IndexedPropertiesSchema:
   type: object

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -51,6 +51,7 @@ DocumentProperties:
       $ref: './time.yml#/PublicationDate'
   additionalProperties:
     $ref: '#/DocumentProperty'
+    x-additionalPropertiesName: document property id
   example:
     title: "News title"
     image_url: "http://example.com/news_image.jpg"
@@ -123,6 +124,7 @@ IndexedPropertiesSchema:
     Be aware that the keys of the object must be valid `DocumentPropertyId`.
   additionalProperties:
     $ref: '#/IndexedPropertyDefinition'
+    x-additionalPropertiesName: document property id
 
 IndexedPropertyDefinition:
   type: object

--- a/web-api/openapi/schemas/error.yml
+++ b/web-api/openapi/schemas/error.yml
@@ -2,7 +2,7 @@ GenericError:
   type: object
   properties:
     request_id:
-      description: Request ID optionally generated from the service. It can be communicated to xayn to help debugging.
+      description: Request ID optionally generated from the service. It can be communicated to Xayn to help debugging.
       type: string
     kind:
       description: What kind of error this is.

--- a/web-api/openapi/schemas/id.yml
+++ b/web-api/openapi/schemas/id.yml
@@ -7,7 +7,7 @@ Id:
   pattern: '^[a-zA-Z0-9\-:@.][a-zA-Z0-9\-:@._]*$'
   minLength: 1
   maxLength: 256
-  example: "valid_id1"
+  example: "id1"
 
 IdNoDot:
   description: |-
@@ -18,4 +18,4 @@ IdNoDot:
   pattern: '^[a-zA-Z0-9\-:@][a-zA-Z0-9\-:@_]*$'
   minLength: 1
   maxLength: 256
-  example: "valid_id1"
+  example: "id1"

--- a/web-api/openapi/schemas/time.yml
+++ b/web-api/openapi/schemas/time.yml
@@ -18,7 +18,7 @@ PublishedAfter:
     $ref: '#/PublicationDate/minLength'
   maxLength:
     $ref: '#/PublicationDate/maxLength'
-  description: Deprecated. Use a `filter` on the document property instead.
+  description: Deprecated. Use a `filter` on the document property instead, for example on `publication_date`.
 
 Timestamp:
   type: string
@@ -28,7 +28,7 @@ Timestamp:
   # but to avoid any accidents we go with 40
   maxLength: 40
   example: "2000-05-14T20:22:50Z"
-  description: |
+  description: |-
     A RFC3339 compatible date-time
 
     - can be in the future

--- a/web-api/openapi/schemas/user.yml
+++ b/web-api/openapi/schemas/user.yml
@@ -1,10 +1,10 @@
 UserId:
-  description: Id of a user.
+  description:
+    $ref: './id.yml#/Id/description'
   $ref: './id.yml#/Id'
-  example: "user_id"
 
 InputUser:
-  description: |
+  description: |-
     Information about a user provided as input for an search
 
     Currently this can _either_ be the user's `id` or a user's `history`.


### PR DESCRIPTION
**Reference**

- [ET-4772]

**Summary**

it is probably best to visually review these changes via the `just generate-openapi-doc` command:
- group routes into sections
- improve phrasing and layout


[ET-4772]: https://xainag.atlassian.net/browse/ET-4772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ