### PR TITLE
ET-4859 remove unavailable es rrf dev option

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -156,8 +156,6 @@ impl_application_error!(InvalidDocumentCount => BAD_REQUEST, INFO);
 pub(crate) enum ForbiddenDevOption {
     /// Dev options are not enabled for this tentant
     DevDisabled,
-    /// ES RRF is not enabled because of the license
-    EsRrfUnlicensed,
 }
 
 impl_application_error!(ForbiddenDevOption => FORBIDDEN, INFO);

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -435,10 +435,6 @@ impl DevOption {
             // notify the caller instead of silently discarding the dev option
             return Err(ForbiddenDevOption::DevDisabled.into());
         }
-        if let Some(DevHybrid::EsRrf { .. }) = self.hybrid {
-            // not available because of the es license, return a 403 instead of forwarding a 500
-            return Err(ForbiddenDevOption::EsRrfUnlicensed.into());
-        }
 
         Ok(())
     }
@@ -447,10 +443,6 @@ impl DevOption {
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum DevHybrid {
-    EsRrf {
-        #[serde(default)]
-        rank_constant: Option<u32>,
-    },
     Customize {
         normalize_knn: NormalizationFn,
         normalize_bm25: NormalizationFn,
@@ -475,10 +467,6 @@ impl<'a> SearchStrategy<'a> {
         };
 
         match dev_hybrid_search {
-            DevHybrid::EsRrf { rank_constant } => Self::HybridEsRrf {
-                query,
-                rank_constant,
-            },
             DevHybrid::Customize {
                 normalize_knn,
                 normalize_bm25,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -72,10 +72,6 @@ pub(crate) enum SearchStrategy<'a> {
         /// An additional query which will be run in parallel with the KNN search.
         query: &'a DocumentQuery,
     },
-    HybridEsRrf {
-        query: &'a DocumentQuery,
-        rank_constant: Option<u32>,
-    },
     HybridDev {
         query: &'a DocumentQuery,
         normalize_knn: NormalizationFn,

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -281,38 +281,6 @@ fn test_semantic_search_with_dev_option_hybrid() {
 }
 
 #[test]
-fn test_semantic_search_with_dev_option_hybrid_es_rrf() {
-    test_two_apps::<Ingestion, Personalization, _>(
-        UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
-        |client, ingestion_url, personalization_url, _| async move {
-            ingest(&client, &ingestion_url).await?;
-
-            send_assert(
-                &client,
-                client
-                    .post(personalization_url.join("/semantic_search")?)
-                    .json(&json!({
-                        "document": { "query": "this is one sentence" },
-                        "enable_hybrid_search": true,
-                        "_dev": { "hybrid": { "es_rrf": {} } }
-                    }))
-                    .build()?,
-                // current license is non-compliant for Reciprocal Rank Fusion (RRF)
-                StatusCode::FORBIDDEN,
-                false,
-            )
-            .await;
-
-            Ok(())
-        },
-    );
-}
-
-#[test]
 fn test_semantic_search_with_dev_option_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,


### PR DESCRIPTION
**Reference**

- [ET-4859]

**Summary**

- remove the unavailable `DevHybrid::EsRrf` dev option and related dead code


[ET-4859]: https://xainag.atlassian.net/browse/ET-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ