### PR TITLE
ET-4855 cleanup tokenizer dead code

### DIFF
--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -15,7 +15,7 @@
 use std::{hint::black_box, path::Path};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use xayn_ai_bert::{tokenizer::Tokenizer, Config, NonePooler};
+use xayn_ai_bert::{Config, NonePooler};
 use xayn_test_utils::asset::smbert;
 
 const TOKEN_SIZE: usize = 64;
@@ -26,7 +26,6 @@ fn bench_tract_bert(manager: &mut Criterion, name: &str, dir: &Path) {
         .unwrap()
         .with_token_size(TOKEN_SIZE)
         .unwrap()
-        .with_tokenizer::<Tokenizer>()
         .with_pooler::<NonePooler>()
         .build()
         .unwrap();

--- a/bert/examples/bert.rs
+++ b/bert/examples/bert.rs
@@ -14,13 +14,12 @@
 
 //! Run as `cargo run --example bert
 
-use xayn_ai_bert::{tokenizer::Tokenizer, Config, FirstPooler};
+use xayn_ai_bert::{Config, FirstPooler};
 use xayn_test_utils::asset::smbert;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pipeline = Config::new(smbert()?)?
         .with_token_size(64)?
-        .with_tokenizer::<Tokenizer>()
         .with_pooler::<FirstPooler>()
         .build()?;
     let embedding = pipeline.run("This is a sequence.")?;

--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -40,7 +40,7 @@ mod config;
 mod model;
 mod pipeline;
 mod pooler;
-pub mod tokenizer;
+mod tokenizer;
 
 pub use crate::{
     config::Config,
@@ -58,4 +58,4 @@ pub use crate::{
 };
 
 /// A Transformer pipeline with an average pooler.
-pub type AvgEmbedder = Pipeline<crate::tokenizer::Tokenizer, AveragePooler>;
+pub type AvgEmbedder = Pipeline<AveragePooler>;

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -42,7 +42,7 @@ enum Dimension {
     Dynamic(DynDim),
 }
 
-impl<T, P> Config<T, P> {
+impl<P> Config<P> {
     fn extract_facts(
         &self,
         io: &'static str,
@@ -93,7 +93,7 @@ pub(crate) struct Prediction(TValue);
 
 impl Model {
     /// Creates a model from a configuration.
-    pub(crate) fn new<T, P>(config: &Config<T, P>) -> Result<Self, TractError> {
+    pub(crate) fn new<P>(config: &Config<P>) -> Result<Self, TractError> {
         let mut model = BufReader::new(File::open(config.dir.join("model.onnx"))?);
         let model = tract_onnx::onnx().model_for_read(&mut model)?;
         let model = config.extract_facts("input", model, InferenceModel::with_input_fact)?;


### PR DESCRIPTION
**Reference**

- [ET-4855]

**Summary**

- remove unused functions and generics related to the tokenizer in the `bert` crate


[ET-4855]: https://xainag.atlassian.net/browse/ET-4855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ