### PR TITLE
ET-4923 multi split support in postgres [6/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,6 +3058,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ba7066011e3fb30d808b51affff34f0a66d3a03a58edd787c6e420e40e44e"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4670,6 +4680,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror",
  "tokio",

--- a/web-api-db-ctrl/elasticsearch/mapping.json
+++ b/web-api-db-ctrl/elasticsearch/mapping.json
@@ -14,6 +14,9 @@
             "tags": {
                 "type": "keyword"
             },
+            "parent": {
+                "type": "keyword"
+            },
             "properties": {
                 "dynamic": false,
                 "properties": {

--- a/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
@@ -25,5 +25,7 @@ CREATE TABLE snippet (
 INSERT INTO snippet(document_id, sub_id, snippet, embedding)
     SELECT document_id, 0, snippet, embedding FROM document;
 
-ALTER TABLE document RENAME COLUMN snippet TO original;
+ALTER TABLE document ALTER COLUMN snippet TYPE BYTEA USING sha256(snippet::bytea);
+ALTER TABLE document RENAME COLUMN snippet TO original_sha256;
+
 ALTER TABLE document DROP COLUMN embedding;

--- a/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
@@ -1,0 +1,29 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+CREATE TABLE snippet (
+    document_id TEXT NOT NULL
+        REFERENCES document(document_id) ON DELETE CASCADE,
+    sub_id INTEGER NOT NULL,
+    snippet TEXT NOT NULL,
+    embedding FLOAT4[] NOT NULL,
+
+    PRIMARY KEY (document_id, sub_id)
+);
+
+INSERT INTO snippet(document_id, sub_id, snippet, embedding)
+    SELECT document_id, 0, snippet, embedding FROM document;
+
+ALTER TABLE document RENAME COLUMN snippet TO raw_document;
+ALTER TABLE document DROP COLUMN embedding;

--- a/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
@@ -25,5 +25,5 @@ CREATE TABLE snippet (
 INSERT INTO snippet(document_id, sub_id, snippet, embedding)
     SELECT document_id, 0, snippet, embedding FROM document;
 
-ALTER TABLE document RENAME COLUMN snippet TO raw_document;
+ALTER TABLE document RENAME COLUMN snippet TO original;
 ALTER TABLE document DROP COLUMN embedding;

--- a/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
@@ -19,4 +19,4 @@ ALTER TABLE interaction
     ADD COLUMN snippet_idx INTEGER NOT NULL DEFAULT 0,
     DROP CONSTRAINT interaction_pkey,
     ADD PRIMARY KEY (document_id, snippet_idx, user_id, time_stamp),
-    ADD FOREIGN KEY (document_id, snippet_idx) REFERENCES snippet(document_id, snippet_idx);
+    ADD FOREIGN KEY (document_id, snippet_idx) REFERENCES snippet(document_id, snippet_idx) ON DELETE CASCADE;

--- a/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
@@ -16,7 +16,7 @@ ALTER TABLE interaction
     RENAME COLUMN doc_id TO document_id;
 
 ALTER TABLE interaction
-    ADD COLUMN snippet_idx INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN sub_id INTEGER NOT NULL DEFAULT 0,
     DROP CONSTRAINT interaction_pkey,
-    ADD PRIMARY KEY (document_id, snippet_idx, user_id, time_stamp),
-    ADD FOREIGN KEY (document_id, snippet_idx) REFERENCES snippet(document_id, snippet_idx) ON DELETE CASCADE;
+    ADD PRIMARY KEY (document_id, sub_id, user_id, time_stamp),
+    ADD FOREIGN KEY (document_id, sub_id) REFERENCES snippet(document_id, sub_id) ON DELETE CASCADE;

--- a/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230807103000_interaction.sql
@@ -1,0 +1,22 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ALTER TABLE interaction
+    RENAME COLUMN doc_id TO document_id;
+
+ALTER TABLE interaction
+    ADD COLUMN snippet_idx INTEGER NOT NULL DEFAULT 0,
+    DROP CONSTRAINT interaction_pkey,
+    ADD PRIMARY KEY (document_id, snippet_idx, user_id, time_stamp),
+    ADD FOREIGN KEY (document_id, snippet_idx) REFERENCES snippet(document_id, snippet_idx);

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -31,6 +31,7 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { version = "0.10.7", features = ["asm"] }
 sqlx = { workspace = true, features = ["chrono", "uuid"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/web-api/src/ingestion/preprocess.rs
+++ b/web-api/src/ingestion/preprocess.rs
@@ -21,27 +21,27 @@ use crate::{
     Error,
 };
 
-pub(super) type DocumentContent = (DocumentSnippet, NormalizedEmbedding);
+pub(super) type DocumentContent = Vec<(DocumentSnippet, NormalizedEmbedding)>;
 
 pub(super) fn preprocess_document(
     embedder: &Embedder,
-    raw_text: DocumentSnippet,
+    raw_document: &DocumentSnippet,
     preprocessing_step: PreprocessingStep,
 ) -> Result<DocumentContent, Error> {
     Ok(match preprocessing_step {
-        PreprocessingStep::None => embed_whole(embedder, raw_text)?,
-        PreprocessingStep::Summarize => embed_with_summarizer(embedder, raw_text)?,
+        PreprocessingStep::None => embed_whole(embedder, raw_document)?,
+        PreprocessingStep::Summarize => embed_with_summarizer(embedder, raw_document)?,
     })
 }
 
-fn embed_whole(embedder: &Embedder, snippet: DocumentSnippet) -> Result<DocumentContent, Error> {
-    let embedding = embedder.run(&snippet)?;
-    Ok((snippet, embedding))
+fn embed_whole(embedder: &Embedder, snippet: &DocumentSnippet) -> Result<DocumentContent, Error> {
+    let embedding = embedder.run(snippet)?;
+    Ok(vec![(snippet.clone(), embedding)])
 }
 
 fn embed_with_summarizer(
     embedder: &Embedder,
-    snippet: DocumentSnippet,
+    snippet: &DocumentSnippet,
 ) -> Result<DocumentContent, Error> {
     let summary = summarize(
         &Summarizer::Naive,
@@ -51,5 +51,5 @@ fn embed_with_summarizer(
         &Config::default(),
     );
     let embedding = embedder.run(&summary)?;
-    Ok((snippet, embedding))
+    Ok(vec![(snippet.clone(), embedding)])
 }

--- a/web-api/src/ingestion/preprocess.rs
+++ b/web-api/src/ingestion/preprocess.rs
@@ -22,7 +22,7 @@ use crate::{
 
 pub(super) fn preprocess_document(
     embedder: &Embedder,
-    original: &DocumentSnippet,
+    original: DocumentSnippet,
     preprocessing_step: PreprocessingStep,
 ) -> Result<Vec<DocumentContent>, Error> {
     Ok(match preprocessing_step {
@@ -33,18 +33,15 @@ pub(super) fn preprocess_document(
 
 fn embed_whole(
     embedder: &Embedder,
-    snippet: &DocumentSnippet,
+    snippet: DocumentSnippet,
 ) -> Result<Vec<DocumentContent>, Error> {
-    let embedding = embedder.run(snippet)?;
-    Ok(vec![DocumentContent {
-        snippet: snippet.clone(),
-        embedding,
-    }])
+    let embedding = embedder.run(&snippet)?;
+    Ok(vec![DocumentContent { snippet, embedding }])
 }
 
 fn embed_with_summarizer(
     embedder: &Embedder,
-    snippet: &DocumentSnippet,
+    snippet: DocumentSnippet,
 ) -> Result<Vec<DocumentContent>, Error> {
     let summary = summarize(
         &Summarizer::Naive,
@@ -55,7 +52,9 @@ fn embed_with_summarizer(
     );
     let embedding = embedder.run(&summary)?;
     Ok(vec![DocumentContent {
-        snippet: snippet.clone(),
+        // Hint: Yes we do not use the summary, this is so that keyword/text search
+        //       can use the original text.
+        snippet,
         embedding,
     }])
 }

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -23,9 +23,9 @@ use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
     models::{
+        DocumentForIngestion,
         DocumentId,
         DocumentProperties,
-        IngestedDocument,
         PreprocessingStep,
         SnippetOrDocumentId,
         UserId,
@@ -75,13 +75,13 @@ impl State {
             .into_iter()
             .map(|document| {
                 let embedding = self.embedder.run(&document.snippet)?;
-                Ok(IngestedDocument {
+                Ok(DocumentForIngestion {
                     id: document.id,
-                    snippet: document.snippet,
+                    raw_document: document.snippet.as_str().to_owned(),
+                    snippets: vec![(document.snippet, embedding)],
                     preprocessing_step: PreprocessingStep::None,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,
-                    embedding,
                     is_candidate: true,
                 })
             })

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -23,6 +23,7 @@ use crate::{
     embedding::{self, Embedder},
     mind::{config::StateConfig, data::Document},
     models::{
+        DocumentContent,
         DocumentForIngestion,
         DocumentId,
         DocumentProperties,
@@ -77,8 +78,11 @@ impl State {
                 let embedding = self.embedder.run(&document.snippet)?;
                 Ok(DocumentForIngestion {
                     id: document.id,
-                    raw_document: document.snippet.as_str().to_owned(),
-                    snippets: vec![(document.snippet, embedding)],
+                    original: document.snippet.as_str().to_owned(),
+                    snippets: vec![DocumentContent {
+                        snippet: document.snippet,
+                        embedding,
+                    }],
                     preprocessing_step: PreprocessingStep::None,
                     properties: DocumentProperties::default(),
                     tags: vec![document.category, document.subcategory].try_into()?,

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -28,6 +28,7 @@ use crate::{
         DocumentId,
         DocumentProperties,
         PreprocessingStep,
+        Sha256Hash,
         SnippetOrDocumentId,
         UserId,
     },
@@ -78,7 +79,7 @@ impl State {
                 let embedding = self.embedder.run(&document.snippet)?;
                 Ok(DocumentForIngestion {
                     id: document.id,
-                    original: document.snippet.as_str().to_owned(),
+                    original_sha256: Sha256Hash::calculate(document.snippet.as_bytes()),
                     snippets: vec![DocumentContent {
                         snippet: document.snippet,
                         embedding,

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -246,9 +246,9 @@ impl SnippetOrDocumentId {
         }
     }
 
-    pub(crate) fn snippet_idx(&self) -> Option<u32> {
+    pub(crate) fn sub_id(&self) -> Option<u32> {
         match self {
-            SnippetOrDocumentId::SnippetId(id) => Some(id.snippet_idx()),
+            SnippetOrDocumentId::SnippetId(id) => Some(id.sub_id()),
             SnippetOrDocumentId::DocumentId(_) => None,
         }
     }
@@ -418,16 +418,11 @@ impl<'a> IntoIterator for &'a DocumentTags {
         self.0.iter()
     }
 }
-/// Represents a result from an interaction query.
+
 #[derive(Clone, Debug)]
 pub(crate) struct SnippetForInteraction {
-    /// Unique identifier of the document.
     pub(crate) id: SnippetId,
-
-    /// Embedding from smbert.
     pub(crate) embedding: NormalizedEmbedding,
-
-    /// The tags associated to the document.
     pub(crate) tags: DocumentTags,
 }
 
@@ -476,10 +471,10 @@ pub(crate) struct DocumentForIngestion {
     pub(crate) id: DocumentId,
 
     /// The raw document provided by the client.
-    pub(crate) raw_document: String,
+    pub(crate) original: String,
 
     /// Snippet used to calculate embeddings for a document.
-    pub(crate) snippets: Vec<(DocumentSnippet, NormalizedEmbedding)>,
+    pub(crate) snippets: Vec<DocumentContent>,
 
     /// Method used to preprocess the document before ingestion.
     pub(crate) preprocessing_step: PreprocessingStep,
@@ -494,10 +489,16 @@ pub(crate) struct DocumentForIngestion {
     pub(crate) is_candidate: bool,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct DocumentContent {
+    pub(crate) snippet: DocumentSnippet,
+    pub(crate) embedding: NormalizedEmbedding,
+}
+
 #[derive(Debug)]
 pub(crate) struct ExcerptedDocument {
     pub(crate) id: DocumentId,
-    pub(crate) raw_document: String,
+    pub(crate) original: String,
     pub(crate) preprocessing_step: PreprocessingStep,
     pub(crate) properties: DocumentProperties,
     pub(crate) tags: DocumentTags,

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -73,8 +73,8 @@ pub(super) fn validate_history(
             let timestamp = unchecked.timestamp.unwrap_or(most_recent_time);
             if timestamp > most_recent_time {
                 let document_id = id.document_id();
-                let snippet_idx = id.snippet_idx();
-                warnings.push(format!("inconsistent history ordering around document {document_id} snippet {snippet_idx:?}").into());
+                let sub_id = id.sub_id();
+                warnings.push(format!("inconsistent history ordering around document {document_id} snippet {sub_id:?}").into());
             }
             most_recent_time = timestamp;
             Ok(HistoryEntry { id, timestamp })
@@ -110,9 +110,7 @@ pub(super) async fn load_history(
         })
         .collect::<HashMap<_, _>>();
 
-    let loaded = storage::Document::get_snippets_for_interaction(storage, history.keys())
-        .await?
-        .into_iter();
+    let loaded = storage::Document::get_snippets_for_interaction(storage, history.keys()).await?;
 
     Ok(loaded
         .into_iter()
@@ -122,6 +120,7 @@ pub(super) async fn load_history(
                  embedding,
                  tags,
              }| {
+                // loaded ⊆ history
                 let timestamp = history[&id];
                 LoadedHistoryEntry {
                     timestamp,
@@ -245,7 +244,7 @@ mod tests {
         assert_eq!(
             documents,
             vec![HistoryEntry {
-                id: SnippetOrDocumentId::DocumentId("doc-2".try_into()?),
+                id: doc_id("doc-2"),
                 timestamp: now - Duration::days(1)
             }]
         );

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use xayn_ai_bert::NormalizedEmbedding;
 use xayn_ai_coi::{Coi, CoiSystem};
 
-use super::{routes::UnvalidatedDocumentOrSnippetId, PersonalizationConfig};
+use super::{routes::UnvalidatedSnippetOrDocumentId, PersonalizationConfig};
 use crate::{
     error::{common::HistoryTooSmall, warning::Warning},
     models::{DocumentTags, SnippetForInteraction, SnippetId, SnippetOrDocumentId},
@@ -31,7 +31,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct UnvalidatedHistoryEntry {
-    id: UnvalidatedDocumentOrSnippetId,
+    id: UnvalidatedSnippetOrDocumentId,
     #[serde(default)]
     timestamp: Option<DateTime<Utc>>,
 }
@@ -195,8 +195,8 @@ mod tests {
         assert!(warnings.is_empty());
     }
 
-    fn unvalidated_doc_id(id: &str) -> UnvalidatedDocumentOrSnippetId {
-        UnvalidatedDocumentOrSnippetId::DocumentId(id.to_owned())
+    fn unvalidated_doc_id(id: &str) -> UnvalidatedSnippetOrDocumentId {
+        UnvalidatedSnippetOrDocumentId::DocumentId(id.to_owned())
     }
 
     fn doc_id(id: &str) -> SnippetOrDocumentId {

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -164,10 +164,10 @@ impl Client {
                     serde_json::to_value(BulkInstruction::Index { id: &document.id }),
                     serde_json::to_value(IngestedDocument {
                         // TODO[pmk/ET-4756-7]
-                        snippet: &document.snippets[0].0,
+                        snippet: &document.snippets[0].snippet,
                         properties: &document.properties,
                         // TODO[pmk/ET-4756-7]
-                        embedding: &document.snippets[0].1,
+                        embedding: &document.snippets[0].embedding,
                         tags: &document.tags,
                     }),
                 ]

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -150,7 +150,7 @@ impl Client {
     pub(super) async fn insert_documents(
         &self,
         documents: impl IntoIterator<
-            IntoIter = impl ExactSizeIterator<Item = &models::IngestedDocument>,
+            IntoIter = impl ExactSizeIterator<Item = &models::DocumentForIngestion>,
         >,
     ) -> Result<Warning<DocumentId>, Error> {
         let documents = documents.into_iter();
@@ -163,9 +163,11 @@ impl Client {
                 [
                     serde_json::to_value(BulkInstruction::Index { id: &document.id }),
                     serde_json::to_value(IngestedDocument {
-                        snippet: &document.snippet,
+                        // TODO[pmk/ET-4756-7]
+                        snippet: &document.snippets[0].0,
                         properties: &document.properties,
-                        embedding: &document.embedding,
+                        // TODO[pmk/ET-4756-7]
+                        embedding: &document.snippets[0].1,
                         tags: &document.tags,
                     }),
                 ]

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -28,6 +28,7 @@ use bincode::{deserialize, serialize};
 use chrono::{DateTime, Utc};
 use derive_more::{AsRef, Deref};
 use instant_distance::{Builder as HnswBuilder, HnswMap, Point, Search};
+use itertools::Itertools;
 use ouroboros::self_referencing;
 use serde::{de, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::RwLock;
@@ -41,6 +42,7 @@ use crate::{
         common::{DocumentNotFound, DocumentPropertyNotFound},
     },
     models::{
+        DocumentForIngestion,
         DocumentId,
         DocumentProperties,
         DocumentProperty,
@@ -49,10 +51,9 @@ use crate::{
         DocumentTag,
         DocumentTags,
         ExcerptedDocument,
-        IngestedDocument,
-        InteractedDocument,
         PersonalizedDocument,
         PreprocessingStep,
+        SnippetForInteraction,
         SnippetId,
         SnippetOrDocumentId,
         UserId,
@@ -235,20 +236,21 @@ pub(crate) struct Storage {
 
 #[async_trait(?Send)]
 impl storage::Document for Storage {
-    async fn get_interacted(
+    async fn get_snippets_for_interaction(
         &self,
-        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &DocumentId>>,
-    ) -> Result<Vec<InteractedDocument>, Error> {
+        ids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = &SnippetId>>,
+    ) -> Result<Vec<SnippetForInteraction>, Error> {
         let documents = self.documents.read().await;
         let documents = ids
             .into_iter()
             .filter_map(|id| {
-                documents.0.get(id).and_then(|document| {
+                assert_eq!(id.snippet_idx(), 0);
+                documents.0.get(id.document_id()).and_then(|document| {
                     documents
                         .1
                         .borrow_map()
-                        .get(id)
-                        .map(|embedding| InteractedDocument {
+                        .get(id.document_id())
+                        .map(|embedding| SnippetForInteraction {
                             id: id.clone(),
                             embedding: embedding.clone(),
                             tags: document.tags.clone(),
@@ -300,7 +302,7 @@ impl storage::Document for Storage {
             .filter_map(|id| {
                 documents.0.get(id).map(|document| ExcerptedDocument {
                     id: id.clone(),
-                    snippet: document.snippet.clone(),
+                    raw_document: document.snippet.as_str().to_owned(),
                     preprocessing_step: document.preprocessing_step,
                     properties: document.properties.clone(),
                     tags: document.tags.clone(),
@@ -365,7 +367,7 @@ impl storage::Document for Storage {
 
     async fn insert(
         &self,
-        new_documents: Vec<IngestedDocument>,
+        new_documents: Vec<DocumentForIngestion>,
     ) -> Result<Warning<DocumentId>, Error> {
         if new_documents.is_empty() {
             return Ok(Warning::default());
@@ -374,18 +376,20 @@ impl storage::Document for Storage {
         let mut documents = self.documents.write().await;
         let mut embeddings = mem::take(&mut documents.1).into_heads().map;
         documents.0.reserve(new_documents.len());
-        for document in new_documents {
+        for mut document in new_documents {
+            assert_eq!(document.snippets.len(), 1);
+            let (snippet, embedding) = document.snippets.pop().unwrap();
             documents.0.insert(
                 document.id.clone(),
                 Document {
-                    snippet: document.snippet,
+                    snippet,
                     preprocessing_step: document.preprocessing_step,
                     properties: document.properties,
                     tags: document.tags,
                     is_candidate: document.is_candidate,
                 },
             );
-            embeddings.insert(document.id, document.embedding);
+            embeddings.insert(document.id, embedding);
         }
         documents.1 = Embeddings::borrowed(embeddings);
 
@@ -630,13 +634,18 @@ impl storage::Interaction for Storage {
         time: DateTime<Utc>,
         mut update_logic: impl for<'a, 'b> FnMut(InteractionUpdateContext<'a, 'b>) -> Coi,
     ) -> Result<(), Error> {
-        // TODO[pmk/ET-4756-5] properly support snippet id
-        let interactions = interactions.iter().map(|id| match id {
-            SnippetOrDocumentId::DocumentId(id) => id,
-            SnippetOrDocumentId::SnippetId(id) => id.document_id(),
-        });
+        // TODO[pmk/soon] properly support reactions to multi-snippet document
+        let interactions = interactions
+            .into_iter()
+            .map(|id| match id {
+                SnippetOrDocumentId::SnippetId(id) => id,
+                SnippetOrDocumentId::DocumentId(id) => SnippetId::new(id, 0),
+            })
+            .collect_vec();
         // Note: This doesn't has the exact same concurrency semantics as the postgres version
-        let documents = self.get_interacted(interactions).await?;
+        let documents = self
+            .get_snippets_for_interaction(interactions.iter())
+            .await?;
         let mut interests = self.interests.write().await;
         let mut interactions = self.interactions.write().await;
         let interactions = interactions.entry(user_id.clone()).or_default();
@@ -659,7 +668,7 @@ impl storage::Interaction for Storage {
                 time,
             });
             if store_user_history {
-                interactions.insert((document.id.clone(), updated.stats.last_view));
+                interactions.insert((document.id.document_id().clone(), updated.stats.last_view));
             }
         }
 
@@ -742,13 +751,13 @@ mod tests {
         let documents = ids
             .iter()
             .zip(embeddings)
-            .map(|(id, embedding)| IngestedDocument {
+            .map(|(id, embedding)| DocumentForIngestion {
                 id: id.document_id().clone(),
-                snippet: DocumentSnippet::new("snippet", 100).unwrap(),
+                raw_document: "snippet".into(),
+                snippets: vec![(DocumentSnippet::new("snippet", 100).unwrap(), embedding)],
                 preprocessing_step: PreprocessingStep::None,
                 properties: DocumentProperties::default(),
                 tags: DocumentTags::default(),
-                embedding,
                 is_candidate: true,
             })
             .collect_vec();
@@ -811,13 +820,13 @@ mod tests {
         let embedding = NormalizedEmbedding::try_from([1., 2., 3.]).unwrap();
         storage::Document::insert(
             &storage,
-            vec![IngestedDocument {
+            vec![DocumentForIngestion {
                 id: doc_id.document_id().clone(),
-                snippet: snippet.clone(),
+                raw_document: snippet.as_str().to_owned(),
+                snippets: vec![(snippet.clone(), embedding.clone())],
                 preprocessing_step: PreprocessingStep::None,
                 properties: DocumentProperties::default(),
                 tags: tags.clone(),
-                embedding: embedding.clone(),
                 is_candidate: true,
             }],
         )
@@ -852,7 +861,7 @@ mod tests {
             .unwrap();
         assert_eq!(documents.len(), 1);
         assert_eq!(&documents[0].id, doc_id.document_id());
-        assert_eq!(documents[0].snippet, snippet);
+        assert_eq!(documents[0].raw_document, snippet.as_str());
         let documents = storage::Document::get_personalized(&storage, [&doc_id], true, true)
             .await
             .unwrap();


### PR DESCRIPTION
Add support for multi-snippet documents in postgres (and only there).

- support for interacting with multi-snippet document is still only semi-supported as there are a bunch of open questions currently it will convert all "interacted with document id" occurrences with "interacted with first snippet of document" but also for search exclusions "exclude all documents with any interaction" 
- memory/mind db are still assuming single snippet documents, changing this would require rewriting huge portions of the memory impl.

**References:**

- story: [ET-4755]
- issue: [ET-4756]
- based on #1055 

[ET-4755]: https://xainag.atlassian.net/browse/ET-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4756]: https://xainag.atlassian.net/browse/ET-4756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ