### PR TITLE
Make maximum size of a string property configurable

### DIFF
--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -74,6 +74,7 @@ pub struct IngestionConfig {
     pub(crate) index_update: IndexUpdateConfig,
     pub(crate) max_snippet_size: usize,
     pub(crate) max_properties_size: usize,
+    pub(crate) max_properties_string_size: usize,
 }
 
 impl Default for IngestionConfig {
@@ -85,6 +86,7 @@ impl Default for IngestionConfig {
             index_update: IndexUpdateConfig::default(),
             max_snippet_size: 2_048,
             max_properties_size: 2_560,
+            max_properties_string_size: 2_048,
         }
     }
 }

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -184,7 +184,8 @@ async fn validate_document_properties(
         .into_iter()
         .map(|(property_id, property)| {
             let property_id = DocumentPropertyId::try_from(property_id)?;
-            let property = DocumentProperty::try_from_value(&property_id, property, max_property_string_size)?;
+            let property =
+                DocumentProperty::try_from_value(&property_id, property, max_property_string_size)?;
             Ok((property_id, property))
         })
         .try_collect::<_, HashMap<_, _>, Error>()?;
@@ -218,9 +219,13 @@ impl UnvalidatedIngestedDocument {
             )
         });
 
-        let properties =
-            validate_document_properties(self.properties, storage, config.max_properties_size, config.max_properties_string_size)
-                .await?;
+        let properties = validate_document_properties(
+            self.properties,
+            storage,
+            config.max_properties_size,
+            config.max_properties_string_size,
+        )
+        .await?;
         let tags = self
             .tags
             .into_iter()
@@ -614,7 +619,11 @@ async fn put_document_property(
     let (document_id, property_id) = ids.into_inner();
     let document_id = document_id.try_into()?;
     let property_id = DocumentPropertyId::try_from(property_id)?;
-    let property = DocumentProperty::try_from_value(&property_id, body.property, state.config.ingestion.max_properties_string_size)?;
+    let property = DocumentProperty::try_from_value(
+        &property_id,
+        body.property,
+        state.config.ingestion.max_properties_string_size,
+    )?;
 
     let properties = storage::DocumentProperties::get(&storage, &document_id)
         .await?

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -182,10 +182,15 @@ impl DocumentProperty {
     pub(crate) fn try_from_value(
         property_id: &DocumentPropertyId,
         mut value: Value,
-        max_properties_string_size: usize
+        max_properties_string_size: usize,
     ) -> Result<Self, InvalidDocumentProperty> {
-        let validate_string =
-            |value: &str| validate_string(value, 0..=(max_properties_string_size), &GENERIC_STRING_SYNTAX);
+        let validate_string = |value: &str| {
+            validate_string(
+                value,
+                0..=(max_properties_string_size),
+                &GENERIC_STRING_SYNTAX,
+            )
+        };
 
         match &mut value {
             Value::Bool(_) | Value::Number(_) | Value::Null => {}
@@ -401,7 +406,7 @@ mod tests {
         type Error = InvalidDocumentProperty;
 
         fn try_from(value: Value) -> Result<Self, Self::Error> {
-            DocumentProperty::try_from_value(&"p".try_into().unwrap(), value)
+            DocumentProperty::try_from_value(&"p".try_into().unwrap(), value, 128)
         }
     }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -187,7 +187,7 @@ impl DocumentProperty {
         let validate_string = |value: &str| {
             validate_string(
                 value,
-                0..=(max_properties_string_size),
+                0..=max_properties_string_size,
                 &GENERIC_STRING_SYNTAX,
             )
         };

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -182,9 +182,10 @@ impl DocumentProperty {
     pub(crate) fn try_from_value(
         property_id: &DocumentPropertyId,
         mut value: Value,
+        max_properties_string_size: usize
     ) -> Result<Self, InvalidDocumentProperty> {
         let validate_string =
-            |value: &str| validate_string(value, 0..=2_048, &GENERIC_STRING_SYNTAX);
+            |value: &str| validate_string(value, 0..=(max_properties_string_size), &GENERIC_STRING_SYNTAX);
 
         match &mut value {
             Value::Bool(_) | Value::Number(_) | Value::Null => {}

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -362,9 +362,11 @@ impl Filter {
     ) -> Option<Self> {
         if let Some(published_after) = published_after {
             let field = "publication_date".try_into().unwrap(/* valid property id */);
+            let date = published_after.to_rfc3339();
             let value = DocumentProperty::try_from_value(
                 &field,
-                json!(published_after.to_rfc3339()),
+                json!(date),
+                date.len()
             ).unwrap(/* valid property */);
             let published_after = Self::Compare(Compare {
                 operation: CompareOp::Gte,

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -47,7 +47,8 @@ stdout = """
       "method": "background"
     },
     "max_snippet_size": 2048,
-    "max_properties_size": 2560
+    "max_properties_size": 2560,
+    "max_properties_string_size": 2048
   },
   "embedding": {
     "directory": "assets",


### PR DESCRIPTION
Allow to configure the maximum size of a string property.
This will need some refactoring to group all these options together and remove all the remaining hardcoded values.