### PR TITLE
ET-4845 validate config invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,6 +4637,7 @@ dependencies = [
 name = "xayn-ai-bert"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "criterion",
  "csv",
  "derive_more",

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }

--- a/bert/src/tokenizer.rs
+++ b/bert/src/tokenizer.rs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use anyhow::anyhow;
 use derive_more::{Deref, From};
 use figment::value::Dict;
 use ndarray::Array2;
@@ -81,7 +82,13 @@ pub(crate) struct Tokenizer {
 
 impl Tokenizer {
     pub(crate) fn new<P>(config: &Config<P>) -> Result<Self, Error> {
-        let mut tokenizer = HfTokenizer::from_file(config.dir.join("tokenizer.json"))?;
+        let tokenizer = config.dir.join("tokenizer.json");
+        if !tokenizer.exists() {
+            return Err(
+                anyhow!("embedder tokenizer '{}' doesn't exist", tokenizer.display()).into(),
+            );
+        }
+        let mut tokenizer = HfTokenizer::from_file(tokenizer)?;
         let padding_token = config.extract::<String>("tokenizer.tokens.padding")?;
         let padding = PaddingParams {
             strategy: PaddingStrategy::Fixed(config.token_size),

--- a/coi/src/config.rs
+++ b/coi/src/config.rs
@@ -61,6 +61,20 @@ pub enum Error {
 }
 
 impl Config {
+    pub fn validate(&self) -> Result<(), Error> {
+        if !(0. ..=1.).contains(&self.shift_factor) {
+            return Err(Error::ShiftFactor);
+        }
+        if !(-1. ..=1.).contains(&self.threshold) {
+            return Err(Error::Threshold);
+        }
+        if self.min_cois == 0 {
+            return Err(Error::MinCois);
+        }
+
+        Ok(())
+    }
+
     /// The shift factor by how much a coi is shifted towards a new point.
     pub fn shift_factor(&self) -> f32 {
         self.shift_factor
@@ -71,12 +85,10 @@ impl Config {
     /// # Errors
     /// Fails if the shift factor is outside of the unit interval.
     pub fn with_shift_factor(mut self, shift_factor: f32) -> Result<Self, Error> {
-        if (0. ..=1.).contains(&shift_factor) {
-            self.shift_factor = shift_factor;
-            Ok(self)
-        } else {
-            Err(Error::ShiftFactor)
-        }
+        self.shift_factor = shift_factor;
+        self.validate()?;
+
+        Ok(self)
     }
 
     /// The maximum similarity between distinct cois.
@@ -89,12 +101,10 @@ impl Config {
     /// # Errors
     /// Fails if the threshold is not within [`-1, 1`].
     pub fn with_threshold(mut self, threshold: f32) -> Result<Self, Error> {
-        if (-1. ..=1.).contains(&threshold) {
-            self.threshold = threshold;
-            Ok(self)
-        } else {
-            Err(Error::Threshold)
-        }
+        self.threshold = threshold;
+        self.validate()?;
+
+        Ok(self)
     }
 
     /// The minimum number of cois required for the context calculation.
@@ -107,12 +117,10 @@ impl Config {
     /// # Errors
     /// Fails if the minimum number is zero.
     pub fn with_min_cois(mut self, min_cois: usize) -> Result<Self, Error> {
-        if min_cois > 0 {
-            self.min_cois = min_cois;
-            Ok(self)
-        } else {
-            Err(Error::MinCois)
-        }
+        self.min_cois = min_cois;
+        self.validate()?;
+
+        Ok(self)
     }
 
     /// The time since the last view after which a coi becomes irrelevant.
@@ -129,5 +137,15 @@ impl Config {
     /// Creates a coi system.
     pub fn build(self) -> System {
         System { config: self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_default_config() {
+        Config::default().validate().unwrap();
     }
 }

--- a/test-utils/src/asset.rs
+++ b/test-utils/src/asset.rs
@@ -36,24 +36,29 @@ fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
         .canonicalize()
 }
 
-/// Resolves the path to the qasmbert.
+/// Resolves the path to the qasmbert model.
 pub fn qasmbert() -> Result<PathBuf> {
     resolve_path(&[DATA_DIR, "qasmbert_v0002"])
 }
 
-/// Resolves the path to the smbert.
+/// Resolves the path to the smbert model.
 pub fn smbert() -> Result<PathBuf> {
     resolve_path(&[DATA_DIR, "smbert_v0004"])
 }
 
-/// Resolves the path to the mocked smbert.
+/// Resolves the path to the mocked smbert model.
 pub fn smbert_mocked() -> Result<PathBuf> {
     resolve_path(&[DATA_DIR, "smbert_mocked_v0004"])
 }
 
-/// Resolves the path to the e5 like model.
+/// Resolves the path to the mocked e5 model.
 pub fn e5_mocked() -> Result<PathBuf> {
     resolve_path(&[DATA_DIR, "e5_mocked_v0000"])
+}
+
+/// Resolves the path to the xaynia model.
+pub fn xaynia() -> Result<PathBuf> {
+    qasmbert()
 }
 
 #[cfg(test)]

--- a/web-api/src/app/state.rs
+++ b/web-api/src/app/state.rs
@@ -61,6 +61,7 @@ where
 
     pub(super) async fn create(config: A::Config) -> Result<Self, SetupError> {
         let extension = A::create_extension(&config)?;
+        // embedder config is validated during loading
         let embedder = Embedder::load(config.as_ref())?;
         let (silo, legacy_tenant) =
             initialize_silo(config.as_ref(), config.as_ref(), embedder.embedding_size()).await?;

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -17,6 +17,7 @@ mod filter;
 
 use std::{collections::HashMap, convert::identity, hash::Hash, ops::AddAssign};
 
+use anyhow::bail;
 pub(crate) use client::{Client, ClientBuilder};
 use itertools::Itertools;
 use reqwest::Method;
@@ -38,6 +39,7 @@ use super::{
     SearchStrategy,
 };
 use crate::{
+    app::SetupError,
     models::{
         self,
         DocumentId,
@@ -473,6 +475,16 @@ impl Default for IndexUpdateConfig {
     }
 }
 
+impl IndexUpdateConfig {
+    pub(crate) fn validate(&self) -> Result<(), SetupError> {
+        if self.requests_per_second == 0 {
+            bail!("invalid IndexUpdateConfig, requests_per_second must be > 0");
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum IndexUpdateMethod {
@@ -724,5 +736,10 @@ mod tests {
             .into_iter()
             .collect()
         );
+    }
+
+    #[test]
+    fn test_validate_default_index_update_config() {
+        IndexUpdateConfig::default().validate().unwrap();
     }
 }

--- a/web-api/src/utils.rs
+++ b/web-api/src/utils.rs
@@ -11,6 +11,8 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 
+use std::path::Path;
+
 use derive_more::Deref;
 use figment::value::magic::RelativePathBuf as FigmentRelativePathBuf;
 use serde::{Deserialize, Serialize};
@@ -22,10 +24,13 @@ pub struct RelativePathBuf {
     inner: FigmentRelativePathBuf,
 }
 
-impl From<&str> for RelativePathBuf {
-    fn from(s: &str) -> Self {
+impl<P> From<P> for RelativePathBuf
+where
+    P: AsRef<Path>,
+{
+    fn from(path: P) -> Self {
         Self {
-            inner: FigmentRelativePathBuf::from(s),
+            inner: FigmentRelativePathBuf::from(path),
         }
     }
 }


### PR DESCRIPTION
**Reference**

- [ET-4845]

**Summary**

- impl validation for front/back office configs where invariants must hold
- run validation during service startup


[ET-4845]: https://xainag.atlassian.net/browse/ET-4845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ