### PR TITLE
ET-4828 post personalized documents

### DIFF
--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.1 - 2023-07-20
+
+- deprecate `GET /users/{id}/personalized_documents` with query params in favor of `POST` with request body
+
 # 2.3.0 - 2023-07-06
 
 - Add back-office endpoints for retrieving and extending the indexed property schema

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Back Office API
-  version: 2.3.0
+  version: 2.3.1
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Front Office API
-  version: 2.3.0
+  version: 2.3.1
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.
@@ -48,11 +48,14 @@ security:
 
 paths:
   /users/{user_id}/personalized_documents:
-    get:
+    parameters:
+      - $ref: './parameters/path/id.yml#/UserId'
+
+    post:
       tags:
         - front office
         - search
-      summary: Get personalized documents for the user
+      summary: Personalize documents for the user
       description: |-
         Get a list of documents personalized for the given `user_id`.
         Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
@@ -60,8 +63,36 @@ paths:
         Documents that have been interacted with by the user are filtered out from the result.
         Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.
       operationId: getPersonalizedDocuments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonalizedDocumentsRequest'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalizedDocumentsResponse'
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
+        '409':
+          description: Impossible to create a personalized documents for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalizedDocumentsError'
+
+    get:
+      tags:
+        - front office
+        - search
+      deprecated: true
+      summary: Get personalized documents for the user
+      description: Deprecated. Use `POST /users/{user_id}/personalized_documents` instead.
+      operationId: getPersonalizedDocumentsDeprecated
       parameters:
-        - $ref: './parameters/path/id.yml#/UserId'
         - name: count
           in: query
           description:
@@ -240,6 +271,21 @@ components:
       oneOf:
         - $ref: '#/components/schemas/FilterCompare'
         - $ref: '#/components/schemas/FilterCombine'
+    PersonalizedDocumentsRequest:
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/Count'
+        published_after:
+          $ref: './schemas/time.yml#/PublishedAfter'
+        include_properties:
+          $ref: '#/components/schemas/IncludeProperties'
+        filter:
+          description:
+            $ref: '#/components/schemas/Filter/description'
+          oneOf:
+            - $ref: '#/components/schemas/FilterCompare'
+            - $ref: '#/components/schemas/FilterCombine'
     PersonalizedDocumentData:
       type: object
       required: [id, score]

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -69,6 +69,18 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
                 .route(web::put().to(set_document_candidates)),
         )
         .service(
+            // this resource is deprecated and undocumented and will be removed in the future
+            web::resource("/documents/candidates")
+                .route(web::get().to(deprecate!(get_document_candidates(state))))
+                .route(web::put().to(deprecate!(set_document_candidates(request, state)))),
+        )
+        .service(
+            // this resource is deprecated and undocumented and will be removed in the future
+            web::resource("/candidates")
+                .route(web::get().to(deprecate!(get_document_candidates(state))))
+                .route(web::put().to(deprecate!(set_document_candidates(request, state)))),
+        )
+        .service(
             web::resource("/documents/_indexed_properties")
                 .route(web::post().to(create_indexed_properties))
                 .route(web::get().to(get_indexed_properties_schema)),
@@ -85,17 +97,6 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
                 .route(web::get().to(get_document_property))
                 .route(web::put().to(put_document_property))
                 .route(web::delete().to(delete_document_property)),
-        )
-        // all routes below are deprecated and undocumented and will be removed in the future
-        .service(
-            web::resource("/candidates")
-                .route(web::get().to(deprecate!(get_document_candidates(state))))
-                .route(web::put().to(deprecate!(set_document_candidates(request, state)))),
-        )
-        .service(
-            web::resource("/documents/candidates")
-                .route(web::get().to(deprecate!(get_document_candidates(state))))
-                .route(web::put().to(deprecate!(set_document_candidates(request, state)))),
         );
 }
 

--- a/web-api/tests/document_candidates.rs
+++ b/web-api/tests/document_candidates.rs
@@ -36,6 +36,7 @@ async fn ingest(client: &Client, url: &Url) -> Result<(), Error> {
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -54,7 +55,7 @@ impl DocumentCandidatesResponse {
 
 async fn get(client: &Client, url: &Url) -> Result<DocumentCandidatesResponse, Error> {
     let request = client.get(url.join("/documents/_candidates")?).build()?;
-    let response = send_assert_json(client, request, StatusCode::OK).await;
+    let response = send_assert_json(client, request, StatusCode::OK, false).await;
 
     Ok(response)
 }
@@ -64,7 +65,7 @@ async fn set(client: &Client, url: &Url, ids: impl IntoIterator<Item = &str>) ->
         .put(url.join("/documents/_candidates")?)
         .json(&json!({ "documents": ids.into_iter().map(|id| json!({ "id": id })).collect_vec() }))
         .build()?;
-    send_assert(client, request, StatusCode::NO_CONTENT).await;
+    send_assert(client, request, StatusCode::NO_CONTENT, false).await;
 
     Ok(())
 }
@@ -123,6 +124,7 @@ fn test_candidates_not_default() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2"].into());
@@ -168,6 +170,7 @@ fn test_candidates_warning() {
                 }))
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error.kind, Kind::FailedToSetSomeDocumentCandidates);
@@ -195,6 +198,7 @@ fn test_candidates_reingestion() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d2"].into());
@@ -215,10 +219,44 @@ fn test_candidates_reingestion() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
         assert_eq!(get(&client, &url).await?.ids(), ["d1", "d4", "d6"].into());
 
         Ok(())
     });
+}
+
+fn deprecated_candidates(path: &'static str) {
+    test_app::<Ingestion, _>(UNCHANGED_CONFIG, |client, url, _| async move {
+        send_assert(
+            &client,
+            client.get(url.join(path)?).build()?,
+            StatusCode::OK,
+            true,
+        )
+        .await;
+        send_assert(
+            &client,
+            client
+                .put(url.join(path)?)
+                .json(&json!({ "documents": [] }))
+                .build()?,
+            StatusCode::NO_CONTENT,
+            true,
+        )
+        .await;
+        Ok(())
+    });
+}
+
+#[test]
+fn test_deprecated_candidates() {
+    deprecated_candidates("/candidates");
+}
+
+#[test]
+fn test_deprecated_documents_candidates() {
+    deprecated_candidates("/documents/candidates");
 }

--- a/web-api/tests/document_properties.rs
+++ b/web-api/tests/document_properties.rs
@@ -45,6 +45,7 @@ fn document_properties(is_candidate: bool) {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -52,6 +53,7 @@ fn document_properties(is_candidate: bool) {
             &client,
             client.get(url.join("/documents/d1/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert!(properties.is_empty());
@@ -59,6 +61,7 @@ fn document_properties(is_candidate: bool) {
             &client,
             client.get(url.join("/documents/d2/properties")?).build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);
@@ -70,6 +73,7 @@ fn document_properties(is_candidate: bool) {
                 .json(&json!({ "properties": { "some": "thing", "else": 42 } }))
                 .build()?,
             StatusCode::NO_CONTENT,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
@@ -79,6 +83,7 @@ fn document_properties(is_candidate: bool) {
                 .json(&json!({ "properties": {} }))
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);
@@ -86,6 +91,7 @@ fn document_properties(is_candidate: bool) {
             &client,
             client.get(url.join("/documents/d1/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(
@@ -103,6 +109,7 @@ fn document_properties(is_candidate: bool) {
                 .delete(url.join("/documents/d1/properties")?)
                 .build()?,
             StatusCode::NO_CONTENT,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
@@ -111,6 +118,7 @@ fn document_properties(is_candidate: bool) {
                 .delete(url.join("/documents/d2/properties")?)
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);
@@ -118,6 +126,7 @@ fn document_properties(is_candidate: bool) {
             &client,
             client.get(url.join("/documents/d1/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert!(properties.is_empty());
@@ -154,6 +163,7 @@ fn document_property(is_candidate: bool) {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -163,6 +173,7 @@ fn document_property(is_candidate: bool) {
                 .get(url.join("/documents/d1/properties/p1")?)
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentPropertyNotFound);
@@ -172,6 +183,7 @@ fn document_property(is_candidate: bool) {
                 .get(url.join("/documents/d2/properties/p1")?)
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);
@@ -182,6 +194,7 @@ fn document_property(is_candidate: bool) {
                 .json(&json!({ "property": 42 }))
                 .build()?,
             StatusCode::NO_CONTENT,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
@@ -191,6 +204,7 @@ fn document_property(is_candidate: bool) {
                 .json(&json!({ "property": 42 }))
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);
@@ -200,6 +214,7 @@ fn document_property(is_candidate: bool) {
                 .get(url.join("/documents/d1/properties/p1")?)
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(property, json!(42));
@@ -210,6 +225,7 @@ fn document_property(is_candidate: bool) {
                 .delete(url.join("/documents/d1/properties/p1")?)
                 .build()?,
             StatusCode::NO_CONTENT,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
@@ -218,6 +234,7 @@ fn document_property(is_candidate: bool) {
                 .delete(url.join("/documents/d1/properties/p1")?)
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentPropertyNotFound);
@@ -227,6 +244,7 @@ fn document_property(is_candidate: bool) {
                 .delete(url.join("/documents/d2/properties/p1")?)
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error, Error::DocumentNotFound);

--- a/web-api/tests/filter.rs
+++ b/web-api/tests/filter.rs
@@ -37,6 +37,7 @@ async fn index(client: &Client, url: &Url, properties: Value) -> Result<(), Erro
             .json(&json!({ "properties": properties }))
             .build()?,
         StatusCode::ACCEPTED,
+        false,
     )
     .await;
     Ok(())
@@ -50,6 +51,7 @@ async fn ingest(client: &Client, url: &Url, documents: Value) -> Result<(), Erro
             .json(&json!({ "documents": documents }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -108,6 +110,7 @@ fn test_filter_string() {
                     .json(&json!({ "document": { "query": "zero" } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -122,6 +125,7 @@ fn test_filter_string() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2"].into());
@@ -136,6 +140,7 @@ fn test_filter_string() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -150,6 +155,7 @@ fn test_filter_string() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -189,6 +195,7 @@ fn test_filter_array_string_single() {
                     .json(&json!({ "document": { "query": "zero" } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -203,6 +210,7 @@ fn test_filter_array_string_single() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2"].into());
@@ -217,6 +225,7 @@ fn test_filter_array_string_single() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3"].into());
@@ -231,6 +240,7 @@ fn test_filter_array_string_single() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -245,6 +255,7 @@ fn test_filter_array_string_single() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -259,6 +270,7 @@ fn test_filter_array_string_single() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -299,6 +311,7 @@ fn test_filter_array_string_multiple() {
                     .json(&json!({ "document": { "query": "zero" } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3", "d4"].into());
@@ -313,6 +326,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3"].into());
@@ -327,6 +341,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d4"].into());
@@ -341,6 +356,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3", "d4"].into());
@@ -355,6 +371,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -369,6 +386,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -383,6 +401,7 @@ fn test_filter_array_string_multiple() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -422,6 +441,7 @@ fn test_filter_combine() {
                     .json(&json!({ "document": { "query": "zero" } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -438,6 +458,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2"].into());
@@ -454,6 +475,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -470,6 +492,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3"].into());
@@ -486,6 +509,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -497,6 +521,7 @@ fn test_filter_combine() {
                     .json(&json!({ "document": { "query": "zero" }, "filter": { "$and": [] } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -508,6 +533,7 @@ fn test_filter_combine() {
                     .json(&json!({ "document": { "query": "zero" }, "filter": { "$or": [] } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -525,6 +551,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d3"].into());
@@ -542,6 +569,7 @@ fn test_filter_combine() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3"].into());
@@ -589,6 +617,7 @@ fn test_filter_date() {
                     .json(&json!({ "document": { "query": "zero" } }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d1", "d2", "d3"].into());
@@ -603,6 +632,7 @@ fn test_filter_date() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d3"].into());
@@ -620,6 +650,7 @@ fn test_filter_date() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2"].into());
@@ -637,6 +668,7 @@ fn test_filter_date() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(documents.ids(), ["d2", "d3"].into());
@@ -651,6 +683,7 @@ fn test_filter_date() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert!(documents.is_empty());
@@ -677,7 +710,7 @@ fn test_deprecated_published_after() {
             )
             .await?;
 
-            let response = send_assert(
+            let documents = send_assert_json::<SemanticSearchResponse>(
                 &client,
                 client
                     .post(personalization_url.join("/semantic_search")?)
@@ -687,12 +720,9 @@ fn test_deprecated_published_after() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                true,
             )
             .await;
-            assert!(response.headers().contains_key("deprecation"));
-            let documents =
-                serde_json::from_slice::<SemanticSearchResponse>(&response.bytes().await.unwrap())
-                    .unwrap();
             assert_eq!(documents.ids(), ["d1"].into());
 
             Ok(())

--- a/web-api/tests/health.rs
+++ b/web-api/tests/health.rs
@@ -31,6 +31,7 @@ fn test_health() {
             &client,
             client.get(url.join("/health")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         Ok(())

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -40,6 +40,7 @@ async fn ingest(client: &Client, url: &Url) -> Result<(), anyhow::Error> {
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -74,18 +75,21 @@ fn test_ingestion_created() {
             &client,
             client.get(url.join("/documents/d1/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         send_assert(
             &client,
             client.get(url.join("/documents/d2/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
             &client,
             client.get(url.join("/documents/d3/properties")?).build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error.kind, Kind::DocumentNotFound);
@@ -109,6 +113,7 @@ fn test_ingestion_bad_request() {
                 }))
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error.kind, Kind::FailedToValidateDocuments);
@@ -120,6 +125,7 @@ fn test_ingestion_bad_request() {
             &client,
             client.get(url.join("/documents/d2/properties")?).build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         Ok(())
@@ -134,6 +140,7 @@ fn test_deletion() {
             &client,
             client.delete(url.join("/documents/d1")?).build()?,
             StatusCode::NO_CONTENT,
+            false,
         )
         .await;
         let error = send_assert_json::<Error>(
@@ -143,6 +150,7 @@ fn test_deletion() {
                 .json(&json!({ "documents": ["d1", "d2"] }))
                 .build()?,
             StatusCode::BAD_REQUEST,
+            false,
         )
         .await;
         assert_eq!(error.kind, Kind::FailedToDeleteSomeDocuments);
@@ -184,6 +192,7 @@ fn test_reingestion_candidates() {
                     }))
                     .build()?,
                 StatusCode::CREATED,
+                false,
             )
             .await;
             let SemanticSearchResponse { documents } = send_assert_json(
@@ -196,6 +205,7 @@ fn test_reingestion_candidates() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(
@@ -220,6 +230,7 @@ fn test_reingestion_candidates() {
                     }))
                     .build()?,
                 StatusCode::CREATED,
+                false,
             )
             .await;
             let SemanticSearchResponse { documents } = send_assert_json(
@@ -232,6 +243,7 @@ fn test_reingestion_candidates() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_eq!(
@@ -267,6 +279,7 @@ fn test_reingestion_snippets() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
         send_assert(
@@ -283,6 +296,7 @@ fn test_reingestion_snippets() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -311,6 +325,7 @@ fn test_ingestion_same_id() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
         let OrderPropertyResponse { property } = send_assert_json(
@@ -319,6 +334,7 @@ fn test_ingestion_same_id() {
                 .get(url.join("/documents/d1/properties/order")?)
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(property, 3);
@@ -328,6 +344,7 @@ fn test_ingestion_same_id() {
                 .get(url.join("/documents/d2/properties/order")?)
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(property, 2);
@@ -355,6 +372,7 @@ fn test_ingestion_validation() {
                     }))
                     .build()?,
                 StatusCode::BAD_REQUEST,
+                false,
             )
             .await;
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
@@ -374,6 +392,7 @@ fn test_ingestion_validation() {
                     }))
                     .build()?,
                 StatusCode::BAD_REQUEST,
+                false,
             )
             .await;
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
@@ -393,6 +412,7 @@ fn test_ingestion_validation() {
                     }))
                     .build()?,
                 StatusCode::BAD_REQUEST,
+                false,
             )
             .await;
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -203,6 +203,7 @@ fn test_full_migration() {
                 .json(&es_mapping)
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
 
@@ -237,6 +238,7 @@ fn test_full_migration() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -249,6 +251,7 @@ fn test_full_migration() {
                 .json(&json!({ "document": { "query": "snippet" } }))
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(
@@ -312,6 +315,7 @@ fn test_full_migration() {
                 .json(&json!({ "document": { "query": "snippet" } }))
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(
@@ -333,6 +337,7 @@ fn test_full_migration() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -345,6 +350,7 @@ fn test_full_migration() {
                 .json(&json!({ "document": { "query": "snippet" } }))
                 .build()?,
             StatusCode::OK,
+            false,
         )
         .await;
         assert_eq!(

--- a/web-api/tests/manage_indexed_properties.rs
+++ b/web-api/tests/manage_indexed_properties.rs
@@ -49,6 +49,7 @@ fn test_creating_indexed_properties() {
                     }))
                     .build()?,
                 StatusCode::ACCEPTED,
+                false,
             )
             .await;
 
@@ -91,6 +92,7 @@ fn test_creating_indexed_properties() {
                     }))
                     .build()?,
                 StatusCode::ACCEPTED,
+                false,
             )
             .await;
 
@@ -129,6 +131,7 @@ fn test_creating_indexed_properties() {
                     .get(ingestion_url.join("/documents/_indexed_properties")?)
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -137,7 +140,8 @@ fn test_creating_indexed_properties() {
             let es = services.silo.elastic_config();
             let url = es.url.parse::<Url>()?.join("_mapping")?;
             let res =
-                send_assert_json::<Value>(&client, client.get(url).build()?, StatusCode::OK).await;
+                send_assert_json::<Value>(&client, client.get(url).build()?, StatusCode::OK, false)
+                    .await;
             let properties_mapping = &res[services.test_id.as_str()]["mappings"]["properties"]
                 ["properties"]["properties"];
             assert_eq!(
@@ -201,6 +205,7 @@ fn test_check_new_property_values_against_schema() {
                 }))
                 .build()?,
             StatusCode::CREATED,
+            false,
         )
         .await;
 
@@ -229,6 +234,7 @@ fn test_check_new_property_values_against_schema() {
                     }))
                     .build()?,
                 StatusCode::ACCEPTED,
+                false,
             )
             .await;
 
@@ -275,6 +281,7 @@ fn test_check_new_property_values_against_schema() {
                     }))
                     .build()?,
                 StatusCode::CREATED,
+                false,
             )
             .await;
 
@@ -300,6 +307,7 @@ fn test_check_new_property_values_against_schema() {
                         }))
                         .build()?,
                     StatusCode::BAD_REQUEST,
+                    false,
                 )
                 .await;
 
@@ -326,6 +334,7 @@ fn test_check_new_property_values_against_schema() {
                         }))
                         .build()?,
                     StatusCode::BAD_REQUEST,
+                    false,
                 )
                 .await;
 
@@ -368,6 +377,7 @@ fn test_check_new_property_values_against_schema() {
                         .json(&json!({ "property": bad_value }))
                         .build()?,
                     StatusCode::BAD_REQUEST,
+                    false,
                 )
                 .await;
 

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
 use xayn_web_api::{Ingestion, Personalization};
+use xayn_web_api_shared::serde::json_object;
 
 async fn ingest_with_dates(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
     send_assert(
@@ -42,6 +43,7 @@ async fn ingest_with_dates(client: &Client, ingestion_url: &Url) -> Result<(), E
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -67,6 +69,7 @@ async fn ingest_with_tags(client: &Client, ingestion_url: &Url) -> Result<(), Er
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -80,6 +83,7 @@ async fn interact(client: &Client, personalization_url: &Url) -> Result<(), Erro
             .json(&json!({ "documents": [ { "id": "d2" }, { "id": "d9" } ] }))
             .build()?,
         StatusCode::NO_CONTENT,
+        false,
     )
     .await;
     Ok(())
@@ -111,25 +115,44 @@ async fn personalize(
     personalization_url: &Url,
     published_after: Option<&str>,
     include_properties: Option<bool>,
+    is_deprecated: bool,
 ) -> Result<Vec<PersonalizedDocumentData>, Error> {
-    let mut request = client
-        .get(personalization_url.join("/users/u1/personalized_documents")?)
-        .query(&[("count", "5")]);
-    if let Some(published_after) = published_after {
-        request = request.query(&[(
-            "filter",
-            json!({ "publication_date": { "$gte": published_after } }).to_string(),
-        )]);
+    let request = if is_deprecated {
+        let mut request = client
+            .get(personalization_url.join("/users/u1/personalized_documents")?)
+            .query(&[("count", "5")]);
+        if let Some(published_after) = published_after {
+            request = request.query(&[(
+                "filter",
+                json!({ "publication_date": { "$gte": published_after } }).to_string(),
+            )]);
+        }
+        if let Some(include_properties) = include_properties {
+            request = request.query(&[("include_properties", &include_properties.to_string())]);
+        }
+        request
+    } else {
+        let mut body = json_object!({ "count": 5 });
+        if let Some(published_after) = published_after {
+            body.insert(
+                "filter".into(),
+                json!({ "publication_date": { "$gte": published_after } }),
+            );
+        }
+        if let Some(include_properties) = include_properties {
+            body.insert("include_properties".into(), json!(include_properties));
+        }
+        client
+            .post(personalization_url.join("/users/u1/personalized_documents")?)
+            .json(&body)
     }
-    if let Some(include_properties) = include_properties {
-        request = request.query(&[("include_properties", &include_properties.to_string())]);
-    }
-    let request = request.build()?;
+    .build()?;
 
     let error = send_assert_json::<PersonalizedDocumentsResponse>(
         client,
         request.try_clone().unwrap(),
         StatusCode::CONFLICT,
+        is_deprecated,
     )
     .await;
     assert_eq!(
@@ -139,8 +162,13 @@ async fn personalize(
 
     interact(client, personalization_url).await?;
 
-    let documents =
-        send_assert_json::<PersonalizedDocumentsResponse>(client, request, StatusCode::OK).await;
+    let documents = send_assert_json::<PersonalizedDocumentsResponse>(
+        client,
+        request,
+        StatusCode::OK,
+        is_deprecated,
+    )
+    .await;
     assert!(matches!(
         documents,
         PersonalizedDocumentsResponse::Documents(_),
@@ -171,14 +199,14 @@ macro_rules! assert_order {
     };
 }
 
-#[test]
-fn test_personalization_all_dates() {
+fn personalization_all_dates(is_deprecated: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_dates(&client, &ingestion_url).await?;
-            let documents = personalize(&client, &personalization_url, None, None).await?;
+            let documents =
+                personalize(&client, &personalization_url, None, None, is_deprecated).await?;
             assert_order!(
                 &documents,
                 ["d8", "d6", "d1", "d5"],
@@ -190,7 +218,16 @@ fn test_personalization_all_dates() {
 }
 
 #[test]
-fn test_personalization_limited_dates() {
+fn test_personalization_all_dates() {
+    personalization_all_dates(false);
+}
+
+#[test]
+fn test_deprecated_personalization_all_dates() {
+    personalization_all_dates(true);
+}
+
+fn personalization_limited_dates(is_deprecated: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -201,6 +238,7 @@ fn test_personalization_limited_dates() {
                 &personalization_url,
                 Some("2022-01-01T00:00:00Z"),
                 None,
+                is_deprecated,
             )
             .await?;
             assert_order!(
@@ -214,13 +252,23 @@ fn test_personalization_limited_dates() {
 }
 
 #[test]
-fn test_personalization_with_tags() {
+fn test_personalization_limited_dates() {
+    personalization_limited_dates(false);
+}
+
+#[test]
+fn test_deprecated_personalization_limited_dates() {
+    personalization_limited_dates(true);
+}
+
+fn personalization_with_tags(is_deprecated: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest_with_tags(&client, &ingestion_url).await?;
-            let documents = personalize(&client, &personalization_url, None, None).await?;
+            let documents =
+                personalize(&client, &personalization_url, None, None, is_deprecated).await?;
             assert_order!(
                 &documents,
                 ["d5", "d6", "d1", "d8"],
@@ -231,7 +279,17 @@ fn test_personalization_with_tags() {
     );
 }
 
-fn personalization_include_properties(include_properties: bool) {
+#[test]
+fn test_personalization_with_tags() {
+    personalization_with_tags(false);
+}
+
+#[test]
+fn test_deprecated_personalization_with_tags() {
+    personalization_with_tags(true);
+}
+
+fn personalization_include_properties(include_properties: bool, is_deprecated: bool) {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         UNCHANGED_CONFIG,
@@ -242,6 +300,7 @@ fn personalization_include_properties(include_properties: bool) {
                 &personalization_url,
                 None,
                 Some(include_properties),
+                is_deprecated,
             )
             .await?;
             let is_empty = documents
@@ -260,10 +319,41 @@ fn personalization_include_properties(include_properties: bool) {
 
 #[test]
 fn test_personalization_include_properties() {
-    personalization_include_properties(true);
+    personalization_include_properties(true, false);
 }
 
 #[test]
 fn test_personalization_exclude_properties() {
-    personalization_include_properties(false);
+    personalization_include_properties(false, false);
+}
+
+#[test]
+fn test_deprecated_personalization_include_properties() {
+    personalization_include_properties(true, true);
+}
+
+#[test]
+fn test_deprecated_personalization_exclude_properties() {
+    personalization_include_properties(false, true);
+}
+
+#[test]
+fn test_personalize_no_body() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        UNCHANGED_CONFIG,
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest_with_dates(&client, &ingestion_url).await?;
+            send_assert(
+                &client,
+                client
+                    .post(personalization_url.join("/users/u1/personalized_documents")?)
+                    .build()?,
+                StatusCode::CONFLICT,
+                false,
+            )
+            .await;
+            Ok(())
+        },
+    );
 }

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -41,6 +41,7 @@ async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
     Ok(())
@@ -54,6 +55,7 @@ async fn interact(client: &Client, personalization_url: &Url) -> Result<(), Erro
             .json(&json!({ "documents": [ { "id": "d2" }, { "id": "d9" } ] }))
             .build()?,
         StatusCode::NO_CONTENT,
+        false,
     )
     .await;
     Ok(())
@@ -111,6 +113,7 @@ fn test_full_personalization() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -131,6 +134,7 @@ fn test_full_personalization() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -150,6 +154,7 @@ fn test_full_personalization() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -186,6 +191,7 @@ fn test_subtle_personalization() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -221,6 +227,7 @@ fn test_full_personalization_with_inline_history() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -239,6 +246,7 @@ fn test_full_personalization_with_inline_history() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -258,6 +266,7 @@ fn test_full_personalization_with_inline_history() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -34,6 +34,7 @@ async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
             }))
             .build()?,
         StatusCode::CREATED,
+        false,
     )
     .await;
 
@@ -89,6 +90,7 @@ fn test_semantic_search() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -123,6 +125,7 @@ fn test_semantic_search_with_query() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -162,6 +165,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -180,6 +184,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -198,6 +203,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -216,6 +222,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -237,6 +244,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 
@@ -265,6 +273,7 @@ fn test_semantic_search_with_dev_option_hybrid_es_rrf() {
                     .build()?,
                 // current license is non-compliant for Reciprocal Rank Fusion (RRF)
                 StatusCode::INTERNAL_SERVER_ERROR,
+                false,
             )
             .await;
 
@@ -292,6 +301,7 @@ fn test_semantic_search_with_dev_option_candidates() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(documents, ["d1"], "unexpected documents: {documents:?}");
@@ -307,6 +317,7 @@ fn test_semantic_search_with_dev_option_candidates() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(
@@ -326,6 +337,7 @@ fn test_semantic_search_with_dev_option_candidates() {
                     }))
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             assert_order!(

--- a/web-api/tests/silo_management_api.rs
+++ b/web-api/tests/silo_management_api.rs
@@ -52,6 +52,7 @@ fn test_tenants_can_be_created() {
                     ]
                 })).build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
 

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -54,6 +54,7 @@ fn store_user_history(enabled: bool) {
                     }))
                     .build()?,
                 StatusCode::CREATED,
+                false,
             )
             .await;
 
@@ -64,15 +65,17 @@ fn store_user_history(enabled: bool) {
                     .json(&json!({ "documents": [ { "id": "2" }, { "id": "5" } ] }))
                     .build()?,
                 StatusCode::NO_CONTENT,
+                false,
             )
             .await;
 
             let documents = send_assert_json::<PersonalizedDocumentsResponse>(
                 &client,
                 client
-                    .get(personalization.join("/users/u0/personalized_documents")?)
+                    .post(personalization.join("/users/u0/personalized_documents")?)
                     .build()?,
                 StatusCode::OK,
+                false,
             )
             .await;
             let documents = documents

--- a/web-api/tests/tenant_id_header.rs
+++ b/web-api/tests/tenant_id_header.rs
@@ -39,6 +39,7 @@ fn test_tenant_id_is_required_if_legacy_tenant_is_disabled() {
                     }))
                     .build()?,
                 StatusCode::INTERNAL_SERVER_ERROR,
+                false,
             )
             .await;
             Ok(())
@@ -67,6 +68,7 @@ fn test_tenant_id_is_not_required_if_legacy_tenant_is_enabled() {
                     }))
                     .build()?,
                 StatusCode::CREATED,
+                false,
             )
             .await;
 


### PR DESCRIPTION
**Reference**

- [ET-4828]

**Summary**

- deprecate `GET /users/{id}/personalized_documents` with params in favor of `POST` with body
- add missing deprecation tests for document candidates


[ET-4828]: https://xainag.atlassian.net/browse/ET-4828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ