### PR TITLE
ET-4827 validate semantic search query

### DIFF
--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2 - 2023-07-20
+
+- align the semantic search query string pattern with its description
+
 # 2.3.1 - 2023-07-20
 
 - deprecate `GET /users/{id}/personalized_documents` with query params in favor of `POST` with request body

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Back Office API
-  version: 2.3.1
+  version: 2.3.2
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Front Office API
-  version: 2.3.1
+  version: 2.3.2
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -67,10 +67,9 @@ DocumentSearchQuery:
     A search query can be any non-empty, UTF-8-encoded string which doesn't contain a zero byte.
     The length constraints are in bytes, not characters.
   type: string
-  pattern: ".+"
+  pattern: '^[^\x00]+$'
   minLength: 1
   maxLength: 512
-  example: "inflation is causing world-wide price hikes, especially for energy and food consumption"
 
 History:
   type: array

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -134,6 +134,14 @@ pub(crate) enum InvalidDocumentSnippet {
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);
 
+/// Malformed document query.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct InvalidDocumentQuery {
+    pub(crate) value: String,
+}
+
+impl_application_error!(InvalidDocumentQuery => BAD_REQUEST, INFO);
+
 /// Malsized document count.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct InvalidDocumentCount {

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -34,6 +34,7 @@ use crate::{
         InvalidDocumentProperty,
         InvalidDocumentPropertyId,
         InvalidDocumentPropertyReason,
+        InvalidDocumentQuery,
         InvalidDocumentSnippet,
         InvalidDocumentTag,
         InvalidDocumentTags,
@@ -143,6 +144,8 @@ string_wrapper! {
     pub(crate) UserId, InvalidUserId, is_valid_id;
     /// A document tag.
     pub(crate) DocumentTag, InvalidDocumentTag, |value| is_valid_string(value, 256);
+    /// A document query.
+    pub(crate) DocumentQuery, InvalidDocumentQuery, |value| is_valid_string(value, 512);
 }
 
 /// A document snippet.

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -39,6 +39,7 @@ use crate::{
         self,
         DocumentId,
         DocumentPropertyId,
+        DocumentQuery,
         DocumentTag,
         DocumentTags,
         ExcerptedDocument,
@@ -59,24 +60,24 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) count: usize,
     // must be >= count
     pub(crate) num_candidates: usize,
-    pub(super) strategy: SearchStrategy,
+    pub(super) strategy: SearchStrategy<'a>,
     pub(super) include_properties: bool,
     pub(super) filter: Option<&'a Filter>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum SearchStrategy {
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SearchStrategy<'a> {
     Knn,
     Hybrid {
         /// An additional query which will be run in parallel with the KNN search.
-        query: String,
+        query: &'a DocumentQuery,
     },
     HybridEsRrf {
-        query: String,
+        query: &'a DocumentQuery,
         rank_constant: Option<u32>,
     },
     HybridDev {
-        query: String,
+        query: &'a DocumentQuery,
         normalize_knn: NormalizationFn,
         normalize_bm25: NormalizationFn,
         merge_fn: MergeFn,

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -114,6 +114,17 @@ fn test_semantic_search_with_query() {
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 
+            send_assert(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({ "document": { "query": "" } }))
+                    .build()?,
+                StatusCode::BAD_REQUEST,
+                false,
+            )
+            .await;
+
             let SemanticSearchResponse { documents } = send_assert_json(
                 &client,
                 client


### PR DESCRIPTION
**Reference**

- [ET-4827]

**Summary**

- impl `DocumentQuery` wrapper and use it instead of bare strings in semantic search queries
- validate the document query in the semantic search endpoint according to the spec


[ET-4827]: https://xainag.atlassian.net/browse/ET-4827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ