### PR TITLE
ET-4883 rescale es knn score

### DIFF
--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.0 - 2023-07-31
+
+- Generalize scores in search results
+
 # 2.4.1 - 2023-07-31
 
 - Clarify requirements for filters regarding the indexed document properties

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Back Office API
-  version: 2.4.1
+  version: 2.5.0
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -58,7 +58,7 @@ paths:
       summary: Personalize documents for the user
       description: |-
         Get a list of documents personalized for the given `user_id`.
-        Each document contains the id and the score, where a higher value means that the document matches the preferences of the user better.
+        Each document contains the id and the score, where a higher value means that the document matches the preferences of the user better. Scores can be compared only with other scores that belong to the same request; comparing scores of documents that have been obtained through different requests can lead to unexpected results.
         The documents also contain their properties if this is requested and the properties are not empty.
         Documents that have been interacted with by the user are filtered out from the result.
         Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -178,7 +178,7 @@ paths:
         When a `query` is provided, the system will return documents that are similar to the query.
         If `enable_hybrid_search` is passed, then the system will also perform keyword matching between the query and the documents.
         It is possible to personalize the result by passing a user id or history. In this case, the system will consider the user's interests to rank the documents.
-        Each document contains the `id` and the `score`, where a higher value means that the document is more similar to the input.
+        Each document contains the `id` and the `score`, where a higher value means that the document is more similar to the input. Scores can be compared only with other scores that belong to the same request; comparing scores of documents that have been obtained through different requests can lead to unexpected results.
         The documents also contain their `properties` if this is requested and the properties are not empty.
       operationId: getSimilarDocuments
       requestBody:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Front Office API
-  version: 2.4.1
+  version: 2.5.0
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.
@@ -58,7 +58,7 @@ paths:
       summary: Personalize documents for the user
       description: |-
         Get a list of documents personalized for the given `user_id`.
-        Each document contains the id and the score, which is a value between 0 and 1 where a higher value means that the document matches the preferences of the user better.
+        Each document contains the id and the score, where a higher value means that the document matches the preferences of the user better.
         The documents also contain their properties if this is requested and the properties are not empty.
         Documents that have been interacted with by the user are filtered out from the result.
         Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.
@@ -178,7 +178,7 @@ paths:
         When a `query` is provided, the system will return documents that are similar to the query.
         If `enable_hybrid_search` is passed, then the system will also perform keyword matching between the query and the documents.
         It is possible to personalize the result by passing a user id or history. In this case, the system will consider the user's interests to rank the documents.
-        Each document contains the `id` and the `score`, which is a value between 0 and 1 where a higher value means that the document is more similar to the input.
+        Each document contains the `id` and the `score`, where a higher value means that the document is more similar to the input.
         The documents also contain their `properties` if this is requested and the properties are not empty.
       operationId: getSimilarDocuments
       requestBody:
@@ -303,7 +303,7 @@ components:
         id:
           $ref: './schemas/document.yml#/DocumentId'
         score:
-          description: A number in the interval `[0, 1]` where higher means better.
+          description: A number where higher means better.
           type: number
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -362,6 +362,7 @@ pub(crate) async fn personalize_documents_by(
 
     let tag_weights = storage::Tag::get(storage, user_id).await?;
 
+    normalize_knn_scores(&mut documents);
     rerank_by_scores(
         coi_system,
         &mut documents,
@@ -684,6 +685,9 @@ async fn semantic_search(
     .await?;
 
     if let Some(personalize) = personalize {
+        if matches!(strategy, SearchStrategy::Knn) {
+            normalize_knn_scores(&mut documents);
+        }
         personalize_knn_search_result(
             &storage,
             &state.config,
@@ -757,4 +761,11 @@ async fn personalize_knn_search_result(
     }
 
     Ok(())
+}
+
+/// Normalize knn similarity scores for `rerank_by_scores()`.
+fn normalize_knn_scores(documents: &mut [PersonalizedDocument]) {
+    for document in documents {
+        document.score = (document.score + 1.) / 2.;
+    }
 }

--- a/web-api/tests/personalized_documents.rs
+++ b/web-api/tests/personalized_documents.rs
@@ -124,7 +124,7 @@ macro_rules! assert_order {
             let [d1, d2] = documents else { unreachable!() };
             assert!(1. >= d1.score, $($arg)*);
             assert!(d1.score > d2.score, $($arg)*);
-            assert!(d2.score >= 0., $($arg)*);
+            assert!(d2.score >= -1., $($arg)*);
         }
     }};
 }

--- a/web-api/tests/personalized_semantic_search.rs
+++ b/web-api/tests/personalized_semantic_search.rs
@@ -86,7 +86,7 @@ macro_rules! assert_order {
             let [d1, d2] = documents else { unreachable!() };
             assert!(1. >= d1.score, $($arg)*);
             assert!(d1.score > d2.score, $($arg)*);
-            assert!(d2.score >= 0., $($arg)*);
+            assert!(d2.score >= -1., $($arg)*);
         }
     };
 }

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -69,7 +69,7 @@ macro_rules! assert_order {
             let [d1, d2] = documents else { unreachable!() };
             assert!(1. >= d1.score, $($arg)*);
             assert!(d1.score > d2.score, $($arg)*);
-            assert!(d2.score >= 0., $($arg)*);
+            assert!(d2.score >= -1., $($arg)*);
         }
     };
 }


### PR DESCRIPTION
**Reference**

- [ET-4883]
- followed by #1047

**Summary**

- rescale es knn scores back to similarity scores
- use `ScoreMap` type alias consistently
- normalize es knn scores in cases where we use reranking with interest & tag scores, until we change how we combine the three scores we need to normalize them again
- update docs for scores


[ET-4883]: https://xainag.atlassian.net/browse/ET-4883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ