### PR TITLE
ET-4812 configurable snippet & properties limits

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -103,6 +103,7 @@ impl_application_error!(InvalidDocumentProperty => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct InvalidDocumentProperties {
     pub(crate) size: usize,
+    pub(crate) max_size: usize,
 }
 
 impl_application_error!(InvalidDocumentProperties => BAD_REQUEST, INFO);
@@ -123,10 +124,12 @@ pub(crate) struct InvalidDocumentTags {
 
 impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 
-/// Malformed document snippet.
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidDocumentSnippet {
-    pub(crate) value: String,
+pub(crate) enum InvalidDocumentSnippet {
+    /// Malformed document snippet.
+    Value { value: String },
+    /// Malsized document snippet.
+    Size { size: usize, max_size: usize },
 }
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -69,6 +69,8 @@ pub struct IngestionConfig {
     pub(crate) max_document_batch_size: usize,
     pub(crate) max_indexed_properties: usize,
     pub(crate) index_update: IndexUpdateConfig,
+    pub(crate) max_snippet_size: usize,
+    pub(crate) max_properties_size: usize,
 }
 
 impl Default for IngestionConfig {
@@ -78,6 +80,8 @@ impl Default for IngestionConfig {
             // 10 + publication_date
             max_indexed_properties: 11,
             index_update: IndexUpdateConfig::default(),
+            max_snippet_size: 2_048,
+            max_properties_size: 2_560,
         }
     }
 }

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -101,7 +101,7 @@ impl State {
         .into_iter()
         .map(|document| (document.id.clone(), document))
         .collect::<HashMap<_, _>>();
-        let snippet = DocumentSnippet::try_from("snippet" /* unused for in-memory db */)?;
+        let snippet = DocumentSnippet::new("snippet" /* unused for in-memory db */, 100)?;
         let documents = embeddings
             .into_iter()
             .map(|(id, embedding)| {

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -722,7 +722,7 @@ mod tests {
             .zip(embeddings)
             .map(|(id, embedding)| IngestedDocument {
                 id: id.clone(),
-                snippet: "snippet".try_into().unwrap(),
+                snippet: DocumentSnippet::new("snippet", 100).unwrap(),
                 is_summarized: false,
                 properties: DocumentProperties::default(),
                 tags: DocumentTags::default(),
@@ -779,7 +779,7 @@ mod tests {
     async fn test_serde() {
         let storage = Storage::default();
         let doc_id = DocumentId::try_from("42").unwrap();
-        let snippet = DocumentSnippet::try_from("snippet").unwrap();
+        let snippet = DocumentSnippet::new("snippet", 100).unwrap();
         let tags = DocumentTags::try_from(vec!["tag".try_into().unwrap()]).unwrap();
         let embedding = NormalizedEmbedding::try_from([1., 2., 3.]).unwrap();
         storage::Document::insert(

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -40,7 +40,9 @@ stdout = """
     "index_update": {
       "requests_per_second": 500,
       "method": "background"
-    }
+    },
+    "max_snippet_size": 2048,
+    "max_properties_size": 2560
   },
   "embedding": {
     "directory": "assets",


### PR DESCRIPTION
**Reference**

- [ET-4812]
- #1024

**Summary**

- add max sizes for snippets and properties to ingestion conflict
- use these configs during ingestion validation


[ET-4812]: https://xainag.atlassian.net/browse/ET-4812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ