### PR TITLE
ET-4799 length limit and error reporting in ingestion

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -72,12 +72,11 @@ pub(crate) struct InvalidDocumentPropertyId {
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST, INFO);
 
-/// Malformed property {document}/{property}, {invalid_reason}: {invalid_value}
+/// Malformed property {property}, {invalid_reason}: {invalid_value}
 #[derive(Debug, Error, Display, Serialize)]
 // there are some false positives with clippy and displaydoc
 #[allow(clippy::doc_markdown)]
 pub(crate) struct InvalidDocumentProperty {
-    pub(crate) document: DocumentId,
     pub(crate) property: DocumentPropertyId,
     pub(crate) invalid_value: Value,
     pub(crate) invalid_reason: InvalidDocumentPropertyReason,
@@ -125,6 +124,7 @@ pub(crate) struct InvalidDocumentTags {
 impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 
 #[derive(Debug, Error, Display, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidDocumentSnippet {
     /// Malformed document snippet.
     Value { value: String },

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -52,7 +52,7 @@ impl_application_error!(DocumentPropertyNotFound => BAD_REQUEST, INFO);
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidString {
-    /// Invalid size. Got {got}, expected {min}..={max}.
+    /// Invalid byte size. Got {got}, expected {min}..={max}.
     Size { got: usize, min: usize, max: usize },
     /// Invalid syntax, expected: {expected}
     Syntax { expected: &'static str },
@@ -81,7 +81,7 @@ pub(crate) struct InvalidDocumentPropertyId(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST, INFO);
 
-/// Malformed property {property}, {invalid_reason}: {invalid_value}
+/// Malformed document property {property}, {invalid_reason}: {invalid_value}
 #[derive(Debug, Error, Display, Serialize)]
 // there are some false positives with clippy and displaydoc
 #[allow(clippy::doc_markdown)]
@@ -110,7 +110,7 @@ impl_application_error!(InvalidDocumentProperty => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidDocumentProperties {
-    /// Storage size of properties is to large. Got {got}, expected {max}.
+    /// Storage byte size of document properties is to large. Got {got}, expected at most {max}.
     StorageSize { got: usize, max: usize },
 }
 
@@ -174,7 +174,7 @@ pub(crate) struct FailedToValidateDocuments {
 
 impl_application_error!(FailedToValidateDocuments => BAD_REQUEST, INFO);
 
-#[derive(Serialize, Debug, From)]
+#[derive(Serialize, Debug)]
 pub(crate) struct DocumentInBatchError {
     pub(crate) id: String,
     pub(crate) kind: String,

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -107,12 +107,11 @@ pub(crate) enum InvalidDocumentPropertyReason {
 
 impl_application_error!(InvalidDocumentProperty => BAD_REQUEST, INFO);
 
-/// Storage size of properties is to large. Got {size}, expected {max_size}.
 #[derive(Debug, Error, Display, Serialize)]
-#[allow(clippy::doc_markdown)]
-pub(crate) struct InvalidDocumentProperties {
-    pub(crate) size: usize,
-    pub(crate) max_size: usize,
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InvalidDocumentProperties {
+    /// Storage size of properties is to large. Got {got}, expected {max}.
+    StorageSize { got: usize, max: usize },
 }
 
 impl_application_error!(InvalidDocumentProperties => BAD_REQUEST, INFO);

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -48,27 +48,36 @@ pub(crate) struct DocumentPropertyNotFound;
 
 impl_application_error!(DocumentPropertyNotFound => BAD_REQUEST, INFO);
 
-/// Malformed user id.
-#[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidUserId {
-    pub(crate) value: String,
+#[derive(Debug, Display, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InvalidString {
+    /// Invalid size. Got {got}, expected {min}..={max}.
+    Size { got: usize, min: usize, max: usize },
+    /// Invalid syntax, expected: {expected}
+    Syntax { expected: &'static str },
 }
+
+/// Malformed user id: {0}
+#[derive(Debug, Error, Display, Serialize)]
+#[serde(transparent)]
+pub(crate) struct InvalidUserId(pub(crate) InvalidString);
 
 impl_application_error!(InvalidUserId => BAD_REQUEST, INFO);
 
-/// Malformed document id.
+/// Malformed document id: {0}
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidDocumentId {
-    pub(crate) value: String,
-}
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub(crate) struct InvalidDocumentId(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentId => BAD_REQUEST, INFO);
 
-/// Malformed document property id.
+/// Malformed document property id: {0}
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidDocumentPropertyId {
-    pub(crate) value: String,
-}
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub(crate) struct InvalidDocumentPropertyId(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST, INFO);
 
@@ -98,8 +107,9 @@ pub(crate) enum InvalidDocumentPropertyReason {
 
 impl_application_error!(InvalidDocumentProperty => BAD_REQUEST, INFO);
 
-/// Malsized document properties.
+/// Storage size of properties is to large. Got {size}, expected {max_size}.
 #[derive(Debug, Error, Display, Serialize)]
+#[allow(clippy::doc_markdown)]
 pub(crate) struct InvalidDocumentProperties {
     pub(crate) size: usize,
     pub(crate) max_size: usize,
@@ -107,42 +117,39 @@ pub(crate) struct InvalidDocumentProperties {
 
 impl_application_error!(InvalidDocumentProperties => BAD_REQUEST, INFO);
 
-/// Malformed document tag.
+/// Malformed document tag: {0}
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidDocumentTag {
-    pub(crate) value: String,
-}
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub(crate) struct InvalidDocumentTag(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentTag => BAD_REQUEST, INFO);
 
-/// Malsized document tags.
+/// To many document tags. Got {size}, expect at most {max}.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct InvalidDocumentTags {
     pub(crate) size: usize,
+    pub(crate) max: usize,
 }
 
 impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 
+/// Malformed document snippet: {0}
 #[derive(Debug, Error, Display, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum InvalidDocumentSnippet {
-    /// Malformed document snippet.
-    Value { value: String },
-    /// Malsized document snippet.
-    Size { size: usize, max_size: usize },
-}
+#[serde(transparent)]
+pub(crate) struct InvalidDocumentSnippet(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);
 
-/// Malformed document query.
+/// Malformed document query: {0}
 #[derive(Debug, Error, Display, Serialize)]
-pub(crate) struct InvalidDocumentQuery {
-    pub(crate) value: String,
-}
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub(crate) struct InvalidDocumentQuery(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentQuery => BAD_REQUEST, INFO);
 
-/// Malsized document count.
+/// Malsized document count. Got {count}, expected {min}..={max}.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct InvalidDocumentCount {
     pub(crate) count: usize,
@@ -208,7 +215,7 @@ impl_application_error!(HistoryTooSmall => BAD_REQUEST, INFO);
 
 impl_application_error!(IncompatibleUpdate => BAD_REQUEST, INFO);
 
-/// Custom error for 400 Bad Request status code.
+/// Custom error for 400 Bad Request status code: {message}
 #[derive(Debug, Error, Display, Serialize, From)]
 pub(crate) struct BadRequest {
     pub(crate) message: Cow<'static, str>,

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -163,15 +163,31 @@ impl_application_error!(FailedToDeleteSomeDocuments => BAD_REQUEST, INFO);
 /// The validation of some documents failed.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct FailedToValidateDocuments {
-    pub(crate) documents: Vec<DocumentIdAsObject>,
+    pub(crate) documents: Vec<DocumentInBatchError>,
 }
 
 impl_application_error!(FailedToValidateDocuments => BAD_REQUEST, INFO);
 
+#[derive(Serialize, Debug, From)]
+pub(crate) struct DocumentInBatchError {
+    pub(crate) id: String,
+    pub(crate) kind: String,
+    pub(crate) details: Value,
+}
+
+impl DocumentInBatchError {
+    pub(crate) fn new(id: impl Into<String>, error: &dyn ApplicationError) -> Self {
+        Self {
+            id: id.into(),
+            kind: error.kind().into(),
+            details: error.encode_details(),
+        }
+    }
+}
 /// The ingestion of some documents failed.
 #[derive(Debug, Error, Display, Serialize)]
 pub(crate) struct FailedToIngestDocuments {
-    pub(crate) documents: Vec<DocumentIdAsObject>,
+    pub(crate) documents: Vec<DocumentInBatchError>,
 }
 
 impl_application_error!(FailedToIngestDocuments => INTERNAL_SERVER_ERROR, ERROR);

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -182,7 +182,6 @@ pub(crate) struct DocumentProperty(Value);
 
 impl DocumentProperty {
     pub(crate) fn try_from_value(
-        document_id: &DocumentId,
         property_id: &DocumentPropertyId,
         mut value: Value,
     ) -> Result<Self, InvalidDocumentProperty> {
@@ -191,7 +190,6 @@ impl DocumentProperty {
             Value::String(string) => {
                 if !is_valid_string_empty_ok(string, 2_048) {
                     return Err(InvalidDocumentProperty {
-                        document: document_id.clone(),
                         property: property_id.clone(),
                         invalid_value: value.clone(),
                         invalid_reason: InvalidDocumentPropertyReason::InvalidString,
@@ -201,7 +199,6 @@ impl DocumentProperty {
             Value::Array(array) => {
                 if array.len() > 100 {
                     return Err(InvalidDocumentProperty {
-                        document: document_id.clone(),
                         property: property_id.clone(),
                         invalid_value: value.clone(),
                         invalid_reason: InvalidDocumentPropertyReason::InvalidArray,
@@ -210,7 +207,6 @@ impl DocumentProperty {
                 for value in array {
                     let Value::String(ref mut string) = value else {
                         return Err(InvalidDocumentProperty {
-                            document: document_id.clone(),
                             property: property_id.clone(),
                             invalid_value: value.clone(),
                             invalid_reason: InvalidDocumentPropertyReason::IncompatibleType {
@@ -221,7 +217,6 @@ impl DocumentProperty {
                     trim(string);
                     if !is_valid_string(string, 2_048) {
                         return Err(InvalidDocumentProperty {
-                            document: document_id.clone(),
                             property: property_id.clone(),
                             invalid_value: value.clone(),
                             invalid_reason: InvalidDocumentPropertyReason::InvalidString,
@@ -231,7 +226,6 @@ impl DocumentProperty {
             }
             Value::Object(_) => {
                 return Err(InvalidDocumentProperty {
-                    document: document_id.clone(),
                     property: property_id.clone(),
                     invalid_value: value.clone(),
                     invalid_reason: InvalidDocumentPropertyReason::UnsupportedType,
@@ -401,11 +395,7 @@ mod tests {
         type Error = InvalidDocumentProperty;
 
         fn try_from(value: Value) -> Result<Self, Self::Error> {
-            DocumentProperty::try_from_value(
-                &"d".try_into().unwrap(),
-                &"p".try_into().unwrap(),
-                value,
-            )
+            DocumentProperty::try_from_value(&"p".try_into().unwrap(), value)
         }
     }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -273,7 +273,10 @@ impl DocumentProperties {
         max_size: usize,
     ) -> Result<Self, InvalidDocumentProperties> {
         if size > max_size {
-            return Err(InvalidDocumentProperties { size, max_size });
+            return Err(InvalidDocumentProperties::StorageSize {
+                got: size,
+                max: max_size,
+            });
         }
 
         Ok(Self(properties))

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -39,6 +39,7 @@ use crate::{
         InvalidDocumentSnippet,
         InvalidDocumentTag,
         InvalidDocumentTags,
+        InvalidString,
         InvalidUserId,
     },
     storage::property_filter::IndexedPropertyType,
@@ -52,7 +53,7 @@ fn trim(string: &mut String) {
 }
 
 macro_rules! string_wrapper {
-    ($($(#[$attribute:meta])* $visibility:vis $name:ident, $error:ident, $is_valid:expr);* $(;)?) => {
+    ($($(#[$attribute:meta])* $visibility:vis $name:ident, $error:ident, $syntax:expr, $full_range:expr);* $(;)?) => {
         $(
             $(#[$attribute])*
             #[derive(
@@ -77,12 +78,26 @@ macro_rules! string_wrapper {
                 type Error = $error;
 
                 fn try_from(mut value: String) -> Result<Self, Self::Error> {
+                    use std::ops::RangeInclusive;
+                    use $crate::error::common::InvalidString;
+
                     trim(&mut value);
 
-                    if $is_valid(&value) {
-                        Ok(Self(value))
+                    let size = value.len();
+                    let range = RangeInclusive::from($full_range);
+                    let syntax = &*$syntax;
+                    if !range.contains(&size) {
+                        Err($error(InvalidString::Size {
+                            got: size,
+                            min: *range.start(),
+                            max: *range.end(),
+                        }))
+                    } else if !syntax.is_match(&value) {
+                        Err($error(InvalidString::Syntax {
+                            expected: syntax.as_str(),
+                        }))
                     } else {
-                        Err($error { value })
+                        Ok(Self(value))
                     }
                 }
             }
@@ -110,43 +125,25 @@ macro_rules! string_wrapper {
     };
 }
 
-fn is_valid_id(value: &str) -> bool {
-    static RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-:@.][a-zA-Z0-9\-:@._]*$").unwrap());
+static GENERIC_ID_SYNTAX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-:@.][a-zA-Z0-9\-:@._]*$").unwrap());
 
-    (1..=256).contains(&value.len()) && RE.is_match(value)
-}
+static PROPERTY_ID_SYNTAX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-:@][a-zA-Z0-9\-:@_]*$").unwrap());
 
-fn is_valid_property_id(value: &str) -> bool {
-    static RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-:@][a-zA-Z0-9\-:@_]*$").unwrap());
-
-    (1..=256).contains(&value.len()) && RE.is_match(value)
-}
-
-fn is_valid_string(value: &str, len: usize) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^\x00]+$").unwrap());
-
-    (1..=len).contains(&value.len()) && RE.is_match(value)
-}
-
-fn is_valid_string_empty_ok(value: &str, len: usize) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^\x00]*$").unwrap());
-
-    (0..=len).contains(&value.len()) && RE.is_match(value)
-}
+static GENERIC_STRING_SYNTAX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^\x00]*$").unwrap());
 
 string_wrapper! {
     /// A unique document identifier.
-    pub(crate) DocumentId, InvalidDocumentId, is_valid_id;
+    pub(crate) DocumentId, InvalidDocumentId, GENERIC_ID_SYNTAX, 1..=256;
     /// A unique document property identifier.
-    pub(crate) DocumentPropertyId, InvalidDocumentPropertyId, is_valid_property_id;
+    pub(crate) DocumentPropertyId, InvalidDocumentPropertyId, PROPERTY_ID_SYNTAX, 1..=256;
     /// A unique user identifier.
-    pub(crate) UserId, InvalidUserId, is_valid_id;
+    pub(crate) UserId, InvalidUserId, GENERIC_ID_SYNTAX, 1..=256;
     /// A document tag.
-    pub(crate) DocumentTag, InvalidDocumentTag, |value| is_valid_string(value, 256);
+    pub(crate) DocumentTag, InvalidDocumentTag, GENERIC_STRING_SYNTAX, 1..=256;
     /// A document query.
-    pub(crate) DocumentQuery, InvalidDocumentQuery, |value| is_valid_string(value, 512);
+    pub(crate) DocumentQuery, InvalidDocumentQuery, GENERIC_STRING_SYNTAX, 1..=512;
 }
 
 /// A document snippet.
@@ -163,15 +160,19 @@ impl DocumentSnippet {
         let mut value = value.into();
         trim(&mut value);
 
-        if is_valid_string(&value, max_size) {
-            Ok(Self(value))
+        let size = value.len();
+        if !(1..=max_size).contains(&value.len()) {
+            Err(InvalidDocumentSnippet(InvalidString::Size {
+                got: size,
+                min: 1,
+                max: max_size,
+            }))
+        } else if !GENERIC_STRING_SYNTAX.is_match(&value) {
+            Err(InvalidDocumentSnippet(InvalidString::Syntax {
+                expected: GENERIC_STRING_SYNTAX.as_str(),
+            }))
         } else {
-            let size = value.len();
-            if size > max_size {
-                Err(InvalidDocumentSnippet::Size { size, max_size })
-            } else {
-                Err(InvalidDocumentSnippet::Value { value })
-            }
+            Ok(Self(value))
         }
     }
 }
@@ -185,16 +186,24 @@ impl DocumentProperty {
         property_id: &DocumentPropertyId,
         mut value: Value,
     ) -> Result<Self, InvalidDocumentProperty> {
+        let check_string_property_value = |s: &str| {
+            if s.len() <= 2_048 && GENERIC_STRING_SYNTAX.is_match(s) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        };
+
         match &mut value {
             Value::Bool(_) | Value::Number(_) | Value::Null => {}
             Value::String(string) => {
-                if !is_valid_string_empty_ok(string, 2_048) {
+                let Ok(()) = check_string_property_value(string) else {
                     return Err(InvalidDocumentProperty {
                         property: property_id.clone(),
-                        invalid_value: value.clone(),
+                        invalid_value: value,
                         invalid_reason: InvalidDocumentPropertyReason::InvalidString,
                     });
-                }
+                };
             }
             Value::Array(array) => {
                 if array.len() > 100 {
@@ -215,13 +224,13 @@ impl DocumentProperty {
                         });
                     };
                     trim(string);
-                    if !is_valid_string(string, 2_048) {
+                    let Ok(()) = check_string_property_value(string) else {
                         return Err(InvalidDocumentProperty {
                             property: property_id.clone(),
                             invalid_value: value.clone(),
                             invalid_reason: InvalidDocumentPropertyReason::InvalidString,
                         });
-                    }
+                    };
                 }
             }
             Value::Object(_) => {
@@ -291,10 +300,11 @@ impl TryFrom<Vec<DocumentTag>> for DocumentTags {
 
     fn try_from(tags: Vec<DocumentTag>) -> Result<Self, Self::Error> {
         let size = tags.len();
-        if size <= 10 {
+        let max = 10;
+        if size <= max {
             Ok(Self(tags))
         } else {
-            Err(InvalidDocumentTags { size })
+            Err(InvalidDocumentTags { size, max })
         }
     }
 }
@@ -401,51 +411,143 @@ mod tests {
 
     #[test]
     fn test_is_valid_id() {
-        assert!(is_valid_id("abcdefghijklmnopqrstruvwxyz"));
-        assert!(is_valid_id("ABCDEFGHIJKLMNOPQURSTUVWXYZ"));
-        assert!(is_valid_id("0123456789"));
-        assert!(is_valid_id("-_:@."));
-        assert!(!is_valid_id(""));
-        assert!(!is_valid_id("_"));
-        assert!(!is_valid_id(&["a"; 257].join("")));
-        assert!(!is_valid_id("!?ß"));
+        assert!(DocumentId::try_from("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentId::try_from("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentId::try_from("0123456789").is_ok());
+        assert!(DocumentId::try_from("-_:@.").is_ok());
+
+        assert_eq!(
+            DocumentId::try_from(""),
+            Err(InvalidDocumentId(InvalidString::Size {
+                got: 0,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentId::try_from("_"),
+            Err(InvalidDocumentId(InvalidString::Syntax {
+                expected: GENERIC_ID_SYNTAX.as_str()
+            }))
+        );
+        assert_eq!(
+            DocumentId::try_from(["a"; 257].join("")),
+            Err(InvalidDocumentId(InvalidString::Size {
+                got: 257,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentId::try_from("!?ß"),
+            Err(InvalidDocumentId(InvalidString::Syntax {
+                expected: GENERIC_ID_SYNTAX.as_str()
+            }))
+        );
     }
 
     #[test]
     fn test_is_valid_property_id() {
-        assert!(is_valid_property_id("abcdefghijklmnopqrstruvwxyz"));
-        assert!(is_valid_property_id("ABCDEFGHIJKLMNOPQURSTUVWXYZ"));
-        assert!(is_valid_property_id("0123456789"));
-        assert!(is_valid_property_id("-_:@"));
-        assert!(!is_valid_property_id(""));
-        assert!(!is_valid_property_id("_"));
-        assert!(!is_valid_property_id("."));
-        assert!(!is_valid_property_id(&["a"; 257].join("")));
-        assert!(!is_valid_property_id("!?ß"));
+        assert!(DocumentPropertyId::try_from("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentPropertyId::try_from("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentPropertyId::try_from("0123456789").is_ok());
+        assert!(DocumentPropertyId::try_from("-_:@").is_ok());
+
+        assert_eq!(
+            DocumentPropertyId::try_from(""),
+            Err(InvalidDocumentPropertyId(InvalidString::Size {
+                got: 0,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentPropertyId::try_from("_"),
+            Err(InvalidDocumentPropertyId(InvalidString::Syntax {
+                expected: PROPERTY_ID_SYNTAX.as_str()
+            }))
+        );
+        assert_eq!(
+            DocumentPropertyId::try_from("."),
+            Err(InvalidDocumentPropertyId(InvalidString::Syntax {
+                expected: PROPERTY_ID_SYNTAX.as_str()
+            }))
+        );
+        assert_eq!(
+            DocumentPropertyId::try_from(["a"; 257].join("")),
+            Err(InvalidDocumentPropertyId(InvalidString::Size {
+                got: 257,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentPropertyId::try_from("!?ß"),
+            Err(InvalidDocumentPropertyId(InvalidString::Syntax {
+                expected: PROPERTY_ID_SYNTAX.as_str()
+            }))
+        );
     }
 
     #[test]
-    fn test_is_valid_string() {
-        assert!(is_valid_string("abcdefghijklmnopqrstruvwxyz", 256));
-        assert!(is_valid_string("ABCDEFGHIJKLMNOPQURSTUVWXYZ", 256));
-        assert!(is_valid_string("0123456789", 256));
-        assert!(is_valid_string(" .:,;-_#'+*^°!\"§$%&/()=?\\´`@€", 256));
-        assert!(!is_valid_string("", 256));
-        assert!(!is_valid_string(&["a"; 257].join(""), 256));
-        assert!(!is_valid_string("\0", 256));
+    fn test_is_valid_tag() {
+        assert!(DocumentTag::try_from("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentTag::try_from("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentTag::try_from("0123456789").is_ok());
+        assert!(DocumentTag::try_from(" .:,;-_#'+*^°!\"§$%&/()=?\\´`@€").is_ok());
+
+        assert_eq!(
+            DocumentTag::try_from(""),
+            Err(InvalidDocumentTag(InvalidString::Size {
+                got: 0,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentTag::try_from(["a"; 257].join("")),
+            Err(InvalidDocumentTag(InvalidString::Size {
+                got: 257,
+                min: 1,
+                max: 256
+            }))
+        );
+        assert_eq!(
+            DocumentTag::try_from("\0"),
+            Err(InvalidDocumentTag(InvalidString::Syntax {
+                expected: GENERIC_STRING_SYNTAX.as_str()
+            }))
+        );
     }
 
     #[test]
-    fn test_is_valid_string_empty_ok() {
-        assert!(is_valid_string_empty_ok("abcdefghijklmnopqrstruvwxyz", 256));
-        assert!(is_valid_string_empty_ok("ABCDEFGHIJKLMNOPQURSTUVWXYZ", 256));
-        assert!(is_valid_string_empty_ok("0123456789", 256));
-        assert!(is_valid_string_empty_ok(
-            " .:,;-_#'+*^°!\"§$%&/()=?\\´`@€",
-            256
-        ));
-        assert!(is_valid_string_empty_ok("", 256));
-        assert!(!is_valid_string_empty_ok(&["a"; 257].join(""), 256));
-        assert!(!is_valid_string_empty_ok("\0", 256));
+    fn test_is_valid_query() {
+        assert!(DocumentQuery::try_from("abcdefghijklmnopqrstruvwxyz").is_ok());
+        assert!(DocumentQuery::try_from("ABCDEFGHIJKLMNOPQURSTUVWXYZ").is_ok());
+        assert!(DocumentQuery::try_from("0123456789").is_ok());
+        assert!(DocumentQuery::try_from(" .:,;-_#'+*^°!\"§$%&/()=?\\´`@€").is_ok());
+
+        assert_eq!(
+            DocumentQuery::try_from(""),
+            Err(InvalidDocumentQuery(InvalidString::Size {
+                got: 0,
+                min: 1,
+                max: 512,
+            }))
+        );
+        assert_eq!(
+            DocumentQuery::try_from(["a"; 513].join("")),
+            Err(InvalidDocumentQuery(InvalidString::Size {
+                got: 513,
+                min: 1,
+                max: 512,
+            }))
+        );
+        assert_eq!(
+            DocumentQuery::try_from("\0"),
+            Err(InvalidDocumentQuery(InvalidString::Syntax {
+                expected: GENERIC_STRING_SYNTAX.as_str()
+            }))
+        );
     }
 }

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -359,7 +359,6 @@ impl Filter {
         if let Some(published_after) = published_after {
             let field = "publication_date".try_into().unwrap(/* valid property id */);
             let value = DocumentProperty::try_from_value(
-                &"unused".try_into().unwrap(/* valid document id */),
                 &field,
                 json!(published_after.to_rfc3339()),
             ).unwrap(/* valid property */);

--- a/web-api/src/storage/property_filter.rs
+++ b/web-api/src/storage/property_filter.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 
 use crate::{
     error::common::{InvalidDocumentProperty, InvalidDocumentPropertyReason},
-    models::{DocumentId, DocumentProperty, DocumentPropertyId},
+    models::{DocumentProperty, DocumentPropertyId},
 };
 
 #[derive(Debug, Display, PartialEq, Error, Serialize)]
@@ -78,7 +78,6 @@ impl IndexedPropertiesSchema {
 
     pub(crate) fn validate_property(
         &self,
-        document: &DocumentId,
         property: &DocumentPropertyId,
         value: &DocumentProperty,
     ) -> Result<(), InvalidDocumentProperty> {
@@ -97,7 +96,6 @@ impl IndexedPropertiesSchema {
             | (Value::Array(_), IndexedPropertyType::KeywordArray) => Ok(()),
             (Value::String(string), IndexedPropertyType::Date) => {
                 DateTime::parse_from_rfc3339(string).map_err(|_| InvalidDocumentProperty {
-                    document: document.clone(),
                     property: property.clone(),
                     invalid_value: value.clone(),
                     invalid_reason: InvalidDocumentPropertyReason::MalformedDateTimeString,
@@ -105,7 +103,6 @@ impl IndexedPropertiesSchema {
                 Ok(())
             },
             (_, r#type) => Err(InvalidDocumentProperty {
-                document: document.clone(),
                 property: property.clone(),
                 invalid_value: value.clone(),
                 invalid_reason: InvalidDocumentPropertyReason::IncompatibleType {

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -479,7 +479,6 @@ fn test_ingestion_validation() {
             )
             .await;
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
-            // TODO[pmk/now] this isn't right
             assert_eq!(
                 error.details.unwrap(),
                 Details::Ingest(vec![json!({

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -486,8 +486,10 @@ fn test_ingestion_validation() {
                     "id": "d1",
                     "kind": "InvalidDocumentProperties",
                     "details": {
-                        "size": 27,
-                        "max_size": 10,
+                        "storage_size": {
+                            "got": 27,
+                            "max": 10,
+                        },
                     }
                 })]),
             );

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -155,7 +155,10 @@ fn test_ingestion_bad_request() {
             json!({
                 "kind": "InvalidDocumentSnippet" ,
                 "details": {
-                    "value": long_snippet
+                    "size": {
+                        "size": 2049,
+                        "max_size": 2048,
+                    }
                 }
             })
         );
@@ -417,7 +420,7 @@ fn test_ingestion_validation() {
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
             assert_eq!(
                 error.details.unwrap(),
-                Details::Ingest(json!([{ "id": "d1" }])),
+                Details::Ingest(vec![json!({ "id": "d1" })]),
             );
 
             let error = send_assert_json::<Error>(
@@ -437,7 +440,7 @@ fn test_ingestion_validation() {
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
             assert_eq!(
                 error.details.unwrap(),
-                Details::Ingest(json!([{ "id": "d1" }])),
+                Details::Ingest(vec![json!({ "id": "d1" })]),
             );
 
             let error = send_assert_json::<Error>(
@@ -457,7 +460,7 @@ fn test_ingestion_validation() {
             assert_eq!(error.kind, Kind::FailedToValidateDocuments);
             assert_eq!(
                 error.details.unwrap(),
-                Details::Ingest(json!([{ "id": "d1" }])),
+                Details::Ingest(vec![json!({ "id": "d1" })]),
             );
 
             Ok(())

--- a/web-api/tests/manage_indexed_properties.rs
+++ b/web-api/tests/manage_indexed_properties.rs
@@ -317,7 +317,6 @@ fn test_check_new_property_values_against_schema() {
                         "id": id,
                         "kind": "InvalidDocumentProperty",
                         "details": {
-                            "document": id,
                             "invalid_reason": {
                                 "IncompatibleType": {
                                     "expected": expected_type,
@@ -357,7 +356,6 @@ fn test_check_new_property_values_against_schema() {
                 assert_eq!(
                     &res["details"],
                     &json!({
-                        "document": "d1",
                         "property": property,
                         "invalid_reason": {
                             "IncompatibleType": {
@@ -400,7 +398,6 @@ fn test_check_new_property_values_against_schema() {
                 assert_eq!(
                     &res["details"],
                     &json!({
-                        "document": "d2",
                         "property": property,
                         "invalid_reason": {
                             "IncompatibleType": {


### PR DESCRIPTION

- report per-document errors for ingestion
- update errors to be more informative/less confusing
  - be more explicit about what failed (e.g. syntax vs. length limits)
  - be more explicit about where it failed (e.g. which property)
  - make some errors more clear (e.g. `InvalidDocumentProperties`)
  - be clear about what is expected (wrt. the failure)
  - same uniform error for all "string" validation types
  - do nolonger contain the malformed value (both returned and logged)
    - because the malformed value could e.g. be a 2MiB DocumentId with null bytes and ascii controll codes, nothing we ever want to log
    - through for this point I need some feedback, maybe we should still include it in some normalized and cut/shortened form :thinking:  

**References:**

- issue: [ET-4799]

[ET-4799]: https://xainag.atlassian.net/browse/ET-4799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ