### PR TITLE
ET-4925 support document splitting using cutters [8/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cutters"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd442446f9accd59a61a2a7d94dc61cffabebe2d1562392825d8780a8ccf9d0"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,9 +2419,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2419,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2429,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2442,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.1"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
@@ -4662,6 +4672,7 @@ dependencies = [
  "const_format",
  "criterion",
  "csv",
+ "cutters",
  "derive_more",
  "displaydoc",
  "dotenvy",

--- a/web-api-db-ctrl/postgres/tenant/20230807104500_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230807104500_document.sql
@@ -1,0 +1,15 @@
+-- Copyright 2023 Xayn AG
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, version 3.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ALTER TYPE preprocessing_step ADD VALUE 'cutters_split' AFTER 'summarize';

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 clap = { version = "4.3.4", features = ["derive"] }
 const_format = "0.2.31"
 csv = { workspace = true }
+cutters = "0.1.4"
 derive_more = { workspace = true }
 displaydoc = { workspace = true }
 dotenvy = "0.15.7"

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -146,6 +146,7 @@ pub(crate) struct InvalidDocumentTags {
 impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 
 #[derive(Debug, Error, Display, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidDocumentSnippet {
     /// Malformed document snippet: {0}
     InvalidString(InvalidString),

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -145,10 +145,13 @@ pub(crate) struct InvalidDocumentTags {
 
 impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 
-/// Malformed document snippet: {0}
 #[derive(Debug, Error, Display, Serialize)]
-#[serde(transparent)]
-pub(crate) struct InvalidDocumentSnippet(pub(crate) InvalidString);
+pub(crate) enum InvalidDocumentSnippet {
+    /// Malformed document snippet: {0}
+    InvalidString(InvalidString),
+    /// Input document didn't yield any snippets
+    NoSnippets {},
+}
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);
 

--- a/web-api/src/ingestion/preprocess.rs
+++ b/web-api/src/ingestion/preprocess.rs
@@ -30,7 +30,7 @@ pub(super) fn preprocess_document(
     Ok(match preprocessing_step {
         PreprocessingStep::None => embed_whole(embedder, original)?,
         PreprocessingStep::Summarize => embed_with_summarizer(embedder, original)?,
-        PreprocessingStep::CuttersSplit => embed_with_cutters(embedder, original)?,
+        PreprocessingStep::CuttersSplit => embed_with_cutters(embedder, &original)?,
     })
 }
 

--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -269,7 +269,7 @@ impl DocumentSnippet {
         trim(&mut value);
 
         validate_string(&value, 1..=max_size, &GENERIC_STRING_SYNTAX)
-            .map_err(InvalidDocumentSnippet)?;
+            .map_err(InvalidDocumentSnippet::InvalidString)?;
 
         Ok(Self(value))
     }
@@ -522,12 +522,19 @@ pub(crate) struct ExcerptedDocument {
     pub(crate) is_candidate: bool,
 }
 
+/// The preprocessing step used on the raw document.
+// Note: The same input parameter (e.g. split) can over time
+//       map to different variants, e.g. now it maps to `CuttersSplit`
+//       but in the future it will map to different splits.
+//       This matters for deciding if in case of reingestion we should
+//       reprocess the document even if the raw document didn't change.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "snake_case")]
 #[sqlx(type_name = "preprocessing_step", rename_all = "snake_case")]
 pub(crate) enum PreprocessingStep {
     None,
     Summarize,
+    CuttersSplit,
 }
 
 #[cfg(test)]

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -157,10 +157,12 @@ fn test_ingestion_bad_request() {
             json!({
                 "kind": "InvalidDocumentSnippet" ,
                 "details": {
-                    "size": {
-                        "got": 2049,
-                        "min": 1,
-                        "max": 2048,
+                    "invalid_string": {
+                        "size": {
+                            "got": 2049,
+                            "min": 1,
+                            "max": 2048,
+                        }
                     }
                 }
             })
@@ -427,8 +429,10 @@ fn test_ingestion_validation() {
                     "id": "d1",
                     "kind": "InvalidDocumentSnippet",
                     "details": {
-                        "syntax": {
-                            "expected": "^[^\\x00]*$"
+                        "invalid_string": {
+                            "syntax": {
+                                "expected": "^[^\\x00]*$"
+                            }
                         }
                     }
                 })]),
@@ -455,10 +459,12 @@ fn test_ingestion_validation() {
                     "id": "d1",
                     "kind": "InvalidDocumentSnippet",
                     "details": {
-                        "size": {
-                            "got": 11,
-                            "min": 1,
-                            "max": 10
+                        "invalid_string": {
+                            "size": {
+                                "got": 11,
+                                "min": 1,
+                                "max": 10
+                            }
                         }
                     }
                 })]),

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -1,0 +1,502 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use anyhow::Error;
+use itertools::Itertools;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use url::Url;
+use xayn_integration_tests::{
+    send_assert,
+    send_assert_json,
+    test_two_apps,
+    with_dev_options,
+    UNCHANGED_CONFIG,
+};
+use xayn_web_api::{Ingestion, Personalization};
+
+#[derive(Debug, Deserialize)]
+struct PersonalizedDocumentData {
+    id: String,
+    snippet_id: SnippetId,
+    score: f32,
+    // included by test only dev option
+    #[serde(default)]
+    snippet: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnippetId {
+    document_id: String,
+    snippet_idx: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    documents: Vec<PersonalizedDocumentData>,
+}
+
+impl SearchResponse {
+    fn id_ranking(&self) -> Vec<(&str, u32)> {
+        self.documents
+            .iter()
+            .map(|document| {
+                (
+                    &*document.snippet_id.document_id,
+                    document.snippet_id.snippet_idx,
+                )
+            })
+            .collect_vec()
+    }
+
+    fn sanity_checks(&self) {
+        let ordered = self
+            .documents
+            .iter()
+            .zip(self.documents.iter().skip(1))
+            .all(|(first, second)| first.score > second.score);
+        assert!(
+            ordered,
+            "expects documents to be ordered by score (desc): {:?}",
+            self.documents
+        );
+
+        for document in &self.documents {
+            assert_eq!(&document.id, &document.snippet_id.document_id);
+        }
+    }
+}
+
+async fn query(
+    client: &Client,
+    personalization_url: &Url,
+    text: &str,
+    count: usize,
+    filter: Option<Value>,
+) -> Result<SearchResponse, Error> {
+    let res = send_assert_json::<SearchResponse>(
+        client,
+        client
+            .post(personalization_url.join("/semantic_search")?)
+            .json(&json!({
+                "document": { "query": text },
+                "count": count,
+                "filter": filter,
+                "_dev": { "include_snippet": true }
+            }))
+            .build()?,
+        StatusCode::OK,
+        false,
+    )
+    .await;
+
+    res.sanity_checks();
+
+    Ok(res)
+}
+
+async fn set_candidates(client: &Client, ingestion_url: &Url, ids: &[&str]) -> Result<(), Error> {
+    let ids = ids.iter().map(|id| json!({ "id": id })).collect_vec();
+    send_assert(
+        client,
+        client
+            .put(ingestion_url.join("/documents/_candidates")?)
+            .json(&json!({ "documents": ids }))
+            .build()?,
+        StatusCode::NO_CONTENT,
+        false,
+    )
+    .await;
+    Ok(())
+}
+
+async fn get_properties(
+    client: &Client,
+    ingestion_url: &Url,
+    id: &str,
+) -> Result<Map<String, Value>, Error> {
+    let mut url = ingestion_url.clone();
+    url.path_segments_mut()
+        .unwrap()
+        .extend(["documents", id, "properties"]);
+
+    #[derive(Deserialize)]
+    struct Response {
+        properties: Map<String, Value>,
+    }
+
+    Ok(
+        send_assert_json::<Response>(client, client.get(url).build()?, StatusCode::OK, false)
+            .await
+            .properties,
+    )
+}
+
+fn json_map(
+    pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<Value>)>,
+) -> Map<String, Value> {
+    pairs
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect()
+}
+
+async fn ingest(client: &Client, ingestion_url: &Url) -> Result<(), Error> {
+    send_assert(
+        client,
+        client
+            .post(ingestion_url.join("/documents")?)
+            .json(&json!({
+                "documents": [
+                    {
+                        "id": "d1",
+                        "snippet": "The duck is blue. The truck is yellow. But birds are birds.",
+                        "split": true,
+                        "properties": {
+                            "foo": "filter-a",
+                        }
+                    },
+                    {
+                        "id": "d2",
+                        "snippet": "Cars with wheels. This is a blue sentence. Trains on tracks.",
+                        "split": true,
+                        "properties": {
+                            "foo": "filter-a",
+                        }
+                    },
+                ]
+            }))
+            .build()?,
+        StatusCode::CREATED,
+        false,
+    )
+    .await;
+
+    Ok(())
+}
+
+#[test]
+fn test_split_documents_for_semantic_search() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        with_dev_options(),
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, count| query(&client, &personalization_url, text, count, None);
+            ingest(&client, &ingestion_url).await?;
+
+            let res = query("cars", 2).await?;
+            assert_eq!(res.id_ranking(), vec![("d2", 0), ("d2", 2)]);
+            assert_eq!(
+                res.documents[0].snippet.as_deref(),
+                Some("Cars with wheels.")
+            );
+            assert_eq!(
+                res.documents[1].snippet.as_deref(),
+                Some("Trains on tracks.")
+            );
+
+            let res = query("color", 3).await?;
+            assert_eq!(res.id_ranking(), vec![("d1", 0), ("d1", 1), ("d2", 1)]);
+            assert_eq!(
+                res.documents[0].snippet.as_deref(),
+                Some("The duck is blue.")
+            );
+            assert_eq!(
+                res.documents[1].snippet.as_deref(),
+                Some("The truck is yellow.")
+            );
+            assert_eq!(
+                res.documents[2].snippet.as_deref(),
+                Some("This is a blue sentence.")
+            );
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_split_documents_with_set_candidates() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        with_dev_options(),
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, count| query(&client, &personalization_url, text, count, None);
+            let set_candidates = |ids| set_candidates(&client, &ingestion_url, ids);
+            ingest(&client, &ingestion_url).await?;
+
+            set_candidates(&[]).await?;
+            let res = query("cars", 3).await?;
+            assert!(res.documents.is_empty());
+
+            set_candidates(&["d1"]).await?;
+            let res = query("arbitrary", 4).await?;
+            assert_eq!(
+                res.id_ranking().into_iter().collect::<HashSet<_>>(),
+                [("d1", 0), ("d1", 1), ("d1", 2)].into()
+            );
+
+            set_candidates(&["d2"]).await?;
+            let res = query("arbitrary", 4).await?;
+            assert_eq!(
+                res.id_ranking().into_iter().collect::<HashSet<_>>(),
+                [("d2", 0), ("d2", 1), ("d2", 2)].into()
+            );
+
+            set_candidates(&["d1", "d2"]).await?;
+            let res = query("color", 3).await?;
+            assert_eq!(
+                res.id_ranking().into_iter().collect::<HashSet<_>>(),
+                [("d1", 0), ("d1", 1), ("d2", 1)].into()
+            );
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_split_documents_with_property_updates() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        with_dev_options(),
+        |client, ingestion_url, personalization_url, _| async move {
+            let query = |text, value| {
+                query(
+                    &client,
+                    &personalization_url,
+                    text,
+                    10,
+                    Some(json!({
+                        "foo": {
+                            "$eq": value
+                        }
+                    })),
+                )
+            };
+            let get_properties = |id| get_properties(&client, &ingestion_url, id);
+            ingest(&client, &ingestion_url).await?;
+
+            send_assert(
+                &client,
+                client
+                    .post(ingestion_url.join("/documents/_indexed_properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "foo": {
+                                "type": "keyword"
+                            }
+                        }
+                    }))
+                    .build()?,
+                StatusCode::ACCEPTED,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(
+                res.id_ranking(),
+                vec![
+                    ("d2", 0),
+                    ("d2", 2),
+                    ("d1", 1),
+                    ("d2", 1),
+                    ("d1", 2),
+                    ("d1", 0)
+                ]
+            );
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d1/properties")?)
+                    .json(&json!({
+                        "properties": {
+                            "foo": "filter-b"
+                        }
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            assert_eq!(get_properties("d1").await?, json_map([("foo", "filter-b")]));
+            assert_eq!(get_properties("d2").await?, json_map([("foo", "filter-a")]));
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec![("d2", 0), ("d2", 2), ("d2", 1),]);
+
+            send_assert(
+                &client,
+                client
+                    .delete(ingestion_url.join("/documents/d2/properties")?)
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert!(res.id_ranking().is_empty());
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d1/properties/foo")?)
+                    .json(&json!({
+                        "property": "filter-a",
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec![("d1", 1), ("d1", 2), ("d1", 0),]);
+
+            send_assert(
+                &client,
+                client
+                    .put(ingestion_url.join("/documents/d2/properties/foo")?)
+                    .json(&json!({
+                        "property": "filter-a",
+                    }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(
+                res.id_ranking(),
+                vec![
+                    ("d2", 0),
+                    ("d2", 2),
+                    ("d1", 1),
+                    ("d2", 1),
+                    ("d1", 2),
+                    ("d1", 0)
+                ]
+            );
+
+            send_assert(
+                &client,
+                client
+                    .delete(ingestion_url.join("/documents/d1/properties/foo")?)
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+
+            let res = query("cars", "filter-a").await?;
+            assert_eq!(res.id_ranking(), vec![("d2", 0), ("d2", 2), ("d2", 1),]);
+
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn test_endpoints_which_do_not_yet_fully_support_split_do_not_fall_over() {
+    test_two_apps::<Ingestion, Personalization, _>(
+        UNCHANGED_CONFIG,
+        with_dev_options(),
+        |client, ingestion_url, personalization_url, _| async move {
+            ingest(&client, &ingestion_url).await?;
+            send_assert(
+                &client,
+                client
+                    .patch(personalization_url.join("/users/u1/interactions")?)
+                    .json(&json!({ "documents": [ { "id": "d1" } ] }))
+                    .build()?,
+                StatusCode::NO_CONTENT,
+                false,
+            )
+            .await;
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/users/u1/personalized_documents")?)
+                    .json(&json!({}))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "query": "car"
+                        },
+                        "personalize": {
+                            "user": {
+                                "id": "u1"
+                            }
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "query": "car"
+                        },
+                        "personalize": {
+                            "user": {
+                                "history": [ { "id": "d1" }]
+                            }
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            send_assert_json::<SearchResponse>(
+                &client,
+                client
+                    .post(personalization_url.join("/semantic_search")?)
+                    .json(&json!({
+                        "document": {
+                            "id": "d1"
+                        },
+                    }))
+                    .build()?,
+                StatusCode::OK,
+                false,
+            )
+            .await;
+
+            Ok(())
+        },
+    );
+}

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -42,7 +42,7 @@ struct PersonalizedDocumentData {
 #[derive(Debug, Deserialize)]
 struct SnippetId {
     document_id: String,
-    snippet_idx: u32,
+    sub_id: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,7 +57,7 @@ impl SearchResponse {
             .map(|document| {
                 (
                     &*document.snippet_id.document_id,
-                    document.snippet_id.snippet_idx,
+                    document.snippet_id.sub_id,
                 )
             })
             .collect_vec()

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -34,7 +34,7 @@ struct PersonalizedDocumentData {
     id: String,
     snippet_id: SnippetId,
     score: f32,
-    // included by test only dev option
+    // included by dev option
     #[serde(default)]
     snippet: Option<String>,
 }
@@ -67,7 +67,7 @@ impl SearchResponse {
         let ordered = self
             .documents
             .iter()
-            .zip(self.documents.iter().skip(1))
+            .tuple_windows()
             .all(|(first, second)| first.score > second.score);
         assert!(
             ordered,


### PR DESCRIPTION

- add support for preprecessing documents using cutters
- readded tests for split documents


**References:**

- story: [ET-4755]
- issue: [ET-4756]
- based on #1057 

[ET-4755]: https://xainag.atlassian.net/browse/ET-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-4756]: https://xainag.atlassian.net/browse/ET-4756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ