### PR TITLE
ET-4756 implement minimal base implementation for document splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cutters"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd442446f9accd59a61a2a7d94dc61cffabebe2d1562392825d8780a8ccf9d0"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,9 +2579,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2579,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2589,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2602,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
@@ -4828,6 +4838,7 @@ dependencies = [
  "const_format",
  "criterion",
  "csv",
+ "cutters",
  "derive_more",
  "displaydoc",
  "dotenvy",

--- a/coi/src/document.rs
+++ b/coi/src/document.rs
@@ -22,7 +22,7 @@ pub trait Document {
     fn id(&self) -> &Self::Id;
 
     /// Gets the embedding of the document.
-    fn embedding(&self) -> &NormalizedEmbedding;
+    fn embeddings<'a>(&'a self) -> Box<dyn Iterator<Item = &'a NormalizedEmbedding> + 'a>;
 }
 
 #[cfg(test)]
@@ -46,14 +46,14 @@ pub(crate) mod tests {
 
     pub(crate) struct TestDocument {
         pub(crate) id: DocumentId,
-        pub(crate) embedding: NormalizedEmbedding,
+        pub(crate) embeddings: Vec<NormalizedEmbedding>,
     }
 
     impl TestDocument {
         pub(crate) fn new(id: usize, embedding: NormalizedEmbedding) -> Self {
             Self {
                 id: DocumentId::mocked(id),
-                embedding,
+                embeddings: vec![embedding],
             }
         }
     }
@@ -65,8 +65,8 @@ pub(crate) mod tests {
             &self.id
         }
 
-        fn embedding(&self) -> &NormalizedEmbedding {
-            &self.embedding
+        fn embeddings<'a>(&'a self) -> Box<dyn Iterator<Item = &'a NormalizedEmbedding> + 'a> {
+            Box::new(self.embeddings.iter())
         }
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -608,6 +608,13 @@ fn build_client(services: &Services) -> Arc<Client> {
 
 pub const UNCHANGED_CONFIG: Option<Table> = None;
 
+pub fn with_dev_options() -> Option<Table> {
+    Some(toml! {
+        [tenants]
+        enable_dev = true
+    })
+}
+
 pub fn extend_config(current: &mut Table, extension: Table) {
     for (key, value) in extension {
         if let Some(current) = current.get_mut(&key) {

--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -14,6 +14,9 @@
             "tags": {
                 "type": "keyword"
             },
+            "parent": {
+                "type": "keyword"
+            },
             "properties": {
                 "dynamic": false,
                 "properties": {

--- a/web-api-db-ctrl/postgres/tenant/20230712141144_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230712141144_document.sql
@@ -1,0 +1,31 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TYPE preprocessing_step AS ENUM (
+    'none',
+    'split',
+    'summarize'
+);
+
+ALTER TABLE document
+    ALTER COLUMN is_summarized DROP DEFAULT,
+    ALTER COLUMN is_summarized TYPE preprocessing_step
+        USING CASE
+            WHEN is_summarized THEN 'summarize'::preprocessing_step
+            ELSE 'none'::preprocessing_step
+        END,
+    ALTER COLUMN is_summarized SET DEFAULT 'none';
+
+ALTER TABLE document
+    RENAME COLUMN is_summarized TO preprocessing_step;

--- a/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
@@ -1,0 +1,26 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ALTER TABLE document
+    -- Hint:    Due to limitations in sqlx it's currently impractical to
+    --          to have a FLOAT4[][] type. The jsonb[] array also has the
+    --          benefit of pairing the embedding with it's metadata.
+    --
+    -- The implicit json schema is `{ "embedding": [...], "range": [<start>, <end>]  }`
+    -- with `start` & `end` being utf8 byte offsets into the original document. If
+    -- `range` is missing it's implies a full range.
+    ALTER COLUMN embedding TYPE jsonb[]
+        USING ARRAY[json_build_object('embedding',  array_to_json(embedding))];
+
+ALTER TABLE document RENAME COLUMN embedding TO embeddings;

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 clap = { version = "4.3.4", features = ["derive"] }
 const_format = "0.2.31"
 csv = { workspace = true }
+cutters = "0.1.4"
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 dotenvy = "0.15.7"

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -483,13 +483,12 @@ fn embed_with_splitting(
     embedder: &Embedder,
     snippet: &str,
 ) -> Result<Vec<DocumentEmbedding>, Error> {
-    // TODO[pmk/now] use better splitting algorithm
-    snippet
-        .split('.')
+    cutters::cut(snippet, cutters::Language::English)
+        .into_iter()
         .map(|split| {
             // FIXME use something more elegant and robust
-            let range = derive_range(snippet, split)?;
-            let embedding = embedder.run(split)?;
+            let range = derive_range(snippet, split.str)?;
+            let embedding = embedder.run(split.str)?;
             Ok(DocumentEmbedding {
                 embedding,
                 range: Some(range),

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -25,7 +25,14 @@ use xayn_test_utils::error::Panic;
 use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
-    models::{DocumentId, DocumentProperties, DocumentSnippet, IngestedDocument, UserId},
+    models::{
+        DocumentId,
+        DocumentProperties,
+        DocumentSnippet,
+        IngestedDocument,
+        PreprocessingStep,
+        UserId,
+    },
     personalization::{
         routes::{personalize_documents_by, update_interactions, PersonalizeBy},
         PersonalizationConfig,
@@ -74,10 +81,10 @@ impl State {
                 Ok(IngestedDocument {
                     id: document.id,
                     snippet: document.snippet,
-                    is_summarized: false,
+                    preprocessing_step: PreprocessingStep::None,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
-                    embedding,
+                    embeddings: vec![embedding],
                     is_candidate: true,
                 })
             })
@@ -109,10 +116,10 @@ impl State {
                 IngestedDocument {
                     id,
                     snippet: snippet.clone(),
-                    is_summarized: false,
+                    preprocessing_step: PreprocessingStep::None,
                     properties: document.properties,
                     tags: document.tags,
-                    embedding,
+                    embeddings: vec![embedding],
                     is_candidate: true,
                 }
             })

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -26,6 +26,7 @@ use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
     models::{
+        DocumentEmbedding,
         DocumentId,
         DocumentProperties,
         DocumentSnippet,
@@ -84,7 +85,7 @@ impl State {
                     preprocessing_step: PreprocessingStep::None,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
-                    embeddings: vec![embedding],
+                    embeddings: vec![DocumentEmbedding::whole_document(embedding)],
                     is_candidate: true,
                 })
             })
@@ -119,7 +120,7 @@ impl State {
                     preprocessing_step: PreprocessingStep::None,
                     properties: document.properties,
                     tags: document.tags,
-                    embeddings: vec![embedding],
+                    embeddings: vec![DocumentEmbedding::whole_document(embedding)],
                     is_candidate: true,
                 }
             })

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -367,8 +367,8 @@ pub(crate) struct IngestedDocument {
     /// Snippet used to calculate embeddings for a document.
     pub(crate) snippet: DocumentSnippet,
 
-    /// Whether the embedding was computed on the summarized snippet.
-    pub(crate) is_summarized: bool,
+    /// Method used to pre-process the document before ingestion.
+    pub(crate) preprocessing_step: PreprocessingStep,
 
     /// Contents of the document properties.
     pub(crate) properties: DocumentProperties,
@@ -377,7 +377,7 @@ pub(crate) struct IngestedDocument {
     pub(crate) tags: DocumentTags,
 
     /// Embedding from smbert.
-    pub(crate) embedding: NormalizedEmbedding,
+    pub(crate) embeddings: Vec<NormalizedEmbedding>,
 
     /// Indicates if the document is considered for recommendations.
     pub(crate) is_candidate: bool,
@@ -387,10 +387,19 @@ pub(crate) struct IngestedDocument {
 pub(crate) struct ExcerptedDocument {
     pub(crate) id: DocumentId,
     pub(crate) snippet: DocumentSnippet,
-    pub(crate) is_summarized: bool,
+    pub(crate) preprocessing_step: PreprocessingStep,
     pub(crate) properties: DocumentProperties,
     pub(crate) tags: DocumentTags,
     pub(crate) is_candidate: bool,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, sqlx::Type)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "preprocessing_step", rename_all = "snake_case")]
+pub(crate) enum PreprocessingStep {
+    None,
+    Split,
+    Summarize,
 }
 
 #[cfg(test)]

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -20,7 +20,13 @@ use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiSystem};
 
 use crate::{
-    models::{DocumentId, DocumentProperties, DocumentTag, PersonalizedDocument},
+    models::{
+        DocumentEmbedding,
+        DocumentId,
+        DocumentProperties,
+        DocumentTag,
+        PersonalizedDocument,
+    },
     personalization::PersonalizationConfig,
 };
 
@@ -123,7 +129,7 @@ pub fn bench_rerank<S>(
         .map(|(id, (embedding, tags))| PersonalizedDocument {
             id: id.to_string().try_into().unwrap(),
             score: 1.,
-            embedding,
+            embeddings: vec![DocumentEmbedding::whole_document(embedding)],
             properties: DocumentProperties::default(),
             tags: tags
                 .into_iter()
@@ -181,7 +187,7 @@ mod tests {
                 PersonalizedDocument {
                     id,
                     score: 1.,
-                    embedding,
+                    embeddings: vec![DocumentEmbedding::whole_document(embedding)],
                     properties: DocumentProperties::default(),
                     tags,
                 }

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -12,7 +12,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, hash::BuildHasher};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::BuildHasher,
+};
 
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -130,6 +133,7 @@ pub fn bench_rerank<S>(
             id: id.to_string().try_into().unwrap(),
             score: 1.,
             embeddings: vec![DocumentEmbedding::whole_document(embedding)],
+            splits: HashSet::new(),
             properties: DocumentProperties::default(),
             tags: tags
                 .into_iter()
@@ -188,6 +192,7 @@ mod tests {
                     id,
                     score: 1.,
                     embeddings: vec![DocumentEmbedding::whole_document(embedding)],
+                    splits: HashSet::new(),
                     properties: DocumentProperties::default(),
                     tags,
                 }

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -454,12 +454,14 @@ struct UnvalidatedSemanticSearchRequest {
 struct DevOption {
     hybrid: Option<DevHybrid>,
     max_number_candidates: Option<usize>,
-    include_splits: bool,
+    include_splits: Option<bool>,
 }
 
 impl DevOption {
     fn is_some(&self) -> bool {
-        self.hybrid.is_some() || self.max_number_candidates.is_some()
+        self.hybrid.is_some()
+            || self.max_number_candidates.is_some()
+            || self.include_splits.is_some()
     }
 }
 
@@ -729,7 +731,10 @@ async fn semantic_search(
             documents: documents
                 .into_iter()
                 .map(|document| {
-                    PersonalizedDocumentData::from_document(document, dev.include_splits)
+                    PersonalizedDocumentData::from_document(
+                        document,
+                        dev.include_splits.unwrap_or_default(),
+                    )
                 })
                 .collect(),
         }))

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -37,6 +37,7 @@ use crate::{
     ingestion::IngestionConfig,
     models::{
         self,
+        DocumentEmbedding,
         DocumentId,
         DocumentPropertyId,
         DocumentQuery,
@@ -154,7 +155,10 @@ pub(crate) trait Document {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error>;
 
-    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;
+    async fn get_embeddings(
+        &self,
+        id: &DocumentId,
+    ) -> Result<Option<Vec<DocumentEmbedding>>, Error>;
 
     async fn get_by_embedding<'a>(
         &self,
@@ -254,7 +258,7 @@ pub(crate) trait Interaction {
         interactions: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
         store_user_history: bool,
         time: DateTime<Utc>,
-        update_logic: impl for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> Coi,
+        update_logic: impl for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> Result<Coi, Error>,
     ) -> Result<(), Error>;
 }
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -203,7 +203,8 @@ impl Client {
                     serde_json::to_value(IngestedDocument {
                         snippet: &document.snippet,
                         properties: &document.properties,
-                        embedding: &document.embedding,
+                        // TODO[pmk/now] fix
+                        embedding: document.embeddings.first().unwrap(),
                         tags: &document.tags,
                     })
                     .map_err(Into::into),

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -276,6 +276,7 @@ impl storage::Document for Storage {
                             id: id.clone(),
                             score: 1.,
                             embeddings: vec![embedding.clone()],
+                            splits: HashSet::new(),
                             properties: include_properties
                                 .then(|| document.properties.clone())
                                 .unwrap_or_default(),
@@ -347,6 +348,7 @@ impl storage::Document for Storage {
                         embeddings: vec![DocumentEmbedding::whole_document(
                             item.point.as_ref().clone(),
                         )],
+                        splits: HashSet::new(),
                         properties: document.properties.clone(),
                         tags: document.tags.clone(),
                     })

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -39,9 +39,10 @@ use sqlx::{
 use tracing::{info, instrument};
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiId, CoiStats};
+use xayn_web_api_shared::elastic::ScoreMap;
 
 use super::{
-    elastic::{DocumentDeletionHint, ScoreMap},
+    elastic::DocumentDeletionHint,
     property_filter::{
         IndexedPropertiesSchema,
         IndexedPropertiesSchemaUpdate,
@@ -277,7 +278,7 @@ impl Database {
 
     async fn get_personalized(
         tx: &mut Transaction<'_, Postgres>,
-        scores: ScoreMap,
+        scores: ScoreMap<DocumentId>,
         include_properties: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
         let mut builder = QueryBuilder::new(format!(

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -107,7 +107,7 @@ impl Database {
             "INSERT INTO document (
                 document_id,
                 snippet,
-                is_summarized,
+                preprocessing_step,
                 properties,
                 tags,
                 embedding,
@@ -124,10 +124,11 @@ impl Database {
                         builder
                             .push_bind(&document.id)
                             .push_bind(&document.snippet)
-                            .push_bind(document.is_summarized)
+                            .push_bind(document.preprocessing_step)
                             .push_bind(Json(&document.properties))
                             .push_bind(&document.tags)
-                            .push_bind(&document.embedding)
+                            // TODO[pmk/now] fix
+                            .push_bind(document.embeddings.first().unwrap())
                             .push_bind(document.is_candidate);
                     },
                 )
@@ -308,7 +309,7 @@ impl Database {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error> {
         let mut builder = QueryBuilder::new(
-            "SELECT document_id, snippet, is_summarized, properties, tags, is_candidate
+            "SELECT document_id, snippet, preprocessing_step, properties, tags, is_candidate
             FROM document
             WHERE document_id IN ",
         );
@@ -321,12 +322,12 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, is_summarized, Json(properties), tags, is_candidate) =
+                        let (id, snippet, preprocessing_step, Json(properties), tags, is_candidate) =
                             FromRow::from_row(&row)?;
                         Ok(ExcerptedDocument {
                             id,
                             snippet,
-                            is_summarized,
+                            preprocessing_step,
                             properties,
                             tags,
                             is_candidate,
@@ -394,18 +395,19 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, is_summarized, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, preprocessing_step, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, is_summarized, Json(properties), tags, embedding) =
+                        let (id, snippet, preprocessing_step, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
-                            is_summarized,
+                            preprocessing_step,
                             properties,
                             tags,
-                            embedding,
+                            // TODO[pmk/now] fix
+                            embeddings: vec![embedding],
                             is_candidate: true,
                         })
                     })
@@ -469,18 +471,19 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, snippet, is_summarized, properties, tags, embedding;")
+                    .push(" RETURNING document_id, snippet, preprocessing_step, properties, tags, embedding;")
                     .build()
                     .try_map(|row| {
-                        let (id, snippet, is_summarized, Json(properties), tags, embedding) =
+                        let (id, snippet, preprocessing_step, Json(properties), tags, embedding) =
                             FromRow::from_row(&row)?;
                         Ok(IngestedDocument {
                             id,
                             snippet,
-                            is_summarized,
+                            preprocessing_step,
                             properties,
                             tags,
-                            embedding,
+                            // TODO[pmk/now] fix
+                            embeddings: vec![embedding],
                             is_candidate: true,
                         })
                     })

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -196,7 +196,7 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, is_candidate, array_length(embeddings, 1) as embedding_count;")
+                    .push(" RETURNING document_id, is_candidate, coalesce(array_length(embeddings, 1), 0) as embedding_count;")
                     .build()
                     .persistent(false)
                     .try_map(|row| QueriedDeletedDocumentWithCandidateInfo::from_row(&row))
@@ -420,7 +420,7 @@ impl Database {
             let hints = builder
                 .reset()
                 .push_tuple(ids)
-                .push(" RETURNING document_id, array_length(embeddings, 1) as embedding_count")
+                .push(" RETURNING document_id, coalesce(array_length(embeddings, 1), 0) as embedding_count")
                 .build()
                 .try_map(|row| QueriedDeletedDocument::from_row(&row).map(Into::into))
                 .fetch_all(&mut tx)
@@ -590,7 +590,7 @@ impl Database {
                 builder
                     .reset()
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
-                    .push(" RETURNING document_id, array_length(embeddings, 1) as embedding_count;")
+                    .push(" RETURNING document_id, coalesce(array_length(embeddings, 1), 0) as embedding_count;")
                     .build()
                     .try_map(|row| {
                         QueriedDeletedDocument::from_row(&row).map(DocumentDeletionHint::from)
@@ -977,7 +977,7 @@ impl storage::DocumentProperties for Storage {
                 WHERE document_id = $2
                 FOR UPDATE
             )
-            RETURNING is_candidate, array_length(embeddings, 1);",
+            RETURNING is_candidate, coalesce(array_length(embeddings, 1), 0);",
         )
         .bind(Json(properties))
         .bind(id)
@@ -1015,7 +1015,7 @@ impl storage::DocumentProperties for Storage {
                 WHERE document_id = $1
                 FOR UPDATE
             )
-            RETURNING is_candidate, array_length(embeddings, 1);",
+            RETURNING is_candidate, coalesce(array_length(embeddings, 1), 0);",
         )
         .bind(id)
         .fetch_optional(&mut tx)
@@ -1090,7 +1090,7 @@ impl storage::DocumentProperty for Storage {
                 WHERE document_id = $3
                 FOR UPDATE
             )
-            RETURNING is_candidate, array_length(embeddings, 1);",
+            RETURNING is_candidate, coalesce(array_length(embeddings, 1), 0);",
         )
         .bind(slice::from_ref(property_id))
         .bind(Json(property))
@@ -1134,7 +1134,7 @@ impl storage::DocumentProperty for Storage {
                 WHERE document_id = $2
                 FOR UPDATE
             ) AND properties ? $1
-            RETURNING is_candidate, array_length(embeddings, 1);",
+            RETURNING is_candidate, coalesce(array_length(embeddings, 1), 0);",
         )
         .bind(property_id)
         .bind(document_id)
@@ -1317,7 +1317,7 @@ impl storage::Tag for Storage {
                 WHERE document_id = $2
                 FOR UPDATE
             )
-            RETURNING is_candidate, array_length(embeddings, 1);",
+            RETURNING is_candidate, coalesce(array_length(embeddings, 1), 0);",
         )
         .bind(tags)
         .bind(document_id)

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -17,8 +17,13 @@ use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
-use toml::toml;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
+use xayn_integration_tests::{
+    send_assert,
+    send_assert_json,
+    test_two_apps,
+    with_dev_options,
+    UNCHANGED_CONFIG,
+};
 use xayn_web_api::{Ingestion, Personalization};
 
 async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
@@ -170,10 +175,7 @@ fn test_semantic_search_with_query() {
 fn test_semantic_search_with_dev_option_hybrid() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 
@@ -284,10 +286,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
 fn test_semantic_search_with_dev_option_hybrid_es_rrf() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 
@@ -316,10 +315,7 @@ fn test_semantic_search_with_dev_option_hybrid_es_rrf() {
 fn test_semantic_search_with_dev_option_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -20,7 +20,13 @@ use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use url::Url;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
+use xayn_integration_tests::{
+    send_assert,
+    send_assert_json,
+    test_two_apps,
+    with_dev_options,
+    UNCHANGED_CONFIG,
+};
 use xayn_web_api::{Ingestion, Personalization};
 
 #[derive(Debug, Deserialize)]
@@ -168,7 +174,7 @@ async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
 fn test_split_documents_for_semantic_search() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        UNCHANGED_CONFIG,
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             let query = |text, count| query(&client, &personalization_url, text, count, None);
             ingest(&client, &ingestion_url).await?;
@@ -190,7 +196,7 @@ fn test_split_documents_for_semantic_search() {
 fn test_split_documents_with_set_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        UNCHANGED_CONFIG,
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             let query = |text, count| query(&client, &personalization_url, text, count, None);
             let set_candidates = |ids| set_candidates(&client, &ingestion_url, ids);
@@ -224,7 +230,7 @@ fn test_split_documents_with_set_candidates() {
 fn test_split_documents_with_property_updates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        UNCHANGED_CONFIG,
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             let query = |text, value| {
                 query(
@@ -357,7 +363,7 @@ fn test_split_documents_with_property_updates() {
 fn test_endpoints_which_do_not_yet_fully_support_split_do_not_fall_over() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        UNCHANGED_CONFIG,
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
             send_assert(

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -64,7 +64,7 @@ async fn query(
     filter: Option<Value>,
 ) -> Result<SearchResponse, Error> {
     let res = send_assert_json::<SearchResponse>(
-        &client,
+        client,
         client
             .post(personalization_url.join("/semantic_search")?)
             .json(&json!({
@@ -85,9 +85,9 @@ async fn query(
 }
 
 async fn set_candidates(client: &Client, ingestion_url: &Url, ids: &[&str]) -> Result<(), Error> {
-    let ids = ids.into_iter().map(|id| json!({ "id": id })).collect_vec();
+    let ids = ids.iter().map(|id| json!({ "id": id })).collect_vec();
     send_assert(
-        &client,
+        client,
         client
             .put(ingestion_url.join("/documents/_candidates")?)
             .json(&json!({ "documents": ids }))

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -1,0 +1,442 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use anyhow::Error;
+use itertools::Itertools;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use url::Url;
+use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
+use xayn_web_api::{Ingestion, Personalization};
+
+#[derive(Debug, Deserialize)]
+struct PersonalizedDocumentData {
+    id: String,
+    score: f32,
+    // included by test only dev option
+    #[serde(default)]
+    splits: HashSet<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    documents: Vec<PersonalizedDocumentData>,
+}
+
+impl SearchResponse {
+    fn id_ranking(&self) -> Vec<&str> {
+        self.documents.iter().map(|doc| &*doc.id).collect_vec()
+    }
+
+    fn assert_ordered(&self) {
+        let ordered = self
+            .documents
+            .iter()
+            .zip(self.documents.iter().skip(1))
+            .all(|(first, second)| first.score > second.score);
+        assert!(
+            ordered,
+            "expects documents to be ordered by score (desc): {:?}",
+            self.documents
+        );
+    }
+}
+
+async fn query(
+    client: &Client,
+    personalization_url: &Url,
+    text: &str,
+    count: usize,
+    filter: Option<Value>,
+) -> Result<SearchResponse, Error> {
+    let res = send_assert_json::<SearchResponse>(
+        &client,
+        client
+            .post(personalization_url.join("/semantic_search")?)
+            .json(&json!({
+                "document": { "query": text },
+                "count": count,
+                "filter": filter,
+                "_dev": { "include_splits": true }
+            }))
+            .build()?,
+        StatusCode::OK,
+        false,
+    )
+    .await;
+
+    res.assert_ordered();
+
+    Ok(res)
+}
+
+async fn set_candidates(client: &Client, ingestion_url: &Url, ids: &[&str]) -> Result<(), Error> {
+    let ids = ids.into_iter().map(|id| json!({ "id": id })).collect_vec();
+    send_assert(
+        &client,
+        client
+            .put(ingestion_url.join("/documents/_candidates")?)
+            .json(&json!({ "documents": ids }))
+            .build()?,
+        StatusCode::NO_CONTENT,
+        false,
+    )
+    .await;
+    Ok(())
+}
+
+async fn get_properties(
+    client: &Client,
+    ingestion_url: &Url,
+    id: &str,
+) -> Result<Map<String, Value>, Error> {
+    let mut url = ingestion_url.clone();
+    url.path_segments_mut()
+        .unwrap()
+        .extend(["documents", id, "properties"]);
+
+    #[derive(Deserialize)]
+    struct Response {
+        properties: Map<String, Value>,
+    }
+
+    Ok(
+        send_assert_json::<Response>(client, client.get(url).build()?, StatusCode::OK, false)
+            .await
+            .properties,
+    )
+}
+
+fn json_map(
+    pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<Value>)>,
+) -> Map<String, Value> {
+    pairs
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect()
+}
+
+async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
+    send_assert(
+        client,
+        client
+            .post(ingestion_url.join("/documents")?)
+            .json(&json!({
+                "documents": [
+                    {
+                        "id": "d1",
+                        "snippet": "The duck is blue. The truck is yellow. But birds are birds.",
+                        "split": true,
+                        "properties": {
+                            "foo": "filter-a",
+                        }
+                    },
+                    {
+                        "id": "d2",
+                        "snippet": "Cars with wheels. This is a blue sentence. Trains on tracks. ",
+                        "split": true,
+                        "properties": {
+                            "foo": "filter-a",
+                        }
+                    },
+                ]
+            }))
+            .build()?,
+        StatusCode::CREATED,
+        false,
+    )
+    .await;
+
+    Ok(())
+}
+
+#[test]
+fn test_split_documents_for_semantic_search() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, count| query(&client, &personalization_url, text, count, None);
+            ingest(&client, &ingestion_url).await?;
+
+            let res = query("cars", 2).await?;
+            assert_eq!(res.id_ranking(), vec!["d2"]);
+            assert_eq!(res.documents[0].splits, [0, 2].into_iter().collect());
+
+            let res = query("color", 3).await?;
+            assert_eq!(res.id_ranking(), vec!["d1", "d2"]);
+            assert_eq!(res.documents[0].splits, [0, 1].into_iter().collect());
+            assert_eq!(res.documents[1].splits, [1].into_iter().collect());
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_split_documents_with_set_candidates() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, count| query(&client, &personalization_url, text, count, None);
+            let set_candidates = |ids| set_candidates(&client, &ingestion_url, ids);
+            ingest(&client, &ingestion_url).await?;
+
+            set_candidates(&[]).await?;
+            let res = query("cars", 3).await?;
+            assert!(res.documents.is_empty());
+
+            set_candidates(&["d1"]).await?;
+            let res = query("arbitrary", 4).await?;
+            assert_eq!(res.id_ranking(), vec!["d1"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+
+            set_candidates(&["d2"]).await?;
+            let res = query("arbitrary", 4).await?;
+            assert_eq!(res.id_ranking(), vec!["d2"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+
+            set_candidates(&["d1", "d2"]).await?;
+            let res = query("color", 3).await?;
+            assert_eq!(res.id_ranking(), vec!["d1", "d2"]);
+            assert_eq!(res.documents[0].splits, [0, 1].into_iter().collect());
+            assert_eq!(res.documents[1].splits, [1].into_iter().collect());
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_split_documents_with_property_updates() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, value| {
+                query(
+                    &client,
+                    &personalization_url,
+                    text,
+                    10,
+                    Some(json!({
+                        "foo": {
+                            "$eq": value
+                        }
+                    })),
+                )
+            };
+            let get_properties = |id| get_properties(&client, &ingestion_url, id);
+            ingest(&client, &ingestion_url).await?;
+
+            send_assert(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents/_indexed_properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "foo": {
+                                "type": "keyword"
+                            }
+                        }
+                    }))
+                    .build()?,
+                StatusCode::ACCEPTED,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec!["d2", "d1"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+            assert_eq!(res.documents[1].splits, [0, 1, 2].into_iter().collect());
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d1/properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "foo": "filter-b"
+                        }
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            assert_eq!(get_properties("d1").await?, json_map([("foo", "filter-b")]));
+            assert_eq!(get_properties("d2").await?, json_map([("foo", "filter-a")]));
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec!["d2"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+
+            send_assert(
+                &client,
+                client
+                    .delete(ingestion_url.join("/documents/d2/properties")?)
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert!(res.id_ranking().is_empty());
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d1/properties/foo")?)
+                    .json(&json!({
+                        "property": "filter-a",
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec!["d1"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d2/properties/foo")?)
+                    .json(&json!({
+                        "property": "filter-a",
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec!["d2", "d1"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+            assert_eq!(res.documents[1].splits, [0, 1, 2].into_iter().collect());
+
+            send_assert(
+                &client,
+                client
+                    .delete(ingestion_url.join("/documents/d1/properties/foo")?)
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec!["d2"]);
+            assert_eq!(res.documents[0].splits, [0, 1, 2].into_iter().collect());
+
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_endpoints_which_do_not_yet_fully_support_split_do_not_fall_over() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest(&client, &ingestion_url).await?;
+            send_assert(
+                &client,
+                client
+                    .patch(personalization_url.join("/users/u1/interactions")?)
+                    .json(&json!({ "documents": [ { "id": "d1" } ] }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/users/u1/personalized_documents")?)
+                    .json(&json!({}))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "query": "car"
+                        },
+                        "personalize": {
+                            "user": {
+                                "id": "u1"
+                            }
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "query": "car"
+                        },
+                        "personalize": {
+                            "user": {
+                                "history": [ { "id": "d1" }]
+                            }
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "id": "d1"
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            Ok(())
+        },
+    );
+}


### PR DESCRIPTION
**Limitations:**

- only very simple (but not naive) sentence splitting algorithm
- only english support
- scoring (rerank by interest) with documents with multiple splits needs to be decided on (current implementation might be fine)
- interacting on documents with multiple embedding needs improvements (currently strongly biased for documents the more splits they have), might need fundamental changes depending on customer use-case
- personalized `/semantic_search`  with stateless user history  has the same issue as normal interacting 
- handling `/semantic_search` based on finding documents similar documents with splits needs a full rework (currently it won't fall over but will not  work well) 
- when matching multiple snippets of the same document we currently sum-up the scores and keep track of which snippets where matched (internally, returned with dev option)
  - with the option which return `snippet` we also should (also? instead?) return the slice of the split
  - customers might want to know not just which split was found but ranking between the found splits
  - customers (we?) might want allow reacting to splits (potentially multiple at once) instead of just documents, through we probably still want allow to also react to the document as a whole even if split 

**References:**

- issue [ET-4756]
- story [ET-4755]

[ET-4756]: https://xainag.atlassian.net/browse/ET-4756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4755]: https://xainag.atlassian.net/browse/ET-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ