### PR TITLE
ET-4300 Add ort

### DIFF
--- a/.github/actions/release_artifact/action.yml
+++ b/.github/actions/release_artifact/action.yml
@@ -43,6 +43,7 @@ runs:
         fi
 
         echo "build_target=$BUILD_TARGET" >> $GITHUB_ENV
+        echo "runtime_target=$RUNTIME_TARGET" >> $GITHUB_ENV
 
     - name: Build service
       shell: bash
@@ -56,7 +57,7 @@ runs:
 
         BIN_PATH="${GITHUB_WORKSPACE}/target/${{ env.build_target }}/release/${{ inputs.bin_name }}"
         MODEL_PATH="${GITHUB_WORKSPACE}/assets/${{ inputs.model_full_name }}"
-        RUNTIME_PATH="${GITHUB_WORKSPACE}/assets/${{ inputs.runtime_full_name }}/${RUNTIME_TARGET}"
+        RUNTIME_PATH="${GITHUB_WORKSPACE}/assets/${{ inputs.runtime_full_name }}/${{ env.runtime_target }}"
         DOCKERFILE_PATH="${GITHUB_WORKSPACE}/web-api/Dockerfile"
         ARCHIVE_NAME="${{ inputs.archive_name }}"
 

--- a/.github/actions/release_artifact/action.yml
+++ b/.github/actions/release_artifact/action.yml
@@ -17,7 +17,11 @@ inputs:
     type: string
     required: true
   model_full_name:
-    description: Name of the model to use
+    description: Versioned name of the model
+    type: string
+    required: true
+  runtime_full_name:
+    description: Versioned name of the runtime
     type: string
     required: true
 
@@ -27,10 +31,12 @@ runs:
     - name: Setup env
       shell: bash
       run: |
-        if [[ "${{ inputs.platform }}" = "arm64" ]]; then 
+        if [[ "${{ inputs.platform }}" = "arm64" ]]; then
           BUILD_TARGET="aarch64-unknown-linux-gnu";
-        elif [[ "${{ inputs.platform }}" = "amd64" ]]; then 
+          RUNTIME_TARGET="linux_aarch64"
+        elif [[ "${{ inputs.platform }}" = "amd64" ]]; then
           BUILD_TARGET="x86_64-unknown-linux-gnu";
+          RUNTIME_TARGET="linux_x64"
         else 
           echo "Unsupported platform ${{ inputs.platform }}"
           exit 1
@@ -50,6 +56,7 @@ runs:
 
         BIN_PATH="${GITHUB_WORKSPACE}/target/${{ env.build_target }}/release/${{ inputs.bin_name }}"
         MODEL_PATH="${GITHUB_WORKSPACE}/assets/${{ inputs.model_full_name }}"
+        RUNTIME_PATH="${GITHUB_WORKSPACE}/assets/${{ inputs.runtime_full_name }}/${RUNTIME_TARGET}"
         DOCKERFILE_PATH="${GITHUB_WORKSPACE}/web-api/Dockerfile"
         ARCHIVE_NAME="${{ inputs.archive_name }}"
 
@@ -61,6 +68,8 @@ runs:
         cp "$MODEL_PATH/config.toml" ./$ARCHIVE_NAME/assets/config.toml
         cp "$MODEL_PATH/tokenizer.json" ./$ARCHIVE_NAME/assets/tokenizer.json
         cp "$MODEL_PATH/model.onnx" ./$ARCHIVE_NAME/assets/model.onnx
+        cp -r "$RUNTIME_PATH/include" ./$ARCHIVE_NAME/assets/include
+        cp -r "$RUNTIME_PATH/lib" ./$ARCHIVE_NAME/assets/lib
         tar -cvf "$ARCHIVE_NAME.tar" ./$ARCHIVE_NAME
 
     - name: Upload archive
@@ -70,4 +79,3 @@ runs:
         retention-days: 1
         if-no-files-found: error
         path: ./${{ inputs.archive_name }}.tar
-

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -55,5 +55,5 @@ else
     download smbert_mocked v0004
     download e5_mocked v0000
     download xaynia v0002
-    download ort '1.15.1_v0000'
+    download ort 'v1.15.1'
 fi

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -55,4 +55,5 @@ else
     download smbert_mocked v0004
     download e5_mocked v0000
     download xaynia v0002
+    download ort v0000
 fi

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -49,11 +49,10 @@ if [ $# -gt 0 ]; then
         shift 2
     done
 else
-    download qasmbert v0002
     download smbert v0003
     download smbert v0004
     download smbert_mocked v0004
     download e5_mocked v0000
     download xaynia v0002
-    download ort 'v1.15.1'
+    download ort v1.15.1
 fi

--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -55,5 +55,5 @@ else
     download smbert_mocked v0004
     download e5_mocked v0000
     download xaynia v0002
-    download ort v0000
+    download ort '1.15.1_v0000'
 fi

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -13,16 +13,6 @@ on:
         type: string
         default: v0002
         required: true
-      runtime_name:
-        description: Name of the runtime
-        type: string
-        default: ort
-        required: true
-      runtime_version:
-        description: Version of the runtime
-        type: string
-        default: v1.15.1
-        required: true
       platform:
         description: Platform to build the image for
         type: choice
@@ -34,7 +24,7 @@ on:
       tag:
         description: >
           A tag for image identification. This override the default.
-          Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<runtime_name>_<runtime_version>-<platform>.
+          Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<platform>.
           Step 'Images name' will print the name of the generated images.
         type: string
         required: false
@@ -46,8 +36,10 @@ permissions:
 
 env:
   DENY_WARNINGS: false
-  frontoffice_archive: "web-service-frontoffice"
-  backoffice_archive: "web-service-backoffice"
+  runtime_name: ort
+  runtime_version: v1.15.1
+  frontoffice_archive: web-service-frontoffice
+  backoffice_archive: web-service-backoffice
 
 jobs:
   services-build:
@@ -81,7 +73,7 @@ jobs:
       - name: Download assets
         run: just download-assets \
           ${{ inputs.model_name }} ${{ inputs.model_version }} \
-          ${{ inputs.runtime_name }} ${{ inputs.runtime_version }}
+          ${{ env.runtime_name }} ${{ env.runtime_version }}
 
       - name: Create backoffice artifact
         uses: ./.github/actions/release_artifact
@@ -90,7 +82,7 @@ jobs:
           bin_name: "ingestion"
           archive_name: ${{ env.backoffice_archive }}
           model_full_name: ${{ inputs.model_name }}_${{ inputs.model_version }}
-          runtime_full_name: ${{ inputs.runtime_name }}_${{ inputs.runtime_version }}
+          runtime_full_name: ${{ env.runtime_name }}_${{ env.runtime_version }}
 
       - name: Create frontoffice artifact
         uses: ./.github/actions/release_artifact
@@ -99,7 +91,7 @@ jobs:
           bin_name: "personalization"
           archive_name: ${{ env.frontoffice_archive }}
           model_full_name: ${{ inputs.model_name }}_${{ inputs.model_version }}
-          runtime_full_name: ${{ inputs.runtime_name }}_${{ inputs.runtime_version }}
+          runtime_full_name: ${{ env.runtime_name }}_${{ env.runtime_version }}
 
   docker-build:
     runs-on: ubuntu-22.04
@@ -126,7 +118,6 @@ jobs:
             TAG="$TAG-$(date +"%y%m%d%H%M%S")"
             TAG="$TAG-$(git rev-parse --short HEAD)"
             TAG="$TAG-${{ inputs.model_name }}_${{ inputs.model_version }}"
-            TAG="$TAG-${{ inputs.runtime_name }}_${{ inputs.runtime_version }}"
             TAG="$TAG-${{ inputs.platform }}"
           fi
           frontoffice_image_name="xaynetci/xayn_discovery_web_service:$TAG"

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -4,26 +4,40 @@ on:
   workflow_dispatch:
     inputs:
       model_name:
+        description: Name of the model
         type: string
-        default: 'smbert'
-        description: Name of the model to use
+        default: xaynia
+        required: true
       model_version:
+        description: Version of the model
         type: string
-        default: 'v0003'
-        description: Version of the model to use
+        default: v0002
+        required: true
+      runtime_name:
+        description: Name of the runtime
+        type: string
+        default: ort
+        required: true
+      runtime_version:
+        description: Version of the runtime
+        type: string
+        default: v1.15.1
+        required: true
       platform:
         description: Platform to build the image for
         type: choice
-        default: 'arm64'
         options:
           - arm64
           - amd64
+        default: arm64
+        required: true
       tag:
-        type: string
         description: >
           A tag for image identification. This override the default.
           Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<platform>.
           Step 'Images name' will print the name of the generated images.
+        type: string
+        required: false
 
 run-name: ${{ github.ref_name }} - ${{ inputs.model_name }}_${{ inputs.model_version }}
 
@@ -65,7 +79,9 @@ jobs:
         uses: ./.github/actions/setup-job-docker
 
       - name: Download assets
-        run: just download-assets ${{ inputs.model_name }} ${{ inputs.model_version }}
+        run: just download-assets \
+          ${{ inputs.model_name }} ${{ inputs.model_version }} \
+          ${{ inputs.runtime_name }} ${{ inputs.runtime_version }}
 
       - name: Create backoffice artifact
         uses: ./.github/actions/release_artifact
@@ -74,6 +90,7 @@ jobs:
           bin_name: "ingestion"
           archive_name: ${{ env.backoffice_archive }}
           model_full_name: ${{ inputs.model_name }}_${{ inputs.model_version }}
+          runtime_full_name: ${{ inputs.runtime_name }}_${{ inputs.runtime_version }}
 
       - name: Create frontoffice artifact
         uses: ./.github/actions/release_artifact
@@ -82,6 +99,7 @@ jobs:
           bin_name: "personalization"
           archive_name: ${{ env.frontoffice_archive }}
           model_full_name: ${{ inputs.model_name }}_${{ inputs.model_version }}
+          runtime_full_name: ${{ inputs.runtime_name }}_${{ inputs.runtime_version }}
 
   docker-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -34,7 +34,7 @@ on:
       tag:
         description: >
           A tag for image identification. This override the default.
-          Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<platform>.
+          Default is <branch>-<timestamp>-<commit hash>-<model_name>_<model_version>-<runtime_name>_<runtime_version>-<platform>.
           Step 'Images name' will print the name of the generated images.
         type: string
         required: false
@@ -125,7 +125,8 @@ jobs:
             TAG="$(git rev-parse --abbrev-ref HEAD)"
             TAG="$TAG-$(date +"%y%m%d%H%M%S")"
             TAG="$TAG-$(git rev-parse --short HEAD)"
-            TAG="$TAG-${{ inputs.model_name}}_${{ inputs.model_version }}"
+            TAG="$TAG-${{ inputs.model_name }}_${{ inputs.model_version }}"
+            TAG="$TAG-${{ inputs.runtime_name }}_${{ inputs.runtime_version }}"
             TAG="$TAG-${{ inputs.platform }}"
           fi
           frontoffice_image_name="xaynetci/xayn_discovery_web_service:$TAG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ort"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e56c9c4185ee949ef961aca8777d1dbd52cb104b444669adad63e8181820a7"
+dependencies = [
+ "flate2",
+ "half 2.2.1",
+ "lazy_static",
+ "libc",
+ "ndarray",
+ "tar",
+ "thiserror",
+ "tracing",
+ "ureq",
+ "vswhom",
+ "winapi",
+ "zip",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,7 +3227,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -3693,7 +3713,7 @@ dependencies = [
  "tokio-stream",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "whoami",
 ]
 
@@ -4543,6 +4563,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64 0.21.2",
+ "log",
+ "once_cell",
+ "rustls 0.21.2",
+ "rustls-webpki",
+ "url",
+ "webpki-roots 0.23.1",
+]
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4593,6 +4628,26 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -4721,6 +4776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -4964,6 +5028,7 @@ dependencies = [
  "figment",
  "indicatif",
  "ndarray",
+ "ort",
  "serde",
  "sqlx",
  "thiserror",
@@ -5244,6 +5309,18 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e56c9c4185ee949ef961aca8777d1dbd52cb104b444669adad63e8181820a7"
 dependencies = [
  "flate2",
- "half 2.2.1",
  "lazy_static",
  "libc",
  "ndarray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,6 +5005,7 @@ name = "xayn-ai-bert"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "cfg-if",
  "criterion",
  "csv",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,14 +2700,13 @@ dependencies = [
  "flate2",
  "lazy_static",
  "libc",
+ "libloading",
  "ndarray",
  "tar",
  "thiserror",
  "tracing",
- "ureq",
  "vswhom",
  "winapi",
- "zip",
 ]
 
 [[package]]
@@ -3226,7 +3235,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3712,7 +3721,7 @@ dependencies = [
  "tokio-stream",
  "url",
  "uuid",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "whoami",
 ]
 
@@ -4562,21 +4571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
-dependencies = [
- "base64 0.21.2",
- "log",
- "once_cell",
- "rustls 0.21.2",
- "rustls-webpki",
- "url",
- "webpki-roots 0.23.1",
-]
-
-[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,15 +4769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]
@@ -5308,18 +5293,6 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5122,6 +5122,7 @@ dependencies = [
 name = "xayn-test-utils"
 version = "0.2.0"
 dependencies = [
+ "cfg-if",
  "float-cmp",
  "ndarray",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "AGPL-3.0-only"
 [workspace.dependencies]
 anyhow = "1.0.71"
 async-trait = "0.1.68"
+cfg-if = "1.0.0"
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "serde", "std"] }
 criterion = "0.5.1"
 csv = "1.2.2"

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -11,13 +11,20 @@ derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }
 ndarray = { workspace = true, features = ["serde"] }
-ort = { version = "1.15.2" }
+# TODO: remove download feature and store binary with target arch features
+ort = { version = "1.15.2", default-features = false, features = ["download-binaries"] }
 serde = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokenizers = { version = "0.13.3", default-features = false, features = ["onig"] }
 tract-onnx = "0.20.7"
 xayn-test-utils = { path = "../test-utils" }
+
+# [target.'cfg(target_arch = "arm")'.dependencies]
+# ort = { features = ["acl"] }
+
+# [target.'cfg(target_arch = "cuda")'.dependencies]
+# ort = { features = ["cuda"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-cfg-if = "1.0.0"
+cfg-if = { workspace = true }
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -11,18 +11,13 @@ derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }
 ndarray = { workspace = true, features = ["serde"] }
-# TODO: remove download feature and store binary with target arch features
-ort = { version = "1.15.2", default-features = false, features = ["download-binaries"] }
+ort = { version = "1.15.2", default-features = false, features = ["load-dynamic"] }
 serde = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokenizers = { version = "0.13.3", default-features = false, features = ["onig"] }
 tract-onnx = "0.20.7"
 xayn-test-utils = { path = "../test-utils" }
-# [target.'cfg(target_arch = "arm")'.dependencies]
-# ort = { features = ["acl"] }
-# [target.'cfg(target_arch = "cuda")'.dependencies]
-# ort = { features = ["cuda"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -19,10 +19,8 @@ thiserror = { workspace = true }
 tokenizers = { version = "0.13.3", default-features = false, features = ["onig"] }
 tract-onnx = "0.20.7"
 xayn-test-utils = { path = "../test-utils" }
-
 # [target.'cfg(target_arch = "arm")'.dependencies]
 # ort = { features = ["acl"] }
-
 # [target.'cfg(target_arch = "cuda")'.dependencies]
 # ort = { features = ["cuda"] }
 

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -11,6 +11,7 @@ derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }
 ndarray = { workspace = true, features = ["serde"] }
+ort = { version = "1.15.2" }
 serde = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+cfg-if = "1.0.0"
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 figment = { workspace = true }

--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -15,18 +15,34 @@
 use std::{hint::black_box, path::Path};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use xayn_ai_bert::{Config, NonePooler};
-use xayn_test_utils::asset::smbert;
+use xayn_ai_bert::{AveragePooler, Config, Runtime};
+use xayn_test_utils::asset::{ort, xaynia};
 
-const TOKEN_SIZE: usize = 64;
-const SEQUENCE: &str = "This is a sequence.";
+const TOKEN_SIZE: usize = 250;
+const SEQUENCE: &str = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et
+accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
+eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
+eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+est Lorem ipsum dolor sit amet. Duis autem vel eum iriure dolor in hendrerit in vulputate velit
+esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et
+iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla
+facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod
+tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud
+exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel
+eum iriure dolor in hendrerit in vulputate velit esse";
 
-fn bench_tract_bert(manager: &mut Criterion, name: &str, dir: &Path) {
+fn bench_bert(manager: &mut Criterion, name: &str, dir: &Path, rt: Runtime) {
     let pipeline = Config::new(dir)
         .unwrap()
         .with_token_size(TOKEN_SIZE)
         .unwrap()
-        .with_pooler::<NonePooler>()
+        .with_runtime(rt)
+        .with_pooler::<AveragePooler>()
         .build()
         .unwrap();
     manager.bench_function(name, |bencher| {
@@ -34,15 +50,25 @@ fn bench_tract_bert(manager: &mut Criterion, name: &str, dir: &Path) {
     });
 }
 
-fn bench_tract_smbert(manager: &mut Criterion) {
-    bench_tract_bert(manager, "Tract SMBert", &smbert().unwrap());
+fn bench_bert_tract(manager: &mut Criterion) {
+    bench_bert(manager, "Bert Tract", &xaynia().unwrap(), Runtime::Tract);
+}
+
+fn bench_bert_ort(manager: &mut Criterion) {
+    bench_bert(
+        manager,
+        "Bert Ort",
+        &xaynia().unwrap(),
+        Runtime::Ort(ort().unwrap()),
+    );
 }
 
 criterion_group! {
     name = bench;
     config = Criterion::default();
     targets =
-        bench_tract_smbert,
+        bench_bert_tract,
+        bench_bert_ort,
 }
 
 criterion_main! {

--- a/bert/src/config.rs
+++ b/bert/src/config.rs
@@ -236,18 +236,17 @@ impl<P> Config<P> {
             Runtime::Ort(dir) => dir,
         };
         cfg_if! {
-            if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
-                let runtime = dir.join("linux_aarch64/lib/libonnxruntime.so");
-            } else if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
-                let runtime = dir.join("linux_x64/lib/libonnxruntime.so");
+            if #[cfg(target_os = "linux")] {
+                let extension = "so";
             } else if #[cfg(target_os = "macos")] {
-                let runtime = dir.join("macos/lib/libonnxruntime.dylib");
+                let extension = "dylib";
             } else {
                 return Err(Error::from(Kind::Message(
-                    "embedder runtime isn't available for this target os/arch".into(),
+                    "embedder runtime isn't available for this target os".into(),
                 )));
             }
         }
+        let runtime = dir.join(format!("lib/libonnxruntime.{extension}"));
 
         if runtime.exists() {
             Ok(runtime)

--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -44,6 +44,7 @@ mod tokenizer;
 
 pub use crate::{
     config::Config,
+    model::RuntimeKind,
     pipeline::{Pipeline, PipelineError},
     pooler::{
         AveragePooler,

--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -43,8 +43,7 @@ mod pooler;
 mod tokenizer;
 
 pub use crate::{
-    config::Config,
-    model::RuntimeKind,
+    config::{Config, Runtime},
     pipeline::{Pipeline, PipelineError},
     pooler::{
         AveragePooler,

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -12,18 +12,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, path::PathBuf};
 
 use anyhow::bail;
 use derive_more::{Deref, From};
-use serde::Deserialize;
+use ndarray::CowArray;
+use ort::{
+    environment::Environment,
+    session::{Session, SessionBuilder},
+    value::Value,
+};
+use serde::{Deserialize, Serialize};
 use tract_onnx::prelude::{
     Framework,
     InferenceFact,
     InferenceModel,
     InferenceModelExt,
+    IntoArcTensor,
     TValue,
-    TractError,
     TypedModel,
     TypedRunnableModel,
 };
@@ -43,17 +49,15 @@ enum Dimension {
     Dynamic(DynDim),
 }
 
+use anyhow::Result;
+
 impl<P> Config<P> {
     fn extract_facts(
         &self,
         io: &'static str,
         mut model: InferenceModel,
-        with_io_fact: impl Fn(
-            InferenceModel,
-            usize,
-            InferenceFact,
-        ) -> Result<InferenceModel, TractError>,
-    ) -> Result<InferenceModel, TractError> {
+        with_io_fact: impl Fn(InferenceModel, usize, InferenceFact) -> Result<InferenceModel>,
+    ) -> Result<InferenceModel> {
         let mut i = 0;
         while let Ok(datum_type) = self
             .extract::<String>(&format!("model.{io}.{i}.type"))
@@ -81,9 +85,87 @@ impl<P> Config<P> {
 /// A Bert onnx model.
 #[derive(Debug)]
 pub(crate) struct Model {
-    model: TypedRunnableModel<TypedModel>,
+    runtime: Runtime,
     pub(crate) token_size: usize,
     pub(crate) embedding_size: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RuntimeKind {
+    Tract,
+    Ort,
+}
+
+#[derive(Debug)]
+enum Runtime {
+    Tract(TypedRunnableModel<TypedModel>),
+    Ort(Session),
+}
+
+impl Runtime {
+    pub(crate) fn new<P>(model: &PathBuf, config: &Config<P>) -> Result<Self> {
+        match config.runtime_kind {
+            RuntimeKind::Tract => Self::tract(model, config),
+            RuntimeKind::Ort => Self::ort(model),
+        }
+    }
+
+    fn tract<P>(model: &PathBuf, config: &Config<P>) -> Result<Self> {
+        let mut model = BufReader::new(File::open(model)?);
+        let model = tract_onnx::onnx().model_for_read(&mut model)?;
+        let model = config.extract_facts("input", model, InferenceModel::with_input_fact)?;
+        let model = config.extract_facts("output", model, InferenceModel::with_output_fact)?;
+        let model = model.into_optimized()?.into_runnable()?;
+
+        Ok(Self::Tract(model))
+    }
+
+    fn ort(model: &PathBuf) -> Result<Self> {
+        let environment = Environment::builder()
+            .with_name("embedder")
+            .build()?
+            .into_arc();
+        let session = SessionBuilder::new(&environment)?.with_model_from_file(model)?;
+
+        Ok(Self::Ort(session))
+    }
+
+    pub(crate) fn predict(&self, encoding: Encoding) -> Result<Prediction> {
+        match self {
+            Self::Tract(runtime) => Self::tract_predict(runtime, encoding),
+            Self::Ort(runtime) => Self::ort_predict(runtime, encoding),
+        }
+    }
+
+    fn tract_predict(
+        model: &TypedRunnableModel<TypedModel>,
+        encoding: Encoding,
+    ) -> Result<Prediction> {
+        let inputs = encoding.into();
+        let mut outputs = model.run(inputs)?;
+
+        Ok(outputs.swap_remove(0).into())
+    }
+
+    fn ort_predict(session: &Session, encoding: Encoding) -> Result<Prediction> {
+        let token_ids = CowArray::from(encoding.token_ids.into_dyn());
+        let attention_mask = CowArray::from(encoding.attention_mask.into_dyn());
+        let type_ids = CowArray::from(encoding.type_ids.unwrap().into_dyn());
+
+        let inputs = vec![
+            Value::from_array(session.allocator(), &token_ids)?,
+            Value::from_array(session.allocator(), &attention_mask)?,
+            Value::from_array(session.allocator(), &type_ids)?,
+        ];
+
+        let outputs = session.run(inputs)?;
+        let output = outputs[0]
+            .try_extract::<f32>()?
+            .view()
+            .to_owned()
+            .into_arc_tensor();
+        Ok(TValue::Const(output).into())
+    }
 }
 
 /// The predicted encoding.
@@ -94,35 +176,31 @@ pub(crate) struct Prediction(TValue);
 
 impl Model {
     /// Creates a model from a configuration.
-    pub(crate) fn new<P>(config: &Config<P>) -> Result<Self, TractError> {
+    pub(crate) fn new<P>(config: &Config<P>) -> Result<Self> {
         let model = config.dir.join("model.onnx");
         if !model.exists() {
             bail!("embedder model '{}' doesn't exist", model.display());
         }
-        let mut model = BufReader::new(File::open(model)?);
-        let model = tract_onnx::onnx().model_for_read(&mut model)?;
-        let model = config.extract_facts("input", model, InferenceModel::with_input_fact)?;
-        let model = config.extract_facts("output", model, InferenceModel::with_output_fact)?;
-        let model = model.into_optimized()?.into_runnable()?;
+
+        let runtime = Runtime::new(&model, config)?;
 
         Ok(Model {
-            model,
+            runtime,
             token_size: config.token_size,
             embedding_size: config.extract("model.output.0.shape.2")?,
         })
     }
 
     /// Runs prediction on the encoded sequence.
-    pub(crate) fn predict(&self, encoding: Encoding) -> Result<Prediction, TractError> {
-        let inputs = encoding.into();
-        let mut outputs = self.model.run(inputs)?;
-
-        Ok(outputs.swap_remove(0).into())
+    pub(crate) fn predict(&self, encoding: Encoding) -> Result<Prediction> {
+        self.runtime.predict(encoding)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::unreachable;
+
     use ndarray::{Array, Array2, Dimension};
     use tract_onnx::prelude::{DatumType, IntoArcTensor};
     use xayn_test_utils::asset::smbert_mocked;
@@ -142,29 +220,33 @@ mod tests {
     fn test_new() {
         let config = Config::new(smbert_mocked().unwrap())
             .unwrap()
+            .with_runtime(RuntimeKind::Tract)
             .with_token_size(64)
             .unwrap();
+
         let model = Model::new(&config).unwrap();
+        let Runtime::Tract(tract_model) = model.runtime else { unreachable!()};
+        let tract_model = tract_model.model();
 
-        assert_eq!(model.model.model().input_outlets().unwrap().len(), 3);
-        let fact = model.model.model().input_fact(0).unwrap();
+        assert_eq!(tract_model.input_outlets().unwrap().len(), 3);
+        let fact = tract_model.input_fact(0).unwrap();
         assert_eq!(fact.shape.as_concrete().unwrap(), [1, model.token_size]);
         assert_eq!(fact.datum_type, DatumType::I64);
-        let fact = model.model.model().input_fact(1).unwrap();
+        let fact = tract_model.input_fact(1).unwrap();
         assert_eq!(fact.shape.as_concrete().unwrap(), [1, model.token_size]);
         assert_eq!(fact.datum_type, DatumType::I64);
-        let fact = model.model.model().input_fact(2).unwrap();
+        let fact = tract_model.input_fact(2).unwrap();
         assert_eq!(fact.shape.as_concrete().unwrap(), [1, model.token_size]);
         assert_eq!(fact.datum_type, DatumType::I64);
 
-        assert_eq!(model.model.model().output_outlets().unwrap().len(), 2);
-        let fact = model.model.model().output_fact(0).unwrap();
+        assert_eq!(tract_model.output_outlets().unwrap().len(), 2);
+        let fact = tract_model.output_fact(0).unwrap();
         assert_eq!(
             fact.shape.as_concrete().unwrap(),
             [1, model.token_size, model.embedding_size],
         );
         assert_eq!(fact.datum_type, DatumType::F32);
-        let fact = model.model.model().output_fact(1).unwrap();
+        let fact = tract_model.output_fact(1).unwrap();
         assert_eq!(fact.shape.as_concrete().unwrap(), [1, model.embedding_size]);
         assert_eq!(fact.datum_type, DatumType::F32);
     }

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -110,7 +110,7 @@ impl Runtime {
     pub(crate) fn new<P>(config: &Config<P>) -> Result<Self, Error> {
         match config.runtime {
             config::Runtime::Tract => Self::tract(config),
-            config::Runtime::Ort => Self::ort(config),
+            config::Runtime::Ort(_) => Self::ort(config),
         }
     }
 
@@ -233,7 +233,7 @@ mod tests {
     use ndarray::{Array, Array2, Dimension};
     use ort::tensor::TensorElementDataType;
     use tract_onnx::prelude::{DatumType, IntoArcTensor};
-    use xayn_test_utils::asset::smbert_mocked;
+    use xayn_test_utils::asset::{ort, smbert_mocked};
 
     use super::*;
 
@@ -290,7 +290,7 @@ mod tests {
             .unwrap()
             .with_token_size(64)
             .unwrap()
-            .with_runtime(config::Runtime::Ort);
+            .with_runtime(config::Runtime::Ort(ort().unwrap()));
         let Model {
             runtime,
             embedding_size,
@@ -347,7 +347,7 @@ mod tests {
             .unwrap()
             .with_token_size(shape.1)
             .unwrap()
-            .with_runtime(config::Runtime::Ort);
+            .with_runtime(config::Runtime::Ort(ort().unwrap()));
         let model = Model::new(&config).unwrap();
 
         let encoding = Encoding {

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -125,10 +125,7 @@ impl Runtime {
     }
 
     fn ort<P>(config: &Config<P>) -> Result<Self, Error> {
-        const ORT_DYLIB_PATH: &str = "ORT_DYLIB_PATH";
-        let ort_dylib_path = env::var_os(ORT_DYLIB_PATH);
-        env::set_var(ORT_DYLIB_PATH, config.runtime()?);
-
+        env::set_var("ORT_DYLIB_PATH", config.runtime()?);
         let environment = Environment::builder()
             .with_name("embedder")
             .with_execution_providers([
@@ -141,13 +138,6 @@ impl Runtime {
             .with_log_level(LoggingLevel::Warning)
             .build()?
             .into_arc();
-
-        if let Some(ort_dylib_path) = ort_dylib_path {
-            env::set_var(ORT_DYLIB_PATH, ort_dylib_path);
-        } else {
-            env::remove_var(ORT_DYLIB_PATH);
-        }
-
         let session = SessionBuilder::new(&environment)?
             // TODO: this is the default, we could run the optimizations once offline and then
             // always load the optimized model from disk with GraphOptimizationLevel::Disable

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -14,7 +14,7 @@
 
 use std::{fs::File, io::BufReader, path::PathBuf};
 
-use anyhow::bail;
+use anyhow::{bail, Result};
 use derive_more::{Deref, From};
 use ndarray::CowArray;
 use ort::{
@@ -48,8 +48,6 @@ enum Dimension {
     Fixed(usize),
     Dynamic(DynDim),
 }
-
-use anyhow::Result;
 
 impl<P> Config<P> {
     fn extract_facts(

--- a/bert/src/pipeline.rs
+++ b/bert/src/pipeline.rs
@@ -44,7 +44,7 @@ pub enum PipelineError {
     /// Failed to run the tokenizer: {0}
     Tokenizer(#[from] tokenizers::Error),
     /// Failed to run the model: {0}
-    Model(#[from] tract_onnx::prelude::TractError),
+    Model(#[from] anyhow::Error),
 }
 
 impl Pipeline<NonePooler> {

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -31,7 +31,6 @@ use sqlx::{
     Type,
 };
 use thiserror::Error;
-use tract_onnx::prelude::TractError;
 use xayn_test_utils::ApproxEqIter;
 
 use crate::{model::Prediction, tokenizer::AttentionMask};
@@ -205,7 +204,7 @@ pub struct NonePooler;
 
 impl NonePooler {
     /// Passes through the prediction.
-    pub(crate) fn pool(prediction: &Prediction) -> Result<Embedding2, TractError> {
+    pub(crate) fn pool(prediction: &Prediction) -> anyhow::Result<Embedding2> {
         Ok(prediction
             .to_array_view()?
             .slice(s![0, .., ..])
@@ -221,7 +220,7 @@ pub struct FirstPooler;
 
 impl FirstPooler {
     /// Pools the prediction over its first token.
-    pub(crate) fn pool(prediction: &Prediction) -> Result<Embedding1, TractError> {
+    pub(crate) fn pool(prediction: &Prediction) -> anyhow::Result<Embedding1> {
         Ok(prediction
             .to_array_view()?
             .slice(s![0, 0, ..])
@@ -240,7 +239,7 @@ impl AveragePooler {
     pub(crate) fn pool(
         prediction: &Prediction,
         attention_mask: &AttentionMask,
-    ) -> Result<Embedding1, TractError> {
+    ) -> anyhow::Result<Embedding1> {
         let attention_mask: Array1<f32> = attention_mask.slice(s![0, ..]).mapv(
             #[allow(clippy::cast_precision_loss)] // values are only 0 or 1
             |mask| mask as f32,

--- a/bert/src/pooler.rs
+++ b/bert/src/pooler.rs
@@ -14,6 +14,7 @@
 
 use std::ops::{Add, Mul};
 
+use anyhow::Error;
 use derive_more::{Deref, From};
 use displaydoc::Display;
 use ndarray::{s, Array, Array1, Dimension, Ix, Ix1, Ix2};
@@ -204,7 +205,7 @@ pub struct NonePooler;
 
 impl NonePooler {
     /// Passes through the prediction.
-    pub(crate) fn pool(prediction: &Prediction) -> anyhow::Result<Embedding2> {
+    pub(crate) fn pool(prediction: &Prediction) -> Result<Embedding2, Error> {
         Ok(prediction
             .to_array_view()?
             .slice(s![0, .., ..])
@@ -220,7 +221,7 @@ pub struct FirstPooler;
 
 impl FirstPooler {
     /// Pools the prediction over its first token.
-    pub(crate) fn pool(prediction: &Prediction) -> anyhow::Result<Embedding1> {
+    pub(crate) fn pool(prediction: &Prediction) -> Result<Embedding1, Error> {
         Ok(prediction
             .to_array_view()?
             .slice(s![0, 0, ..])
@@ -239,7 +240,7 @@ impl AveragePooler {
     pub(crate) fn pool(
         prediction: &Prediction,
         attention_mask: &AttentionMask,
-    ) -> anyhow::Result<Embedding1> {
+    ) -> Result<Embedding1, Error> {
         let attention_mask: Array1<f32> = attention_mask.slice(s![0, ..]).mapv(
             #[allow(clippy::cast_precision_loss)] // values are only 0 or 1
             |mask| mask as f32,

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -61,7 +61,7 @@ use tracing_subscriber::{
     EnvFilter,
     Layer,
 };
-use xayn_test_utils::env::clear_env;
+use xayn_test_utils::{asset::ort_target, env::clear_env};
 use xayn_web_api::{config, start, AppHandle, Application, Ingestion};
 use xayn_web_api_db_ctrl::{Silo, Tenant};
 use xayn_web_api_shared::{
@@ -679,7 +679,7 @@ pub fn build_test_config_from_parts_and_names(
     let es_config = Value::try_from(es_config).unwrap();
 
     // Hint: Relative path doesn't work with `cargo flamegraph`
-    let embedding_dir = PROJECT_ROOT
+    let model_dir = PROJECT_ROOT
         .join("assets")
         .join(model_name)
         .display()
@@ -697,7 +697,7 @@ pub fn build_test_config_from_parts_and_names(
 
         [embedding]
         type = "pipeline"
-        directory = embedding_dir
+        directory = model_dir
         runtime = runtime_dir
     };
 
@@ -725,7 +725,7 @@ pub fn build_test_config_from_parts(
         es_config,
         configure,
         "xaynia_v0002",
-        "ort_v1.15.1",
+        &format!("ort_v1.15.1/{}", ort_target().unwrap()),
     )
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -667,11 +667,12 @@ where
 /// Embedding size used by the `Embedder` used for testing.
 pub const TEST_EMBEDDING_SIZE: usize = 384;
 
-pub fn build_test_config_from_parts_and_model(
+pub fn build_test_config_from_parts_and_names(
     pg_config: &postgres::Config,
     es_config: &elastic::Config,
     configure: Table,
     model_name: &str,
+    runtime_name: &str,
 ) -> Table {
     let pg_password = pg_config.password.expose_secret().as_str();
     let pg_config = Value::try_from(pg_config).unwrap();
@@ -683,6 +684,11 @@ pub fn build_test_config_from_parts_and_model(
         .join(model_name)
         .display()
         .to_string();
+    let runtime_dir = PROJECT_ROOT
+        .join("assets")
+        .join(runtime_name)
+        .display()
+        .to_string();
 
     let mut config = toml! {
         [storage]
@@ -692,6 +698,7 @@ pub fn build_test_config_from_parts_and_model(
         [embedding]
         type = "pipeline"
         directory = embedding_dir
+        runtime = runtime_dir
     };
 
     //the password was serialized as REDACTED in to_toml_value
@@ -713,7 +720,13 @@ pub fn build_test_config_from_parts(
     es_config: &elastic::Config,
     configure: Table,
 ) -> Table {
-    build_test_config_from_parts_and_model(pg_config, es_config, configure, "xaynia_v0002")
+    build_test_config_from_parts_and_names(
+        pg_config,
+        es_config,
+        configure,
+        "xaynia_v0002",
+        "ort_v1.15.1",
+    )
 }
 
 #[derive(Clone, Debug, Display, Deref, AsRef)]

--- a/justfile
+++ b/justfile
@@ -151,11 +151,11 @@ web-dev-up:
         ln -s "./assets/xaynia_v0002" "./web-api/assets"
     fi
     export HOST_PORT_SCOPE=30
-    docker-compose -p "$PROJECT" -f "./web-api/compose.db.yml" up --detach --remove-orphans --build
+    podman-compose -p "$PROJECT" -f "./web-api/compose.db.yml" up --detach --remove-orphans --build
 
 web-dev-down:
     #!/usr/bin/env -S bash -eu -o pipefail
-    docker-compose -p web-dev -f "./web-api/compose.db.yml" down
+    podman-compose -p web-dev -f "./web-api/compose.db.yml" down
 
 build-service-image $CRATE_PATH $BIN $ASSET_DIR="":
     #!/usr/bin/env -S bash -eux -o pipefail
@@ -189,7 +189,7 @@ compose-all-up *args:
         exit 1
     fi
     export HOST_PORT_SCOPE=40
-    docker-compose \
+    podman-compose \
         -p "$PROJECT" \
         -f "./web-api/compose.db.yml" \
         -f "./web-api/compose.personalization.yml" \
@@ -199,7 +199,7 @@ compose-all-up *args:
 
 compose-all-down *args:
     #!/usr/bin/env -S bash -eux -o pipefail
-    docker-compose \
+    podman-compose \
         -p "compose-all" \
         -f "./web-api/compose.db.yml" \
         -f "./web-api/compose.personalization.yml" \

--- a/justfile
+++ b/justfile
@@ -151,11 +151,11 @@ web-dev-up:
         ln -s "./assets/xaynia_v0002" "./web-api/assets"
     fi
     export HOST_PORT_SCOPE=30
-    podman-compose -p "$PROJECT" -f "./web-api/compose.db.yml" up --detach --remove-orphans --build
+    docker-compose -p "$PROJECT" -f "./web-api/compose.db.yml" up --detach --remove-orphans --build
 
 web-dev-down:
     #!/usr/bin/env -S bash -eu -o pipefail
-    podman-compose -p web-dev -f "./web-api/compose.db.yml" down
+    docker-compose -p web-dev -f "./web-api/compose.db.yml" down
 
 build-service-image $CRATE_PATH $BIN $ASSET_DIR="":
     #!/usr/bin/env -S bash -eux -o pipefail
@@ -189,7 +189,7 @@ compose-all-up *args:
         exit 1
     fi
     export HOST_PORT_SCOPE=40
-    podman-compose \
+    docker-compose \
         -p "$PROJECT" \
         -f "./web-api/compose.db.yml" \
         -f "./web-api/compose.personalization.yml" \
@@ -199,7 +199,7 @@ compose-all-up *args:
 
 compose-all-down *args:
     #!/usr/bin/env -S bash -eux -o pipefail
-    podman-compose \
+    docker-compose \
         -p "compose-all" \
         -f "./web-api/compose.db.yml" \
         -f "./web-api/compose.personalization.yml" \

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 publish = false
 
 [dependencies]
+cfg-if = { workspace = true }
 float-cmp = "0.9.0"
 ndarray = { workspace = true }
 once_cell = { workspace = true }

--- a/test-utils/src/asset.rs
+++ b/test-utils/src/asset.rs
@@ -18,7 +18,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const DATA_DIR: &str = "assets/";
+use cfg_if::cfg_if;
+
+const ASSETS_DIR: &str = "assets/";
 
 /// Resolves the path to the requested data relative to the workspace directory.
 fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
@@ -36,34 +38,47 @@ fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
         .canonicalize()
 }
 
-/// Resolves the path to the qasmbert model.
-pub fn qasmbert() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "qasmbert_v0002"])
-}
-
 /// Resolves the path to the smbert model.
 pub fn smbert() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "smbert_v0004"])
+    resolve_path(&[ASSETS_DIR, "smbert_v0004"])
 }
 
 /// Resolves the path to the mocked smbert model.
 pub fn smbert_mocked() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "smbert_mocked_v0004"])
+    resolve_path(&[ASSETS_DIR, "smbert_mocked_v0004"])
 }
 
 /// Resolves the path to the mocked e5 model.
 pub fn e5_mocked() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "e5_mocked_v0000"])
+    resolve_path(&[ASSETS_DIR, "e5_mocked_v0000"])
 }
 
 /// Resolves the path to the xaynia model.
 pub fn xaynia() -> Result<PathBuf> {
-    qasmbert()
+    resolve_path(&[ASSETS_DIR, "xaynia_v0002"])
+}
+
+/// Resolves the target of the onnxruntime library.
+pub fn ort_target() -> Result<&'static str> {
+    cfg_if! {
+        if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
+            Ok("linux_aarch64")
+        } else if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
+            Ok("linux_x64")
+        } else if #[cfg(target_os = "macos")] {
+            Ok("macos")
+        } else {
+            Err(Error::new(
+                ErrorKind::Unsupported,
+                "onnxruntime isn't available for this target os/arch",
+            ))
+        }
+    }
 }
 
 /// Resolves the path to the onnxruntime library.
 pub fn ort() -> Result<PathBuf> {
-    resolve_path(&[DATA_DIR, "ort_v1.15.1"])
+    resolve_path(&[ASSETS_DIR, "ort_v1.15.1", ort_target()?])
 }
 
 #[cfg(test)]
@@ -81,12 +96,17 @@ mod tests {
     }
 
     #[test]
-    fn test_qasmbert() {
-        assert!(qasmbert().is_ok());
+    fn test_e5_mocked() {
+        assert!(e5_mocked().is_ok());
     }
 
     #[test]
-    fn test_e5_mocked() {
-        assert!(e5_mocked().is_ok());
+    fn test_xaynia() {
+        assert!(xaynia().is_ok());
+    }
+
+    #[test]
+    fn test_ort() {
+        assert!(ort().is_ok());
     }
 }

--- a/test-utils/src/asset.rs
+++ b/test-utils/src/asset.rs
@@ -61,6 +61,11 @@ pub fn xaynia() -> Result<PathBuf> {
     qasmbert()
 }
 
+/// Resolves the path to the onnxruntime library.
+pub fn ort() -> Result<PathBuf> {
+    resolve_path(&[DATA_DIR, "ort_v1.15.1"])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/web-api/compose.db.yml
+++ b/web-api/compose.db.yml
@@ -8,9 +8,7 @@ services:
       POSTGRES_PASSWORD: pw
       POSTGRES_DB: xayn
     ports:
-      - "${HOST_PORT_SCOPE:-30}54:5432"
-    networks:
-      - internal
+      - "5432:5432"
     healthcheck:
       test: pg_isready
       interval: 10s
@@ -25,9 +23,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
     ports:
-      - "${HOST_PORT_SCOPE:-30}92:9200"
-    networks:
-      - internal
+      - "9200:9200"
     healthcheck:
       test: curl --fail 'http://localhost:9200/_cluster/health'
       interval: 10s
@@ -61,6 +57,3 @@ services:
   #     - elasticsearch
   #   networks:
   #     - internal
-
-networks:
-  internal:

--- a/web-api/compose.db.yml
+++ b/web-api/compose.db.yml
@@ -8,7 +8,9 @@ services:
       POSTGRES_PASSWORD: pw
       POSTGRES_DB: xayn
     ports:
-      - "5432:5432"
+      - "${HOST_PORT_SCOPE:-30}54:5432"
+    networks:
+      - internal
     healthcheck:
       test: pg_isready
       interval: 10s
@@ -23,7 +25,9 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
     ports:
-      - "9200:9200"
+      - "${HOST_PORT_SCOPE:-30}92:9200"
+    networks:
+      - internal
     healthcheck:
       test: curl --fail 'http://localhost:9200/_cluster/health'
       interval: 10s
@@ -57,3 +61,6 @@ services:
   #     - elasticsearch
   #   networks:
   #     - internal
+
+networks:
+  internal:

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -55,7 +55,7 @@ impl Default for Pipeline {
         Self {
             directory: "assets".into(),
             token_size: 250,
-            runtime: Runtime::Tract,
+            runtime: Runtime::Ort("assets".into()),
         }
     }
 }
@@ -204,14 +204,26 @@ impl Embedder {
 
 #[cfg(test)]
 mod tests {
-    use xayn_test_utils::asset::xaynia;
+    use xayn_test_utils::asset::{ort, xaynia};
 
     use super::*;
 
     #[tokio::test]
-    async fn test_embedder() {
+    async fn test_embedder_tract() {
         let config = Config::Pipeline(Pipeline {
             directory: xaynia().unwrap().into(),
+            runtime: Runtime::Tract,
+            ..Pipeline::default()
+        });
+        let embedder = Embedder::load(&config).await.unwrap();
+        embedder.run("test").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_embedder_ort() {
+        let config = Config::Pipeline(Pipeline {
+            directory: xaynia().unwrap().into(),
+            runtime: Runtime::Ort(ort().unwrap()),
             ..Pipeline::default()
         });
         let embedder = Embedder::load(&config).await.unwrap();

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -16,7 +16,7 @@ use aws_config::retry::RetryConfig;
 use aws_sdk_sagemakerruntime::{config::Region, primitives::Blob, Client};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding, RuntimeKind};
+use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding, Runtime};
 
 use crate::{app::SetupError, error::common::InternalError, utils::RelativePathBuf};
 
@@ -39,7 +39,7 @@ pub struct Pipeline {
     #[serde(deserialize_with = "deserialize_relative_path_buf")]
     pub(crate) directory: RelativePathBuf,
     pub(crate) token_size: usize,
-    pub(crate) runtime_kind: RuntimeKind,
+    pub(crate) runtime: Runtime,
 }
 
 fn deserialize_relative_path_buf<'de, D>(deserializer: D) -> Result<RelativePathBuf, D::Error>
@@ -55,7 +55,7 @@ impl Default for Pipeline {
         Self {
             directory: "assets".into(),
             token_size: 250,
-            runtime_kind: RuntimeKind::Tract,
+            runtime: Runtime::Tract,
         }
     }
 }
@@ -63,7 +63,7 @@ impl Default for Pipeline {
 impl Pipeline {
     fn load(&self) -> Result<Embedder, SetupError> {
         let config = EmbedderConfig::new(self.directory.relative())?
-            .with_runtime(self.runtime_kind)
+            .with_runtime(self.runtime)
             .with_token_size(self.token_size)?
             .with_pooler();
         config.validate()?;

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -16,7 +16,7 @@ use aws_config::retry::RetryConfig;
 use aws_sdk_sagemakerruntime::{config::Region, primitives::Blob, Client};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding};
+use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding, RuntimeKind};
 
 use crate::{app::SetupError, error::common::InternalError, utils::RelativePathBuf};
 
@@ -39,6 +39,7 @@ pub struct Pipeline {
     #[serde(deserialize_with = "deserialize_relative_path_buf")]
     pub(crate) directory: RelativePathBuf,
     pub(crate) token_size: usize,
+    pub(crate) runtime_kind: RuntimeKind,
 }
 
 fn deserialize_relative_path_buf<'de, D>(deserializer: D) -> Result<RelativePathBuf, D::Error>
@@ -54,7 +55,21 @@ impl Default for Pipeline {
         Self {
             directory: "assets".into(),
             token_size: 250,
+            runtime_kind: RuntimeKind::Tract,
         }
+    }
+}
+
+impl Pipeline {
+    fn load(&self) -> Result<Embedder, SetupError> {
+        let config = EmbedderConfig::new(self.directory.relative())?
+            .with_runtime(self.runtime_kind)
+            .with_token_size(self.token_size)?
+            .with_pooler();
+        config.validate()?;
+        let embedder = config.build()?;
+
+        Ok(Embedder::Pipeline(embedder))
     }
 }
 
@@ -115,19 +130,9 @@ struct SagemakerResponse {
 impl Embedder {
     pub(crate) async fn load(config: &Config) -> Result<Self, SetupError> {
         match config {
-            Config::Pipeline(config) => Self::load_pipeline(config),
+            Config::Pipeline(config) => config.load(),
             Config::Sagemaker(config) => config.load().await,
         }
-    }
-
-    fn load_pipeline(config: &Pipeline) -> Result<Self, SetupError> {
-        let config = EmbedderConfig::new(config.directory.relative())?
-            .with_token_size(config.token_size)?
-            .with_pooler();
-        config.validate()?;
-        let embedder = config.build()?;
-
-        Ok(Self::Pipeline(embedder))
     }
 
     pub(crate) async fn run(&self, sequence: &str) -> Result<NormalizedEmbedding, InternalError> {

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -63,7 +63,7 @@ impl Default for Pipeline {
 impl Pipeline {
     fn load(&self) -> Result<Embedder, SetupError> {
         let config = EmbedderConfig::new(self.directory.relative())?
-            .with_runtime(self.runtime)
+            .with_runtime(self.runtime.clone())
             .with_token_size(self.token_size)?
             .with_pooler();
         config.validate()?;

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -14,7 +14,7 @@
 
 use aws_config::retry::RetryConfig;
 use aws_sdk_sagemakerruntime::{config::Region, primitives::Blob, Client};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding, Runtime};
 
@@ -36,18 +36,10 @@ impl Default for Config {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Pipeline {
-    #[serde(deserialize_with = "deserialize_relative_path_buf")]
+    #[serde(deserialize_with = "RelativePathBuf::deserialize_string")]
     pub(crate) directory: RelativePathBuf,
     pub(crate) token_size: usize,
     pub(crate) runtime: Runtime,
-}
-
-fn deserialize_relative_path_buf<'de, D>(deserializer: D) -> Result<RelativePathBuf, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let buf = String::deserialize(deserializer)?;
-    Ok(RelativePathBuf::from(buf))
 }
 
 impl Default for Pipeline {

--- a/web-api/tests/cmd/assets/config.toml
+++ b/web-api/tests/cmd/assets/config.toml
@@ -20,3 +20,7 @@ application_name = "the-application"
 
 [ingestion]
 max_document_batch_size = 999999
+
+[embedding]
+type = "pipeline"
+directory = "assets/model"

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -53,7 +53,7 @@ stdout = """
   },
   "embedding": {
     "type": "pipeline",
-    "directory": "assets",
+    "directory": "assets/model",
     "token_size": 250,
     "runtime": "assets"
   },

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -49,7 +49,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "personalization": {
     "max_number_documents": 100,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -50,7 +50,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "personalization": {
     "max_number_documents": 100,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -50,7 +50,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "personalization": {
     "max_number_documents": 100,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -53,7 +53,7 @@ stdout = """
   },
   "embedding": {
     "type": "pipeline",
-    "directory": "assets",
+    "directory": "assets/model",
     "token_size": 250,
     "runtime": "assets"
   },

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -53,7 +53,7 @@ stdout = """
   },
   "embedding": {
     "type": "pipeline",
-    "directory": "assets",
+    "directory": "assets/model",
     "token_size": 250,
     "runtime": "assets"
   },

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -53,7 +53,7 @@ stdout = """
   },
   "embedding": {
     "type": "pipeline",
-    "directory": "assets",
+    "directory": "assets/model",
     "token_size": 250,
     "runtime": "assets"
   },

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -54,7 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "runtime_kind": "Tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime": "tract"
+    "runtime": "assets"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -55,7 +55,7 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "token_size": 250,
-    "runtime_kind": "Tract"
+    "runtime": "tract"
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -12,12 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-    collections::HashMap,
-    env,
-    ffi::{OsStr, OsString},
-    sync::Mutex,
-};
+use std::{env, ffi::OsStr, sync::Mutex};
 
 use trycmd::TestCases;
 
@@ -45,8 +40,8 @@ fn with_env_guard(
     drop(guard)
 }
 
-fn no_env() -> HashMap<OsString, OsString> {
-    HashMap::new()
+const fn no_env() -> [(&'static str, &'static str); 0] {
+    []
 }
 
 #[test]

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -34,7 +34,7 @@ use xayn_integration_tests::{
     MANAGEMENT_DB,
     TEST_EMBEDDING_SIZE,
 };
-use xayn_test_utils::env::clear_env;
+use xayn_test_utils::{asset::ort_target, env::clear_env};
 use xayn_web_api::{config, start, Ingestion, Personalization};
 use xayn_web_api_db_ctrl::{elastic_create_tenant, LegacyTenantInfo, Silo};
 use xayn_web_api_shared::{
@@ -185,7 +185,7 @@ fn test_full_migration() {
             &es_config,
             Table::new(),
             "smbert_v0003",
-            "ort_v1.15.1",
+            &format!("ort_v1.15.1/{}", ort_target().unwrap()),
         );
 
         info!("test setup done");
@@ -290,7 +290,7 @@ fn test_full_migration() {
             &es_config,
             Table::new(),
             "smbert_v0004",
-            "ort_v1.15.1",
+            &format!("ort_v1.15.1/{}", ort_target().unwrap()),
         );
         let args = &[
             "integration-test",

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -23,7 +23,7 @@ use sqlx::{Connection, Executor, PgConnection};
 use toml::Table;
 use tracing::{info, instrument};
 use xayn_integration_tests::{
-    build_test_config_from_parts_and_model,
+    build_test_config_from_parts_and_names,
     create_db,
     db_configs_for_testing,
     run_async_test,
@@ -180,11 +180,12 @@ fn test_full_migration() {
         info!("entered async test");
 
         let (pg_config, es_config) = legacy_test_setup(&test_id).await?;
-        let config = build_test_config_from_parts_and_model(
+        let config = build_test_config_from_parts_and_names(
             &pg_config,
             &es_config,
             Table::new(),
             "smbert_v0003",
+            "ort_v1.15.1",
         );
 
         info!("test setup done");
@@ -284,11 +285,12 @@ fn test_full_migration() {
             .await?;
         conn.close().await?;
 
-        let config = build_test_config_from_parts_and_model(
+        let config = build_test_config_from_parts_and_names(
             &pg_config,
             &es_config,
             Table::new(),
             "smbert_v0004",
+            "ort_v1.15.1",
         );
         let args = &[
             "integration-test",


### PR DESCRIPTION
**Reference**

- [ET-4300]
- [ET-4912]
- [ET-4301]
- followed by #1066

**Summary**

Initial support for ort to compute the embeddings.
It can be selected with an option.
Some data structure it is converted to the tract one to avoid changing too much.

To deploy it, some changes can be needed in a follow-up.

Once we have ort working and deployed, we can remove tract.

- currently the onnxruntime lib is added to the assets bucket, probably will be added to the ci image later (but no gpu lib yet)
- integration tests already run with onnxruntime instead of tract
- engine defaults run with onnxruntime
- webservice build also copies onnxruntime files
- update the benchmark, the results are in [ET-4301]
- image builds successfully: https://github.com/xaynetwork/xayn_discovery_engine/actions/runs/5857592118

[ET-4300]: https://xainag.atlassian.net/browse/ET-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-4912]: https://xainag.atlassian.net/browse/ET-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-4301]: https://xainag.atlassian.net/browse/ET-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4301]: https://xainag.atlassian.net/browse/ET-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ