### PR TITLE
dev customize hybrid option improvements

### DIFF
--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -399,6 +399,7 @@ struct DevOptions {
 #[serde(rename_all = "snake_case")]
 enum HybridDevOption {
     EsRrf {
+        #[serde(default)]
         rank_constant: Option<u32>,
     },
     Customize {

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -95,11 +95,14 @@ pub(crate) enum NormalizationFn {
 #[serde(rename_all = "snake_case")]
 pub(crate) enum MergeFn {
     Sum {
+        #[serde(default)]
         knn_weight: Option<f32>,
+        #[serde(default)]
         bm25_weight: Option<f32>,
     },
     AverageDuplicatesOnly {},
     Rrf {
+        #[serde(default)]
         rank_constant: Option<f32>,
     },
 }

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -104,6 +104,10 @@ pub(crate) enum MergeFn {
     Rrf {
         #[serde(default)]
         rank_constant: Option<f32>,
+        #[serde(default)]
+        knn_weight: Option<f32>,
+        #[serde(default)]
+        bm25_weight: Option<f32>,
     },
 }
 

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -596,18 +596,18 @@ where
 }
 
 /// Reciprocal Rank Fusion
-fn rrf<K>(k: f32, scores: impl IntoIterator<Item = HashMap<K, f32>>) -> HashMap<K, f32>
+fn rrf<K>(k: f32, scores: impl IntoIterator<Item = (f32, HashMap<K, f32>)>) -> HashMap<K, f32>
 where
     K: Eq + Hash,
 {
-    let rrf_scores = scores.into_iter().flat_map(|scores| {
+    let rrf_scores = scores.into_iter().flat_map(|(weight, scores)| {
         scores
             .into_iter()
             .sorted_by(|(_, s1), (_, s2)| s1.total_cmp(s2).reverse())
             .enumerate()
-            .map(|(rank0, (document, _))| {
+            .map(move |(rank0, (document, _))| {
                 #[allow(clippy::cast_precision_loss)]
-                (document, (k + rank0 as f32 + 1.).recip())
+                (document, (k + rank0 as f32 + 1.).recip() * weight)
             })
     });
     collect_summing_repeated(rrf_scores)
@@ -665,9 +665,57 @@ impl MergeFn {
                 ])
             }),
             MergeFn::AverageDuplicatesOnly {} => Box::new(merge_scores_average_duplicates_only),
-            MergeFn::Rrf { rank_constant } => {
-                Box::new(move |s1, s2| rrf(rank_constant.unwrap_or(60.), [s1, s2]))
+            MergeFn::Rrf {
+                rank_constant,
+                knn_weight,
+                bm25_weight,
+            } => {
+                let rank_constant = rank_constant.unwrap_or(60.);
+                let knn_weight = knn_weight.unwrap_or(1.);
+                let bm25_weight = bm25_weight.unwrap_or(1.);
+                Box::new(move |knn, bm25| {
+                    rrf(rank_constant, [(knn_weight, knn), (bm25_weight, bm25)])
+                })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rrf_parameters_are_used() {
+        let left = [
+            ("foo", 2.),
+            ("bar", 1.),
+            ("baz", 3.),
+        ].into_iter().collect::<HashMap<_, _>>();
+
+        let right = [
+            ("baz", 5.),
+            ("dodo", 1.2),
+        ].into_iter().collect::<HashMap<_, _>>();
+
+        assert_eq!(rrf(80., [
+            (1., left.clone()),
+            (1., right.clone())
+        ]), [
+            ("foo", 1./(80. + 2.)),
+            ("bar", 1./(80. + 3.)),
+            ("baz", 1./(80. + 1.) + 1./(80. + 1.)),
+            ("dodo", 1./(80. + 2.)),
+        ].into_iter().collect());
+
+        assert_eq!(rrf(80., [
+            (0.2, left.clone()),
+            (8., right.clone())
+        ]), [
+            ("foo", 0.2/(80. + 2.)),
+            ("bar", 0.2/(80. + 3.)),
+            ("baz", 0.2/(80. + 1.) + 8./(80. + 1.)),
+            ("dodo", 8./(80. + 2.)),
+        ].into_iter().collect());
     }
 }

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -687,35 +687,36 @@ mod tests {
 
     #[test]
     fn test_rrf_parameters_are_used() {
-        let left = [
-            ("foo", 2.),
-            ("bar", 1.),
-            ("baz", 3.),
-        ].into_iter().collect::<HashMap<_, _>>();
+        let left = [("foo", 2.), ("bar", 1.), ("baz", 3.)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
 
-        let right = [
-            ("baz", 5.),
-            ("dodo", 1.2),
-        ].into_iter().collect::<HashMap<_, _>>();
+        let right = [("baz", 5.), ("dodo", 1.2)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
 
-        assert_eq!(rrf(80., [
-            (1., left.clone()),
-            (1., right.clone())
-        ]), [
-            ("foo", 1./(80. + 2.)),
-            ("bar", 1./(80. + 3.)),
-            ("baz", 1./(80. + 1.) + 1./(80. + 1.)),
-            ("dodo", 1./(80. + 2.)),
-        ].into_iter().collect());
+        assert_eq!(
+            rrf(80., [(1., left.clone()), (1., right.clone())]),
+            [
+                ("foo", 1. / (80. + 2.)),
+                ("bar", 1. / (80. + 3.)),
+                ("baz", 1. / (80. + 1.) + 1. / (80. + 1.)),
+                ("dodo", 1. / (80. + 2.)),
+            ]
+            .into_iter()
+            .collect()
+        );
 
-        assert_eq!(rrf(80., [
-            (0.2, left.clone()),
-            (8., right.clone())
-        ]), [
-            ("foo", 0.2/(80. + 2.)),
-            ("bar", 0.2/(80. + 3.)),
-            ("baz", 0.2/(80. + 1.) + 8./(80. + 1.)),
-            ("dodo", 8./(80. + 2.)),
-        ].into_iter().collect());
+        assert_eq!(
+            rrf(80., [(0.2, left.clone()), (8., right.clone())]),
+            [
+                ("foo", 0.2 / (80. + 2.)),
+                ("bar", 0.2 / (80. + 3.)),
+                ("baz", 0.2 / (80. + 1.) + 8. / (80. + 1.)),
+                ("dodo", 8. / (80. + 2.)),
+            ]
+            .into_iter()
+            .collect()
+        );
     }
 }

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -261,6 +261,24 @@ fn test_semantic_search_with_dev_options() {
             )
             .await;
 
+            send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "this is one sentence" },
+                        "enable_hybrid_search": true,
+                        "_dev": { "hybrid": { "customize": {
+                            "normalize_knn": "identity",
+                            "normalize_bm25": "identity",
+                            "merge_fn": { "rrf": { }}
+                        } } }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+
             Ok(())
         },
     );

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -279,6 +279,27 @@ fn test_semantic_search_with_dev_options() {
             )
             .await;
 
+            send_assert_json::<SemanticSearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "this is one sentence" },
+                        "enable_hybrid_search": true,
+                        "_dev": { "hybrid": { "customize": {
+                            "normalize_knn": "identity",
+                            "normalize_bm25": "identity",
+                            "merge_fn": { "rrf": {
+                                "knn_weight": 0.8,
+                                "bm25_weight": 0.2
+                            }}
+                        } } }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+            )
+            .await;
+
             Ok(())
         },
     );


### PR DESCRIPTION
- use `serde(default)` to allow omitting optional fields
- add functionality to weight rrf 
- add some additional tests


With this following (undocumented , unstable) option can be passed to semantic search:

```json
{
    ...
    "enable_hybrid_search": true,
    "_dev": { "hybrid": { "customize": {
        "normalize_knn": "identity",
        "normalize_bm25": "identity",
        "merge_fn": { "rrf": {
            "knn_weight": 0.8,
            "bm25_weight": 0.2
         } }
    } } }
}
```

This would to a hybrid search using rrf and also weight/boost the knn search by 0.8 and the bm25 search by 0.2.