### PR TITLE
ET-4792 number filter

### DIFF
--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add property filters to the `/users/{id}/personalized_documents` and `/semantic_search` front-office endpoints:
     - boolean equality
+    - number range
 
 # 2.3.2 - 2023-07-20
 

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -227,13 +227,21 @@ components:
               - $ref: './schemas/document.yml#/DocumentPropertyArrayString'
               - maxItems: 500
           $gt:
-            $ref: './schemas/time.yml#/Timestamp'
+            oneOf:
+              - type: number
+              - $ref: './schemas/time.yml#/Timestamp'
           $gte:
-            $ref: './schemas/time.yml#/Timestamp'
+            oneOf:
+              - type: number
+              - $ref: './schemas/time.yml#/Timestamp'
           $lt:
-            $ref: './schemas/time.yml#/Timestamp'
+            oneOf:
+              - type: number
+              - $ref: './schemas/time.yml#/Timestamp'
           $lte:
-            $ref: './schemas/time.yml#/Timestamp'
+            oneOf:
+              - type: number
+              - $ref: './schemas/time.yml#/Timestamp'
         minProperties: 1
         maxProperties: 1
         x-additionalPropertiesName: document property id

--- a/web-api/src/storage/elastic/filter.rs
+++ b/web-api/src/storage/elastic/filter.rs
@@ -392,26 +392,25 @@ mod tests {
 
     #[test]
     fn test_range() {
-        for (clause, value) in [
-            (
-                &serde_json::from_str(&json!({ "a": { "$gt": DATE } }).to_string()).unwrap(),
-                json!({ FILTER: [{ RANGE: { PROP_A: { "gt": DATE } } }] }),
-            ),
-            (
-                &serde_json::from_str(&json!({ "a": { "$gte": DATE } }).to_string()).unwrap(),
-                json!({ FILTER: [{ RANGE: { PROP_A: { "gte": DATE } } }] }),
-            ),
-            (
-                &serde_json::from_str(&json!({ "a": { "$lt": DATE } }).to_string()).unwrap(),
-                json!({ FILTER: [{ RANGE: { PROP_A: { "lt": DATE } } }] }),
-            ),
-            (
-                &serde_json::from_str(&json!({ "a": { "$lte": DATE } }).to_string()).unwrap(),
-                json!({ FILTER: [{ RANGE: { PROP_A: { "lte": DATE } } }] }),
-            ),
+        for operation in [
+            ("$gt", "gt"),
+            ("$gte", "gte"),
+            ("$lt", "lt"),
+            ("$lte", "lte"),
         ] {
+            let clause =
+                serde_json::from_str(&json!({ "a": { operation.0: 42 } }).to_string()).unwrap();
+            let value = json!({ FILTER: [{ RANGE: { PROP_A: { operation.1: 42 } } }] });
             assert_eq!(
-                serde_json::to_value(Clause::new(clause, true)).unwrap(),
+                serde_json::to_value(Clause::new(&clause, true)).unwrap(),
+                value,
+            );
+
+            let clause =
+                serde_json::from_str(&json!({ "a": { operation.0: DATE } }).to_string()).unwrap();
+            let value = json!({ FILTER: [{ RANGE: { PROP_A: { operation.1: DATE } } }] });
+            assert_eq!(
+                serde_json::to_value(Clause::new(&clause, true)).unwrap(),
                 value,
             );
         }


### PR DESCRIPTION
**Reference**

- [ET-4792]
- requires #1023
- followed by #1027

**Summary**

- add number compare serde to routes
- update spec & tests


[ET-4792]: https://xainag.atlassian.net/browse/ET-4792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ