### PR TITLE
ET-4918 dev.include_snippet [1/n]

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -608,6 +608,13 @@ fn build_client(services: &Services) -> Arc<Client> {
 
 pub const UNCHANGED_CONFIG: Option<Table> = None;
 
+pub fn with_dev_options() -> Option<Table> {
+    Some(toml! {
+        [tenants]
+        enable_dev = true
+    })
+}
+
 pub fn extend_config(current: &mut Table, extension: Table) {
     for (key, value) in extension {
         if let Some(current) = current.get_mut(&key) {

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -25,7 +25,7 @@ use xayn_test_utils::error::Panic;
 use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
-    models::{DocumentId, DocumentProperties, DocumentSnippet, IngestedDocument, UserId},
+    models::{DocumentId, DocumentProperties, IngestedDocument, UserId},
     personalization::{
         routes::{personalize_documents_by, update_interactions, PersonalizeBy},
         PersonalizationConfig,
@@ -96,21 +96,21 @@ impl State {
             &self.storage,
             embeddings.iter().map(|(id, _)| id),
             true,
+            true,
         )
         .await?
         .into_iter()
         .map(|document| (document.id.clone(), document))
         .collect::<HashMap<_, _>>();
-        let snippet = DocumentSnippet::new("snippet" /* unused for in-memory db */, 100)?;
         let documents = embeddings
             .into_iter()
             .map(|(id, embedding)| {
                 let document = documents.remove(&id).unwrap(/* document must already exist */);
                 IngestedDocument {
                     id,
-                    snippet: snippet.clone(),
+                    snippet: document.snippet.unwrap(/* we fetch it*/),
                     is_summarized: false,
-                    properties: document.properties,
+                    properties: document.properties.unwrap(/* we fetch it*/),
                     tags: document.tags,
                     embedding,
                     is_candidate: true,
@@ -155,6 +155,7 @@ impl State {
             &self.personalization,
             by,
             time,
+            false,
             false,
         )
         .await

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -344,8 +344,15 @@ pub(crate) struct PersonalizedDocument {
     /// Embedding from smbert.
     pub(crate) embedding: NormalizedEmbedding,
 
-    /// Contents of the document properties.
-    pub(crate) properties: DocumentProperties,
+    /// User-defined document properties.
+    ///
+    /// Depending on the context the properties might not be loaded from the db.
+    pub(crate) properties: Option<DocumentProperties>,
+
+    /// Snippet of the document.
+    ///
+    /// Depending on the context the snippet might not be loaded from the db.
+    pub(crate) snippet: Option<DocumentSnippet>,
 
     /// The tags associated to the document.
     pub(crate) tags: DocumentTags,

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -38,6 +38,7 @@ pub(super) struct CoiSearch<'a, I> {
     pub(super) num_candidates: usize,
     pub(super) time: DateTime<Utc>,
     pub(super) include_properties: bool,
+    pub(super) include_snippet: bool,
     pub(super) filter: Option<&'a Filter>,
 }
 
@@ -77,6 +78,7 @@ where
                         num_candidates,
                         strategy: SearchStrategy::Knn,
                         include_properties: self.include_properties,
+                        include_snippet: self.include_snippet,
                         filter: self.filter,
                     },
                 )
@@ -155,6 +157,7 @@ mod tests {
             num_candidates: 10,
             time: Utc::now(),
             include_properties: false,
+            include_snippet: false,
             filter: None,
         }
         .run_on(&storage)

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -20,7 +20,7 @@ use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiSystem};
 
 use crate::{
-    models::{DocumentId, DocumentProperties, DocumentTag, PersonalizedDocument},
+    models::{DocumentId, DocumentTag, PersonalizedDocument},
     personalization::PersonalizationConfig,
 };
 
@@ -124,7 +124,8 @@ pub fn bench_rerank<S>(
             id: id.to_string().try_into().unwrap(),
             score: 1.,
             embedding,
-            properties: DocumentProperties::default(),
+            properties: None,
+            snippet: None,
             tags: tags
                 .into_iter()
                 .map(|tag| tag.try_into().unwrap())
@@ -182,7 +183,8 @@ mod tests {
                     id,
                     score: 1.,
                     embedding,
-                    properties: DocumentProperties::default(),
+                    properties: None,
+                    snippet: None,
                     tags,
                 }
             })

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -12,8 +12,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-
 use actix_web::{
     http::StatusCode,
     web::{self, Data, Json, Path, Query, ServiceConfig},
@@ -49,7 +47,14 @@ use crate::{
         common::{BadRequest, DocumentNotFound, ForbiddenDevOption, InvalidDocumentCount},
         warning::Warning,
     },
-    models::{DocumentId, DocumentProperties, DocumentQuery, PersonalizedDocument, UserId},
+    models::{
+        DocumentId,
+        DocumentProperties,
+        DocumentQuery,
+        DocumentSnippet,
+        PersonalizedDocument,
+        UserId,
+    },
     storage::{self, KnnSearchParams, MergeFn, NormalizationFn, SearchStrategy},
     tenants,
     utils::deprecate,
@@ -252,6 +257,7 @@ async fn personalized_documents(
         },
         Utc::now(),
         include_properties,
+        false,
     )
     .await?
     {
@@ -274,8 +280,10 @@ async fn personalized_documents(
 struct PersonalizedDocumentData {
     id: DocumentId,
     score: f32,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    properties: DocumentProperties,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<DocumentProperties>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snippet: Option<DocumentSnippet>,
 }
 
 impl From<PersonalizedDocument> for PersonalizedDocumentData {
@@ -284,6 +292,7 @@ impl From<PersonalizedDocument> for PersonalizedDocumentData {
             id: document.id,
             score: document.score,
             properties: document.properties,
+            snippet: document.snippet,
         }
     }
 }
@@ -310,6 +319,7 @@ pub(crate) enum PersonalizeBy<'a> {
     Documents(&'a [&'a DocumentId]),
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn personalize_documents_by(
     storage: &(impl storage::Document + storage::Interaction + storage::Interest + storage::Tag),
     coi_system: &CoiSystem,
@@ -318,6 +328,7 @@ pub(crate) async fn personalize_documents_by(
     by: PersonalizeBy<'_>,
     time: DateTime<Utc>,
     include_properties: bool,
+    include_snippet: bool,
 ) -> Result<Option<Vec<PersonalizedDocument>>, Error> {
     storage::Interaction::user_seen(storage, user_id, time).await?;
 
@@ -344,6 +355,7 @@ pub(crate) async fn personalize_documents_by(
                 num_candidates: personalization.max_number_candidates,
                 time,
                 include_properties,
+                include_snippet,
                 filter,
             }
             .run_on(storage)
@@ -355,6 +367,7 @@ pub(crate) async fn personalize_documents_by(
                 storage,
                 documents.iter().copied(),
                 include_properties,
+                include_snippet,
             )
             .await?
         }
@@ -434,11 +447,16 @@ struct UnvalidatedSemanticSearchRequest {
 struct DevOption {
     hybrid: Option<DevHybrid>,
     max_number_candidates: Option<usize>,
+    include_snippet: Option<bool>,
 }
 
 impl DevOption {
     fn validate(&self, enable_dev: bool) -> Result<(), Error> {
-        if !enable_dev && (self.hybrid.is_some() || self.max_number_candidates.is_some()) {
+        if !enable_dev
+            && (self.hybrid.is_some()
+                || self.max_number_candidates.is_some()
+                || self.include_snippet.is_some())
+        {
             // notify the caller instead of silently discarding the dev option
             return Err(ForbiddenDevOption::DevDisabled.into());
         }
@@ -539,6 +557,7 @@ impl UnvalidatedSemanticSearchRequest {
             enable_hybrid_search,
             dev_hybrid_search,
             include_properties,
+            include_snippet: dev.include_snippet.unwrap_or_default(),
             filter,
             is_deprecated,
         })
@@ -591,6 +610,8 @@ impl UnvalidatedPersonalize {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::struct_excessive_bools)]
 struct SemanticSearchRequest {
     document: InputDocument,
     count: usize,
@@ -599,6 +620,7 @@ struct SemanticSearchRequest {
     enable_hybrid_search: bool,
     dev_hybrid_search: Option<DevHybrid>,
     include_properties: bool,
+    include_snippet: bool,
     filter: Option<Filter>,
     is_deprecated: bool,
 }
@@ -644,6 +666,7 @@ async fn semantic_search(
         enable_hybrid_search,
         dev_hybrid_search,
         include_properties,
+        include_snippet,
         filter,
         is_deprecated,
     } = body
@@ -679,6 +702,7 @@ async fn semantic_search(
             num_candidates,
             strategy,
             include_properties,
+            include_snippet,
             filter: filter.as_ref(),
         },
     )

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -280,10 +280,16 @@ async fn personalized_documents(
 struct PersonalizedDocumentData {
     id: DocumentId,
     score: f32,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "no_properties")]
     properties: Option<DocumentProperties>,
     #[serde(skip_serializing_if = "Option::is_none")]
     snippet: Option<DocumentSnippet>,
+}
+
+fn no_properties(properties: &Option<DocumentProperties>) -> bool {
+    properties
+        .as_ref()
+        .map_or(true, |properties| properties.is_empty())
 }
 
 impl From<PersonalizedDocument> for PersonalizedDocumentData {

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -62,6 +62,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(crate) num_candidates: usize,
     pub(super) strategy: SearchStrategy<'a>,
     pub(super) include_properties: bool,
+    pub(super) include_snippet: bool,
     pub(super) filter: Option<&'a Filter>,
 }
 
@@ -143,6 +144,7 @@ pub(crate) trait Document {
         &self,
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
         include_properties: bool,
+        include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error>;
 
     async fn get_excerpted(

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -260,6 +260,7 @@ impl storage::Document for Storage {
         &self,
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
         include_properties: bool,
+        include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
         let documents = self.documents.read().await;
         let documents = ids
@@ -274,9 +275,8 @@ impl storage::Document for Storage {
                             id: id.clone(),
                             score: 1.,
                             embedding: embedding.clone(),
-                            properties: include_properties
-                                .then(|| document.properties.clone())
-                                .unwrap_or_default(),
+                            properties: include_properties.then(|| document.properties.clone()),
+                            snippet: include_snippet.then(|| document.snippet.clone()),
                             tags: document.tags.clone(),
                         })
                 })
@@ -338,7 +338,10 @@ impl storage::Document for Storage {
                         id: id.clone(),
                         score: item.distance,
                         embedding: item.point.as_ref().clone(),
-                        properties: document.properties.clone(),
+                        properties: params
+                            .include_properties
+                            .then(|| document.properties.clone()),
+                        snippet: params.include_snippet.then(|| document.snippet.clone()),
                         tags: document.tags.clone(),
                     })
                 }
@@ -745,6 +748,7 @@ mod tests {
                 num_candidates: 2,
                 strategy: SearchStrategy::Knn,
                 include_properties: false,
+                include_snippet: false,
                 filter: None,
             },
         )
@@ -764,6 +768,7 @@ mod tests {
                 num_candidates: 3,
                 strategy: SearchStrategy::Knn,
                 include_properties: false,
+                include_snippet: false,
                 filter: None,
             },
         )
@@ -824,13 +829,17 @@ mod tests {
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].id, doc_id);
         assert_eq!(documents[0].snippet, snippet);
-        let documents = storage::Document::get_personalized(&storage, [&doc_id], true)
+        let documents = storage::Document::get_personalized(&storage, [&doc_id], true, true)
             .await
             .unwrap();
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].id, doc_id);
         assert_approx_eq!(f32, documents[0].embedding, embedding);
-        assert!(documents[0].properties.is_empty());
+        assert!(documents[0].properties.as_ref().unwrap().is_empty());
+        assert_eq!(
+            documents[0].snippet.as_ref().map(|s| s.as_str()),
+            Some("snippet")
+        );
         assert_eq!(documents[0].tags, tags);
         assert_eq!(
             storage::Tag::get(&storage, &user_id).await.unwrap(),

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -18,7 +18,13 @@ use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
 use toml::toml;
-use xayn_integration_tests::{send_assert, send_assert_json, test_two_apps, UNCHANGED_CONFIG};
+use xayn_integration_tests::{
+    send_assert,
+    send_assert_json,
+    test_two_apps,
+    with_dev_options,
+    UNCHANGED_CONFIG,
+};
 use xayn_web_api::{Ingestion, Personalization};
 
 async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
@@ -195,10 +201,7 @@ fn test_semantic_search_with_query() {
 fn test_semantic_search_with_dev_option_hybrid() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 
@@ -309,10 +312,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
 fn test_semantic_search_with_dev_option_candidates() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 
@@ -381,10 +381,7 @@ fn test_semantic_search_with_dev_option_candidates() {
 fn test_semantic_search_with_snippets() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        Some(toml! {
-            [tenants]
-            enable_dev = true
-        }),
+        with_dev_options(),
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -17,7 +17,6 @@ use itertools::Itertools;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
-use toml::toml;
 use xayn_integration_tests::{
     send_assert,
     send_assert_json,

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -118,7 +118,7 @@ fn test_semantic_search() {
                 ["d3", "d2"],
                 "unexpected documents: {documents:?}",
             );
-            assert_eq!(documents[0].properties, Some(json!({})));
+            assert_eq!(documents[0].properties, None);
             assert_eq!(documents[1].properties, Some(json!({ "dodo": 4 })));
 
             Ok(())
@@ -164,8 +164,8 @@ fn test_semantic_search_with_query() {
                 ["d1", "d3", "d2"],
                 "unexpected documents: {documents:?}",
             );
-            assert_eq!(documents[0].properties, Some(json!({})));
-            assert_eq!(documents[1].properties, Some(json!({})));
+            assert_eq!(documents[0].properties, None);
+            assert_eq!(documents[1].properties, None);
             assert_eq!(documents[2].properties, Some(json!({ "dodo": 4 })));
 
             let SemanticSearchResponse { documents } = send_assert_json(
@@ -377,7 +377,7 @@ fn test_semantic_search_with_dev_option_candidates() {
 }
 
 #[test]
-fn test_semantic_search_with_snippets() {
+fn test_semantic_search_with_dev_option_snippet() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
         with_dev_options(),

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -47,7 +47,9 @@ struct PersonalizedDocumentData {
     id: String,
     score: f32,
     #[serde(default)]
-    properties: serde_json::Value,
+    properties: Option<serde_json::Value>,
+    #[serde(default)]
+    snippet: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -111,8 +113,8 @@ fn test_semantic_search() {
                 ["d3", "d2"],
                 "unexpected documents: {documents:?}",
             );
-            assert!(documents[0].properties.is_null());
-            assert_eq!(documents[1].properties, json!({ "dodo": 4 }));
+            assert_eq!(documents[0].properties, Some(json!({})));
+            assert_eq!(documents[1].properties, Some(json!({ "dodo": 4 })));
 
             Ok(())
         },
@@ -157,9 +159,32 @@ fn test_semantic_search_with_query() {
                 ["d1", "d3", "d2"],
                 "unexpected documents: {documents:?}",
             );
-            assert!(documents[0].properties.is_null());
-            assert!(documents[1].properties.is_null());
-            assert_eq!(documents[2].properties, json!({ "dodo": 4 }));
+            assert_eq!(documents[0].properties, Some(json!({})));
+            assert_eq!(documents[1].properties, Some(json!({})));
+            assert_eq!(documents[2].properties, Some(json!({ "dodo": 4 })));
+
+            let SemanticSearchResponse { documents } = send_assert_json(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "this is one sentence" },
+                        "enable_hybrid_search": true,
+                        "include_properties": false
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+            assert_order!(
+                documents,
+                ["d1", "d3", "d2"],
+                "unexpected documents: {documents:?}",
+            );
+            assert!(documents[0].properties.is_none());
+            assert!(documents[1].properties.is_none());
+            assert!(documents[2].properties.is_none());
 
             Ok(())
         },
@@ -346,6 +371,52 @@ fn test_semantic_search_with_dev_option_candidates() {
                 ["d1", "d3", "d2"],
                 "unexpected documents: {documents:?}",
             );
+
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_semantic_search_with_snippets() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        Some(toml! {
+            [tenants]
+            enable_dev = true
+        }),
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest(&client, &ingestion_url).await?;
+
+            let SemanticSearchResponse { documents } = send_assert_json(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": { "query": "this is one sentence" },
+                        "count": 3,
+                        "_dev": { "include_snippet": true }
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            assert_order!(
+                documents,
+                ["d1", "d3", "d2"],
+                "unexpected documents: {documents:?}",
+            );
+            assert_eq!(
+                documents[0].snippet.as_deref(),
+                Some("this is one sentence which we have")
+            );
+            assert_eq!(
+                documents[1].snippet.as_deref(),
+                Some("this is another sentence which we have")
+            );
+            assert_eq!(documents[2].snippet.as_deref(), Some("duck duck quack"));
 
             Ok(())
         },


### PR DESCRIPTION
Needed for testing, previously we had dev.include_splits.

This implements most of [ET-4678] but is not quite the same, mainly it's a dev options so it doesn't yet need to lock itself into a specific format. For [ET-4678] we also need to consider the difference between raw document splits and snippets and maybe we want to compact `include_FIELD` into something like `include: Includes(HashSet<OptionalField>)` or similar.

**References:**

- issue: [ET-4756]
- story: [ET-4755]
- related: [ET-4678]

[ET-4678]: https://xainag.atlassian.net/browse/ET-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4678]: https://xainag.atlassian.net/browse/ET-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4756]: https://xainag.atlassian.net/browse/ET-4756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4755]: https://xainag.atlassian.net/browse/ET-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4678]: https://xainag.atlassian.net/browse/ET-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ