### PR TITLE
ET-4921  SnippetId in interface [4/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,6 +4715,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "futures-retry-policies",
+ "itertools 0.10.5",
  "once_cell",
  "rand",
  "regex",

--- a/coi/src/document.rs
+++ b/coi/src/document.rs
@@ -16,7 +16,7 @@ use xayn_ai_bert::NormalizedEmbedding;
 
 /// Common document properties.
 pub trait Document {
-    type Id: std::fmt::Display + std::fmt::Debug + Eq + std::hash::Hash + Clone;
+    type Id: std::fmt::Debug + Eq + std::hash::Hash + Clone;
 
     /// Gets the document id.
     fn id(&self) -> &Self::Id;

--- a/web-api-shared/Cargo.toml
+++ b/web-api-shared/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1.4.0"
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 futures-retry-policies = { version = "0.2.3", features = [ "tokio" ] }
+itertools = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -444,14 +444,12 @@ impl Client {
             )
             .await?;
 
-        let scores = response
+        response
             .hits
             .hits
             .into_iter()
             .map(|hit| Ok((parse_id(hit.id)?, hit.score)))
-            .try_collect::<_, _, E>()?;
-
-        Ok(scores)
+            .try_collect()
     }
 
     pub async fn query_with_bytes<T>(

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -420,7 +420,7 @@ impl Client {
             .await
     }
 
-    pub async fn search_request<I, E, F>(
+    pub async fn search_request<F, I, E>(
         &self,
         mut body: JsonObject,
         parse_id: F,

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -81,6 +81,14 @@ pub(crate) struct InvalidDocumentPropertyId(pub(crate) InvalidString);
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST, INFO);
 
+/// Invalid ES snippet id: {id}
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct InvalidEsSnippetIdFormat {
+    pub(crate) id: String,
+}
+
+impl_application_error!(InvalidEsSnippetIdFormat => INTERNAL_SERVER_ERROR, ERROR);
+
 /// Malformed document property {property_id}, {invalid_reason}: {invalid_value}
 #[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -22,7 +22,14 @@ use xayn_test_utils::error::Panic;
 use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
-    models::{DocumentId, DocumentProperties, IngestedDocument, PreprocessingStep, UserId},
+    models::{
+        DocumentId,
+        DocumentProperties,
+        IngestedDocument,
+        PreprocessingStep,
+        SnippetOrDocumentId,
+        UserId,
+    },
     personalization::{
         routes::{personalize_documents_by, update_interactions, PersonalizeBy},
         PersonalizationConfig,
@@ -87,14 +94,14 @@ impl State {
     pub(super) async fn interact(
         &self,
         user: &UserId,
-        documents: impl IntoIterator<Item = (&DocumentId, DateTime<Utc>)>,
+        documents: impl IntoIterator<Item = (SnippetOrDocumentId, DateTime<Utc>)>,
     ) -> Result<(), Panic> {
         for (id, time) in documents {
             update_interactions(
                 &self.storage,
                 &self.coi,
                 user,
-                [id],
+                vec![id],
                 self.personalization.store_user_history,
                 time,
             )

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -172,14 +172,14 @@ string_wrapper! {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub(crate) struct SnippetId {
     document_id: DocumentId,
-    snippet_idx: usize,
+    sub_id: usize,
 }
 
 impl SnippetId {
-    pub(crate) fn new(document_id: DocumentId, snippet_idx: usize) -> Self {
+    pub(crate) fn new(document_id: DocumentId, sub_id: usize) -> Self {
         Self {
             document_id,
-            snippet_idx,
+            sub_id,
         }
     }
 
@@ -192,8 +192,8 @@ impl SnippetId {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn snippet_idx(&self) -> usize {
-        self.snippet_idx
+    pub(crate) fn sub_id(&self) -> usize {
+        self.sub_id
     }
 
     const ES_SNIPPET_ID_PREFIX: &str = "_s.";
@@ -201,16 +201,16 @@ impl SnippetId {
     pub(crate) fn try_from_es_id(es_id: impl AsRef<str>) -> Result<Self, Error> {
         let es_id = es_id.as_ref();
         if let Some(suffix) = es_id.strip_prefix(Self::ES_SNIPPET_ID_PREFIX) {
-            let Some((snippet_idx, document_id)) = suffix.split_once('.') else {
+            let Some((sub_id, document_id)) = suffix.split_once('.') else {
                 return Err(InvalidEsSnippetIdFormat { id: es_id.into() }.into());
             };
-            let Ok(snippet_idx) = snippet_idx.parse() else {
+            let Ok(sub_id) = sub_id.parse() else {
                 return Err(InvalidEsSnippetIdFormat { id: es_id.into() }.into());
             };
             let Ok(document_id) = document_id.parse() else {
                 return Err(InvalidEsSnippetIdFormat { id: es_id.into() }.into());
             };
-            Ok(Self::new(document_id, snippet_idx))
+            Ok(Self::new(document_id, sub_id))
         } else {
             let Ok(document_id) = es_id.parse() else {
                 return Err(InvalidEsSnippetIdFormat { id: es_id.into() }.into());
@@ -220,13 +220,13 @@ impl SnippetId {
     }
 
     pub(crate) fn to_es_id(&self) -> Cow<'_, str> {
-        if self.snippet_idx == 0 {
+        if self.sub_id == 0 {
             Cow::Borrowed(&self.document_id)
         } else {
             Cow::Owned(format!(
                 "{}{}.{}",
                 Self::ES_SNIPPET_ID_PREFIX,
-                self.snippet_idx,
+                self.sub_id,
                 self.document_id,
             ))
         }

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -127,8 +127,8 @@ macro_rules! string_wrapper {
             impl FromStr for $name {
                 type Err = $error;
 
-                fn from_str(s: &str) -> Result<Self, Self::Err> {
-                    s.try_into()
+                fn from_str(value: &str) -> Result<Self, Self::Err> {
+                    value.try_into()
                 }
             }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -12,7 +12,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{borrow::Borrow, collections::HashMap, ops::RangeInclusive};
+use std::{
+    borrow::{Borrow, Cow},
+    collections::HashMap,
+    ops::RangeInclusive,
+    str::FromStr,
+};
 
 use chrono::DateTime;
 use derive_more::{Deref, DerefMut, Display, Into};
@@ -30,6 +35,7 @@ use xayn_ai_coi::Document as AiDocument;
 
 use crate::{
     error::common::{
+        InternalError,
         InvalidDocumentId,
         InvalidDocumentProperties,
         InvalidDocumentProperty,
@@ -43,6 +49,7 @@ use crate::{
         InvalidUserId,
     },
     storage::property_filter::IndexedPropertyType,
+    Error,
 };
 
 fn trim(string: &mut String) {
@@ -117,6 +124,14 @@ macro_rules! string_wrapper {
                 }
             }
 
+            impl FromStr for $name {
+                type Err = $error;
+
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    s.try_into()
+                }
+            }
+
             impl PgHasArrayType for $name {
                 fn array_type_info() -> PgTypeInfo {
                     <String as PgHasArrayType>::array_type_info()
@@ -151,6 +166,68 @@ string_wrapper! {
     pub(crate) DocumentTag, InvalidDocumentTag, GENERIC_STRING_SYNTAX, 1..=256;
     /// A document query.
     pub(crate) DocumentQuery, InvalidDocumentQuery, GENERIC_STRING_SYNTAX, 1..=512;
+}
+
+/// Id pointing to a specific snippet in a document.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub(crate) struct SnippetId {
+    document_id: DocumentId,
+    snippet_idx: usize,
+}
+
+impl SnippetId {
+    pub(crate) fn new(document_id: DocumentId, snippet_idx: usize) -> Self {
+        Self {
+            document_id,
+            snippet_idx,
+        }
+    }
+
+    pub(crate) fn document_id(&self) -> &DocumentId {
+        &self.document_id
+    }
+
+    pub(crate) fn into_document_id(self) -> DocumentId {
+        self.document_id
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn snippet_idx(&self) -> usize {
+        self.snippet_idx
+    }
+
+    const ES_SNIPPET_ID_PREFIX: &str = "_s.";
+
+    pub(crate) fn try_from_es_id(es_id: impl AsRef<str>) -> Result<Self, Error> {
+        let es_id = es_id.as_ref();
+        if let Some(suffix) = es_id.strip_prefix(Self::ES_SNIPPET_ID_PREFIX) {
+            let Some((snippet_idx, document_id)) = suffix.split_once('.') else {
+                return Err(InternalError::from_message(format!("failed to split child id: {suffix}")).into());
+            };
+            let Ok(snippet_idx) = snippet_idx.parse() else {
+                return Err(InternalError::from_message(format!("failed to parse child idx: {snippet_idx}")).into());
+            };
+            let Ok(document_id) = document_id.parse() else {
+                return Err(InternalError::from_message(format!("failed to parse parents document id: {document_id}")).into());
+            };
+            Ok(Self::new(document_id, snippet_idx))
+        } else {
+            Ok(Self::new(es_id.parse()?, 0))
+        }
+    }
+
+    pub(crate) fn to_es_id(&self) -> Cow<'_, str> {
+        if self.snippet_idx == 0 {
+            Cow::Borrowed(&self.document_id)
+        } else {
+            Cow::Owned(format!(
+                "{}{}.{}",
+                Self::ES_SNIPPET_ID_PREFIX,
+                self.snippet_idx,
+                self.document_id,
+            ))
+        }
+    }
 }
 
 /// A document snippet.
@@ -336,7 +413,7 @@ pub(crate) struct InteractedDocument {
 #[derive(Clone, Debug)]
 pub(crate) struct PersonalizedDocument {
     /// Unique identifier of the document.
-    pub(crate) id: DocumentId,
+    pub(crate) id: SnippetId,
 
     /// Similarity score of the personalized document.
     pub(crate) score: f32,
@@ -359,7 +436,7 @@ pub(crate) struct PersonalizedDocument {
 }
 
 impl AiDocument for PersonalizedDocument {
-    type Id = DocumentId;
+    type Id = SnippetId;
 
     fn id(&self) -> &Self::Id {
         &self.id

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -230,6 +230,11 @@ impl SnippetId {
     }
 }
 
+pub(crate) enum SnippetOrDocumentId {
+    SnippetId(SnippetId),
+    DocumentId(DocumentId),
+}
+
 /// A document snippet.
 #[derive(Clone, Debug, Deref, Deserialize, PartialEq, Serialize, Type)]
 #[serde(transparent)]

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -80,7 +80,7 @@ struct UnvalidatedUserInteractionRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct UnvalidatedUserInteraction {
-    id: UnvalidatedDocumentOrSnippetId,
+    id: UnvalidatedSnippetOrDocumentId,
 }
 
 impl UnvalidatedUserInteractionRequest {
@@ -378,7 +378,7 @@ pub(crate) async fn personalize_documents_by(
         PersonalizeBy::Documents(documents) => {
             let ids = documents
                 .iter()
-                .map(|id| SnippetId::new((*id).clone(), 0))
+                .map(|&id| SnippetId::new(id.clone(), 0))
                 .collect_vec();
             storage::Document::get_personalized(
                 storage,
@@ -586,7 +586,7 @@ impl UnvalidatedSemanticSearchRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
-enum UnvalidatedDocumentOrSnippetId {
+enum UnvalidatedSnippetOrDocumentId {
     DocumentId(String),
     PotentialSnippetId {
         document_id: String,
@@ -604,11 +604,11 @@ impl From<SnippetOrDocumentId> for InputDocument {
     }
 }
 
-impl UnvalidatedDocumentOrSnippetId {
+impl UnvalidatedSnippetOrDocumentId {
     fn validate(self) -> Result<SnippetOrDocumentId, Error> {
         let (document_id, snippet_idx) = match self {
-            UnvalidatedDocumentOrSnippetId::DocumentId(document_id) => (document_id, None),
-            UnvalidatedDocumentOrSnippetId::PotentialSnippetId {
+            UnvalidatedSnippetOrDocumentId::DocumentId(document_id) => (document_id, None),
+            UnvalidatedSnippetOrDocumentId::PotentialSnippetId {
                 document_id,
                 snippet_idx,
             } => (document_id, snippet_idx),
@@ -627,7 +627,7 @@ impl UnvalidatedDocumentOrSnippetId {
 
 #[derive(Debug, Deserialize)]
 struct UnvalidatedInputDocument {
-    id: Option<UnvalidatedDocumentOrSnippetId>,
+    id: Option<UnvalidatedSnippetOrDocumentId>,
     query: Option<String>,
 }
 

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -15,7 +15,9 @@
 use actix_web::{
     http::StatusCode,
     web::{self, Data, Json, Path, Query, ServiceConfig},
-    Either, HttpResponse, Responder,
+    Either,
+    HttpResponse,
+    Responder,
 };
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -28,10 +30,16 @@ use super::{
     knn,
     rerank::rerank_by_scores,
     stateless::{
-        derive_interests_and_tag_weights, load_history, trim_history, validate_history,
-        HistoryEntry, UnvalidatedHistoryEntry,
+        derive_interests_and_tag_weights,
+        load_history,
+        trim_history,
+        validate_history,
+        HistoryEntry,
+        UnvalidatedHistoryEntry,
     },
-    AppState, PersonalizationConfig, SemanticSearchConfig,
+    AppState,
+    PersonalizationConfig,
+    SemanticSearchConfig,
 };
 use crate::{
     app::TenantState,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -47,6 +47,7 @@ use crate::{
         InteractedDocument,
         PersonalizedDocument,
         SnippetId,
+        SnippetOrDocumentId,
         UserId,
     },
     personalization::filter::Filter,
@@ -257,7 +258,7 @@ pub(crate) trait Interaction {
     async fn update_interactions(
         &self,
         user_id: &UserId,
-        interactions: impl IntoIterator<IntoIter = impl Clone + ExactSizeIterator<Item = &DocumentId>>,
+        interactions: Vec<SnippetOrDocumentId>,
         store_user_history: bool,
         time: DateTime<Utc>,
         update_logic: impl for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> Coi,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -46,6 +46,7 @@ use crate::{
         IngestedDocument,
         InteractedDocument,
         PersonalizedDocument,
+        SnippetId,
         UserId,
     },
     personalization::filter::Filter,
@@ -54,7 +55,7 @@ use crate::{
 };
 
 pub(crate) struct KnnSearchParams<'a> {
-    pub(crate) excluded: &'a [DocumentId],
+    pub(crate) excluded: &'a Exclusions,
     pub(crate) embedding: &'a NormalizedEmbedding,
     /// The number of documents which will be returned if there are enough fitting documents.
     pub(crate) count: usize,
@@ -64,6 +65,12 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(super) include_properties: bool,
     pub(super) include_snippet: bool,
     pub(super) filter: Option<&'a Filter>,
+}
+
+#[derive(Default)]
+pub(crate) struct Exclusions {
+    pub(crate) documents: Vec<DocumentId>,
+    pub(crate) snippets: Vec<SnippetId>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -140,9 +147,10 @@ pub(crate) trait Document {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<InteractedDocument>, Error>;
 
+    //FIXME this is only used by (view) tests and dead code, consider removing it
     async fn get_personalized(
         &self,
-        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &SnippetId>>,
         include_properties: bool,
         include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error>;
@@ -152,7 +160,7 @@ pub(crate) trait Document {
         ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
     ) -> Result<Vec<ExcerptedDocument>, Error>;
 
-    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error>;
+    async fn get_embedding(&self, id: &SnippetId) -> Result<Option<NormalizedEmbedding>, Error>;
 
     async fn get_by_embedding<'a>(
         &self,

--- a/web-api/src/storage/elastic/filter.rs
+++ b/web-api/src/storage/elastic/filter.rs
@@ -213,7 +213,7 @@ struct Ids<'a, Id: Clone> {
 
 impl<Id> Serialize for Ids<'_, Id>
 where
-    //Hint: a Display bound an a serialize as string helper would be more correct
+    //Hint: a Display bound and a serialize as string helper would be more correct
     Id: Clone + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/web-api/src/storage/elastic/filter.rs
+++ b/web-api/src/storage/elastic/filter.rs
@@ -12,13 +12,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp::Ordering, collections::HashMap};
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap};
 
 use serde::{Serialize, Serializer};
 
 use crate::{
-    models::{DocumentId, DocumentProperty, DocumentPropertyId},
+    models::{DocumentId, DocumentProperty, DocumentPropertyId, SnippetId},
     personalization::filter::{self, Combine, CombineOp, Compare, CompareOp},
+    storage::Exclusions,
 };
 
 #[derive(Debug)]
@@ -64,6 +65,35 @@ impl Serialize for Terms<'_> {
         let terms = [(field.as_str(), self.value)].into();
 
         Terms { terms }.serialize(serializer)
+    }
+}
+
+#[derive(Debug)]
+struct Parents<'a> {
+    parents: &'a [DocumentId],
+}
+
+impl Serialize for Parents<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Terms<'a> {
+            terms: ParentField<'a>,
+        }
+
+        #[derive(Serialize)]
+        struct ParentField<'a> {
+            parent: &'a [DocumentId],
+        }
+
+        Terms {
+            terms: ParentField {
+                parent: self.parents,
+            },
+        }
+        .serialize(serializer)
     }
 }
 
@@ -177,28 +207,32 @@ impl Serialize for Range<'_> {
 }
 
 #[derive(Debug)]
-struct Ids<'a> {
-    values: &'a [DocumentId],
+struct Ids<'a, Id: Clone> {
+    values: Cow<'a, [Id]>,
 }
 
-impl Serialize for Ids<'_> {
+impl<Id> Serialize for Ids<'_, Id>
+where
+    //Hint: a Display bound an a serialize as string helper would be more correct
+    Id: Clone + Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         #[derive(Serialize)]
-        struct Values<'a> {
-            values: &'a [DocumentId],
+        struct Values<'a, Id> {
+            values: &'a [Id],
         }
 
         #[derive(Serialize)]
-        struct Ids<'a> {
-            ids: Values<'a>,
+        struct Ids<'a, Id> {
+            ids: Values<'a, Id>,
         }
 
         Ids {
             ids: Values {
-                values: self.values,
+                values: &self.values,
             },
         }
         .serialize(serializer)
@@ -473,11 +507,19 @@ pub(super) struct Clauses<'a> {
     #[serde(flatten, skip_serializing_if = "Should::is_empty")]
     should: Should<'a>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    must_not: Vec<Ids<'a>>,
+    must_not: Vec<ExcludedIds<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ExcludedIds<'a> {
+    DocumentsById(Ids<'a, DocumentId>),
+    SnippetsById(Ids<'a, Cow<'a, str>>),
+    DocumentsByParent(Parents<'a>),
 }
 
 impl<'a> Clauses<'a> {
-    pub(super) fn new(filter: Option<&'a filter::Filter>, excluded: &'a [DocumentId]) -> Self {
+    pub(super) fn new(filter: Option<&'a filter::Filter>, exclusions: &'a Exclusions) -> Self {
         let mut clauses = Self {
             filter: Filter {
                 filter: Vec::new(),
@@ -498,10 +540,26 @@ impl<'a> Clauses<'a> {
                 Clause::Should(clause) => clauses.should = clause,
             }
         }
-        if !excluded.is_empty() {
-            // existing pg documents are not filtered in the query to avoid too much work for a cold
-            // path, filtering them afterwards can occasionally lead to less than k results though
-            clauses.must_not.push(Ids { values: excluded });
+
+        if !exclusions.documents.is_empty() {
+            clauses.must_not.push(ExcludedIds::DocumentsById(Ids {
+                values: Cow::Borrowed(&exclusions.documents),
+            }));
+            clauses
+                .must_not
+                .push(ExcludedIds::DocumentsByParent(Parents {
+                    parents: &exclusions.documents,
+                }));
+        }
+        if !exclusions.snippets.is_empty() {
+            let ids = exclusions
+                .snippets
+                .iter()
+                .map(SnippetId::to_es_id)
+                .collect();
+            clauses.must_not.push(ExcludedIds::SnippetsById(Ids {
+                values: Cow::Owned(ids),
+            }));
         }
 
         clauses
@@ -531,14 +589,14 @@ mod tests {
         let clause = serde_json::from_str(r#"{ "a": { "$eq": true } }"#).unwrap();
         let value = json!({ FILTER: [{ TERM: { PROP_A: true } }] });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
 
         let clause = serde_json::from_str(r#"{ "a": { "$eq": "b" } }"#).unwrap();
         let value = json!({ FILTER: [{ TERM: { PROP_A: "b" } }] });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -548,7 +606,7 @@ mod tests {
         let clause = serde_json::from_str(r#"{ "a": { "$in": ["b", "c"] } }"#).unwrap();
         let value = json!({ FILTER: [{ TERMS: { PROP_A: ["b", "c"] } }] });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -729,7 +787,7 @@ mod tests {
                 serde_json::from_str(&json!({ "a": { operation.0: 42 } }).to_string()).unwrap();
             let value = json!({ FILTER: [{ RANGE: { PROP_A: { operation.1: 42 } } }] });
             assert_eq!(
-                serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+                serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
                 value,
             );
 
@@ -737,7 +795,7 @@ mod tests {
                 serde_json::from_str(&json!({ "a": { operation.0: DATE } }).to_string()).unwrap();
             let value = json!({ FILTER: [{ RANGE: { PROP_A: { operation.1: DATE } } }] });
             assert_eq!(
-                serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+                serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
                 value,
             );
         }
@@ -761,7 +819,7 @@ mod tests {
             { RANGE: { PROP_C: { "gt": 5, "lte": 0 } } }
         ] });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -789,7 +847,7 @@ mod tests {
             MINIMUM_SHOULD_MATCH: 1
         });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -810,7 +868,7 @@ mod tests {
             { RANGE: { PROP_C: { "gt": DATE, "lt": DATE } } }
         ] });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -835,7 +893,7 @@ mod tests {
             MINIMUM_SHOULD_MATCH: 1
         });
         assert_eq!(
-            serde_json::to_value(Clauses::new(Some(&clause), &[])).unwrap(),
+            serde_json::to_value(Clauses::new(Some(&clause), &Exclusions::default())).unwrap(),
             value,
         );
     }
@@ -889,14 +947,26 @@ mod tests {
 
     #[test]
     fn test_must_not() {
-        let ids = [
-            "a".try_into().unwrap(),
-            "b".try_into().unwrap(),
-            "c".try_into().unwrap(),
-        ];
-        let value = json!({ "must_not": [{ "ids": { "values": ["a", "b", "c"] } }] });
+        let exclusions = Exclusions {
+            documents: vec![
+                "a".try_into().unwrap(),
+                "b".try_into().unwrap(),
+                "c".try_into().unwrap(),
+            ],
+            snippets: vec![
+                SnippetId::new("e".try_into().unwrap(), 0),
+                SnippetId::new("e".try_into().unwrap(), 1),
+            ],
+        };
+        let value = json!({
+            "must_not": [
+                { "ids": { "values": ["a", "b", "c"] } },
+                { "terms": { "parent": [ "a", "b", "c"] } },
+                { "ids": { "values": ["e", "_s.1.e"] } },
+            ]
+        });
         assert_eq!(
-            serde_json::to_value(Clauses::new(None, &ids)).unwrap(),
+            serde_json::to_value(Clauses::new(None, &exclusions)).unwrap(),
             value,
         );
     }

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -53,6 +53,7 @@ use crate::{
         InteractedDocument,
         PersonalizedDocument,
         PreprocessingStep,
+        SnippetId,
         UserId,
     },
     storage::{self, KnnSearchParams, Warning},
@@ -260,7 +261,7 @@ impl storage::Document for Storage {
 
     async fn get_personalized(
         &self,
-        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &SnippetId>>,
         include_properties: bool,
         include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
@@ -268,11 +269,11 @@ impl storage::Document for Storage {
         let documents = ids
             .into_iter()
             .filter_map(|id| {
-                documents.0.get(id).and_then(|document| {
+                documents.0.get(id.document_id()).and_then(|document| {
                     documents
                         .1
                         .borrow_map()
-                        .get(id)
+                        .get(id.document_id())
                         .map(|embedding| PersonalizedDocument {
                             id: id.clone(),
                             score: 1.,
@@ -310,8 +311,15 @@ impl storage::Document for Storage {
         Ok(documents)
     }
 
-    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
-        Ok(self.documents.read().await.1.borrow_map().get(id).cloned())
+    async fn get_embedding(&self, id: &SnippetId) -> Result<Option<NormalizedEmbedding>, Error> {
+        Ok(self
+            .documents
+            .read()
+            .await
+            .1
+            .borrow_map()
+            .get(id.document_id())
+            .cloned())
     }
 
     async fn get_by_embedding<'a>(
@@ -322,7 +330,7 @@ impl storage::Document for Storage {
             unimplemented!(/* we don't need it for memory.rs */);
         }
 
-        let excluded = params.excluded.iter().collect::<HashSet<_>>();
+        let excluded = params.excluded.documents.iter().collect::<HashSet<_>>();
         let documents = self.documents.read().await;
         let documents = documents
             .1
@@ -337,7 +345,7 @@ impl storage::Document for Storage {
                     None
                 } else {
                     documents.0.get(id).map(|document| PersonalizedDocument {
-                        id: id.clone(),
+                        id: SnippetId::new(id.clone(), 0),
                         score: item.distance,
                         embedding: item.point.as_ref().clone(),
                         properties: params
@@ -710,12 +718,15 @@ mod tests {
     use xayn_test_utils::assert_approx_eq;
 
     use super::*;
-    use crate::{models::PreprocessingStep, storage::SearchStrategy};
+    use crate::{
+        models::PreprocessingStep,
+        storage::{Exclusions, SearchStrategy},
+    };
 
     #[tokio::test]
     async fn test_knn_search() {
         let ids = (0..3)
-            .map(|id| DocumentId::try_from(id.to_string()).unwrap())
+            .map(|id| SnippetId::new(DocumentId::try_from(id.to_string()).unwrap(), 0))
             .collect_vec();
         let embeddings = [
             [1., 0., 0.].try_into().unwrap(),
@@ -726,7 +737,7 @@ mod tests {
             .iter()
             .zip(embeddings)
             .map(|(id, embedding)| IngestedDocument {
-                id: id.clone(),
+                id: id.document_id().clone(),
                 snippet: DocumentSnippet::new("snippet", 100).unwrap(),
                 preprocessing_step: PreprocessingStep::None,
                 properties: DocumentProperties::default(),
@@ -744,7 +755,7 @@ mod tests {
         let documents = storage::Document::get_by_embedding(
             &storage,
             KnnSearchParams {
-                excluded: &[],
+                excluded: &Exclusions::default(),
                 embedding,
                 count: 2,
                 num_candidates: 2,
@@ -764,7 +775,10 @@ mod tests {
         let documents = storage::Document::get_by_embedding(
             &storage,
             KnnSearchParams {
-                excluded: &ids[1..=1],
+                excluded: &Exclusions {
+                    documents: vec![ids[1].document_id().clone()],
+                    snippets: Vec::new(),
+                },
                 embedding,
                 count: 3,
                 num_candidates: 3,
@@ -785,14 +799,14 @@ mod tests {
     #[tokio::test]
     async fn test_serde() {
         let storage = Storage::default();
-        let doc_id = DocumentId::try_from("42").unwrap();
+        let doc_id = SnippetId::new(DocumentId::try_from("42").unwrap(), 0);
         let snippet = DocumentSnippet::new("snippet", 100).unwrap();
         let tags = DocumentTags::try_from(vec!["tag".try_into().unwrap()]).unwrap();
         let embedding = NormalizedEmbedding::try_from([1., 2., 3.]).unwrap();
         storage::Document::insert(
             &storage,
             vec![IngestedDocument {
-                id: doc_id.clone(),
+                id: doc_id.document_id().clone(),
                 snippet: snippet.clone(),
                 preprocessing_step: PreprocessingStep::None,
                 properties: DocumentProperties::default(),
@@ -807,7 +821,7 @@ mod tests {
         storage::Interaction::update_interactions(
             &storage,
             &user_id,
-            [&doc_id],
+            [doc_id.document_id()],
             true,
             Utc::now(),
             |context| {
@@ -825,11 +839,11 @@ mod tests {
         .unwrap();
 
         let storage = Storage::deserialize(&storage.serialize().await.unwrap()).unwrap();
-        let documents = storage::Document::get_excerpted(&storage, [&doc_id])
+        let documents = storage::Document::get_excerpted(&storage, [doc_id.document_id()])
             .await
             .unwrap();
         assert_eq!(documents.len(), 1);
-        assert_eq!(documents[0].id, doc_id);
+        assert_eq!(&documents[0].id, doc_id.document_id());
         assert_eq!(documents[0].snippet, snippet);
         let documents = storage::Document::get_personalized(&storage, [&doc_id], true, true)
             .await

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -274,7 +274,7 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row: PgRow| {
-                        // TODO[pmk/now] for this PR we blindly assume snippet_idx==0, this function
+                        // TODO[pmk/now] for this PR we blindly assume sub_id==0, this function
                         //               will change majorly in the followup PR anyway
                         let id = SnippetId::new(row.try_get("document_id")?, 0);
                         let embedding = row.try_get("embedding")?;

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -41,6 +41,7 @@ use sqlx::{
 use tracing::{info, instrument};
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiId, CoiStats};
+use xayn_web_api_shared::elastic::ScoreMap;
 
 use super::{
     property_filter::{
@@ -65,6 +66,7 @@ use crate::{
         IngestedDocument,
         InteractedDocument,
         PersonalizedDocument,
+        SnippetId,
         UserId,
     },
     storage::{self, utils::SqlxPushTupleExt, KnnSearchParams, Storage, Warning},
@@ -249,8 +251,7 @@ impl Database {
 
     async fn get_personalized(
         tx: &mut Transaction<'_, Postgres>,
-        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
-        scores: impl Fn(&DocumentId) -> Option<f32> + Sync,
+        scores: ScoreMap<SnippetId>,
         include_properties: bool,
         include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
@@ -263,9 +264,8 @@ impl Database {
                 .unwrap_or_default(),
             include_snippet.then_some(", snippet").unwrap_or_default(),
         ));
-        let ids = ids.into_iter();
-        let mut documents = Vec::with_capacity(ids.len());
-        let mut ids = ids.filter(|id| scores(id).is_some()).peekable();
+        let mut documents = Vec::with_capacity(scores.len());
+        let mut ids = scores.keys().map(SnippetId::document_id).peekable();
         while ids.peek().is_some() {
             documents.extend(
                 builder
@@ -273,7 +273,9 @@ impl Database {
                     .push_tuple(ids.by_ref().take(Self::BIND_LIMIT))
                     .build()
                     .try_map(|row: PgRow| {
-                        let id = row.try_get("document_id")?;
+                        // TODO[pmk/now] for this PR we blindly assume snippet_idx==0, this function
+                        //               will change majorly in the followup PR anyway
+                        let id = SnippetId::new(row.try_get("document_id")?, 0);
                         let embedding = row.try_get("embedding")?;
                         let tags = row.try_get("tags")?;
                         let properties = if include_properties {
@@ -286,7 +288,7 @@ impl Database {
                         } else {
                             None
                         };
-                        let score = scores(&id).unwrap(/* filtered ids */);
+                        let score = scores[&id];
 
                         Ok(PersonalizedDocument {
                             id,
@@ -301,12 +303,8 @@ impl Database {
                     .await?,
             );
         }
-        documents.sort_unstable_by(|d1, d2| {
-            scores(&d1.id)
-                .unwrap()
-                .total_cmp(&scores(&d2.id).unwrap())
-                .reverse()
-        });
+
+        documents.sort_unstable_by(|d1, d2| d1.score.total_cmp(&d2.score).reverse());
 
         Ok(documents)
     }
@@ -350,10 +348,11 @@ impl Database {
 
     async fn get_embedding(
         tx: &mut Transaction<'_, Postgres>,
-        id: &DocumentId,
+        id: &SnippetId,
     ) -> Result<Option<NormalizedEmbedding>, Error> {
+        // TODO[pmk/ET-4756-5] handle snippet idx
         sqlx::query_as("SELECT embedding FROM document WHERE document_id = $1;")
-            .bind(id)
+            .bind(id.document_id())
             .fetch_optional(tx)
             .await
             .map_err(Into::into)
@@ -776,19 +775,14 @@ impl storage::Document for Storage {
 
     async fn get_personalized(
         &self,
-        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &SnippetId>>,
         include_properties: bool,
         include_snippet: bool,
     ) -> Result<Vec<PersonalizedDocument>, Error> {
         let mut tx = self.postgres.begin().await?;
-        let documents = Database::get_personalized(
-            &mut tx,
-            ids,
-            |_| Some(1.0),
-            include_properties,
-            include_snippet,
-        )
-        .await?;
+        let ids = ids.into_iter().map(|id| (id.clone(), 1.0)).collect();
+        let documents =
+            Database::get_personalized(&mut tx, ids, include_properties, include_snippet).await?;
         tx.commit().await?;
 
         Ok(documents)
@@ -806,7 +800,7 @@ impl storage::Document for Storage {
     }
 
     #[instrument(skip(self))]
-    async fn get_embedding(&self, id: &DocumentId) -> Result<Option<NormalizedEmbedding>, Error> {
+    async fn get_embedding(&self, id: &SnippetId) -> Result<Option<NormalizedEmbedding>, Error> {
         let mut tx = self.postgres.begin().await?;
         let embedding = Database::get_embedding(&mut tx, id).await?;
         tx.commit().await?;
@@ -822,14 +816,9 @@ impl storage::Document for Storage {
         let include_properties = params.include_properties;
         let include_snippet = params.include_snippet;
         let scores = self.elastic.get_by_embedding(params).await?;
-        let documents = Database::get_personalized(
-            &mut tx,
-            scores.keys(),
-            |id| scores.get(id).copied(),
-            include_properties,
-            include_snippet,
-        )
-        .await?;
+        let documents =
+            Database::get_personalized(&mut tx, scores, include_properties, include_snippet)
+                .await?;
         tx.commit().await?;
 
         Ok(documents)


### PR DESCRIPTION
SnippetId is a ID into a document consisting of a document if and a snippet idx.

Added `SnippetId` into the interface and internal APIs:

- `PersonalizedDocument` now have `SnippetId` as id, when returning it we return the old `id: DocumentId` field and a `snippet_id: SnippetId` field, we will deprecate the `id` field and long term add an option to not include it for new tenants

- `/semantic_search` new accepts both a  `SnippetId` and `DocumentId`

- internal APIs use `SnippetId` where appropriate
  - except for mind related code which for now keeps using `DocumentId` where possible, we can add better snippet id support for it later
  
- doesn't yet change any internal representation, DB code etc.
  - there is one small exception around excluded documents &  elastic search filters 

**References:**

- based on: #1050 