### PR TITLE
deny unknown config values

### DIFF
--- a/coi/src/config.rs
+++ b/coi/src/config.rs
@@ -25,7 +25,7 @@ use crate::{
 
 /// Configurations of the coi system.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 #[must_use]
 pub struct Config {
     shift_factor: f32,

--- a/web-api-db-ctrl/src/lib.rs
+++ b/web-api-db-ctrl/src/lib.rs
@@ -199,6 +199,7 @@ pub enum OperationResult {
     DeleteTenant { tenant: Option<Tenant> },
     Error { msg: String },
 }
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Tenant {
     pub tenant_id: TenantId,

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -50,7 +50,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub url: String,
     pub user: String,

--- a/web-api-shared/src/net.rs
+++ b/web-api-shared/src/net.rs
@@ -29,6 +29,7 @@ use tracing::warn;
 use crate::serde::serde_duration_in_config;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExponentialJitterRetryPolicyConfig {
     pub max_retries: u8,
     #[serde(with = "serde_duration_in_config")]

--- a/web-api-shared/src/postgres.rs
+++ b/web-api-shared/src/postgres.rs
@@ -26,7 +26,7 @@ use crate::{request::TenantId, serde::serialize_redacted};
 pub type Client = Pool<Postgres>;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The default base url.
     ///

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -18,7 +18,7 @@ use xayn_ai_bert::{AvgEmbedder, Config as EmbedderConfig, NormalizedEmbedding};
 use crate::{app::SetupError, error::common::InternalError, utils::RelativePathBuf};
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub(crate) directory: RelativePathBuf,
     pub(crate) token_size: usize,

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -56,7 +56,7 @@ impl Application for Ingestion {
 type AppState = app::AppState<Ingestion>;
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub(crate) logging: logging::Config,
     pub(crate) net: net::Config,
@@ -67,7 +67,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct IngestionConfig {
     pub(crate) max_document_batch_size: usize,
     pub(crate) max_indexed_properties: usize,

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -106,6 +106,7 @@ pub(super) fn configure_ops_service(config: &mut ServiceConfig) {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedIngestedDocument {
     id: String,
     snippet: String,
@@ -258,6 +259,7 @@ impl UnvalidatedIngestedDocument {
 
 /// Represents body of a POST documents request.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct IngestionRequestBody {
     documents: Vec<UnvalidatedIngestedDocument>,
 }
@@ -477,6 +479,7 @@ async fn delete_documents(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BatchDeleteRequest {
     documents: Vec<String>,
 }
@@ -495,11 +498,13 @@ async fn get_document_candidates(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DocumentCandidate {
     id: String,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DocumentCandidatesRequest {
     documents: Vec<DocumentCandidate>,
 }
@@ -544,6 +549,7 @@ pub(crate) async fn get_document_properties(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DocumentPropertiesRequest {
     properties: HashMap<String, Value>,
 }
@@ -605,6 +611,7 @@ async fn get_document_property(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DocumentPropertyRequest {
     property: Value,
 }
@@ -684,6 +691,7 @@ async fn get_indexed_properties_schema(
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 struct ManagementRequest {
     operations: Vec<Operation>,
 }

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -54,7 +54,7 @@ mod serde_level_filter {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub file: Option<RelativePathBuf>,
     #[serde(with = "serde_level_filter")]

--- a/web-api/src/mind/config.rs
+++ b/web-api/src/mind/config.rs
@@ -92,6 +92,7 @@ impl GridSearchConfig {
 
 /// The config of hyperparameters for the persona based benchmark.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct PersonaBasedConfig {
     pub(super) click_probability: f64,
     pub(super) ndocuments: usize,
@@ -117,6 +118,7 @@ impl Default for PersonaBasedConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct SaturationConfig {
     pub(super) click_probability: f64,
     pub(super) ndocuments: usize,

--- a/web-api/src/mind/data.rs
+++ b/web-api/src/mind/data.rs
@@ -42,6 +42,7 @@ where
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct ViewedDocument {
     pub(super) document_id: DocumentId,
     pub(super) was_clicked: bool,
@@ -76,6 +77,7 @@ where
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Impression {
     #[allow(dead_code)]
     id: String,
@@ -89,6 +91,7 @@ pub(super) struct Impression {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Document {
     pub(super) id: DocumentId,
     pub(super) category: DocumentTag,

--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -51,7 +51,7 @@ use crate::middleware::{
 /// Configuration for roughly network/connection layer specific configurations.
 // Hint: this value just happens to be copy, if needed the Copy trait can be removed
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// Address to which the server should bind.
     pub(crate) bind_to: SocketAddr,

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -64,7 +64,7 @@ impl Application for Personalization {
 type AppState = app::AppState<Personalization>;
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub(crate) logging: logging::Config,
     pub(crate) net: net::Config,
@@ -77,7 +77,7 @@ pub struct Config {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct PersonalizationConfig {
     /// Max number of documents to return.
     pub(crate) max_number_documents: usize,
@@ -145,7 +145,7 @@ impl PersonalizationConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct SemanticSearchConfig {
     /// Max number of documents to return.
     pub(crate) max_number_documents: usize,

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -73,11 +73,13 @@ pub(super) fn configure_service(config: &mut ServiceConfig) {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UserInteractionRequest {
     documents: Vec<UserInteractionData>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UserInteractionData {
     #[serde(rename = "id")]
     document_id: String,
@@ -144,6 +146,7 @@ const fn default_include_properties() -> bool {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedPersonalizedDocumentsRequest {
     count: Option<usize>,
     published_after: Option<DateTime<Utc>>,
@@ -153,6 +156,7 @@ struct UnvalidatedPersonalizedDocumentsRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedPersonalizedDocumentsQuery {
     count: Option<usize>,
     published_after: Option<DateTime<Utc>>,
@@ -383,6 +387,7 @@ pub(crate) async fn personalize_documents_by(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedInputUser {
     id: Option<String>,
     history: Option<Vec<UnvalidatedHistoryEntry>>,
@@ -415,6 +420,7 @@ impl UnvalidatedInputUser {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedSemanticSearchRequest {
     document: UnvalidatedInputDocument,
     count: Option<usize>,
@@ -430,7 +436,7 @@ struct UnvalidatedSemanticSearchRequest {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 struct DevOption {
     hybrid: Option<DevHybrid>,
     max_number_candidates: Option<usize>,
@@ -448,7 +454,7 @@ impl DevOption {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 enum DevHybrid {
     Customize {
         normalize_knn: NormalizationFn,
@@ -546,6 +552,7 @@ impl UnvalidatedSemanticSearchRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedInputDocument {
     id: Option<String>,
     query: Option<String>,
@@ -572,6 +579,7 @@ const fn default_exclude_seen() -> bool {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnvalidatedPersonalize {
     #[serde(default = "default_exclude_seen")]
     exclude_seen: bool,

--- a/web-api/src/personalization/stateless.rs
+++ b/web-api/src/personalization/stateless.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct UnvalidatedHistoryEntry {
     id: String,
     #[serde(default)]
@@ -36,6 +37,7 @@ pub(super) struct UnvalidatedHistoryEntry {
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 pub(super) struct HistoryEntry {
     pub(super) id: DocumentId,
     pub(super) timestamp: DateTime<Utc>,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -89,7 +89,7 @@ pub(crate) enum NormalizationFn {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum MergeFn {
     Sum {
         #[serde(default)]
@@ -284,7 +284,7 @@ pub(crate) trait IndexedProperties {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     elastic: elastic::Config,
     postgres: postgres_shared::Config,

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -411,7 +411,7 @@ impl Client {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct IndexUpdateConfig {
     requests_per_second: usize,
     method: IndexUpdateMethod,

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -58,6 +58,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct Document {
     snippet: DocumentSnippet,
     is_summarized: bool,

--- a/web-api/src/storage/property_filter.rs
+++ b/web-api/src/storage/property_filter.rs
@@ -40,6 +40,7 @@ pub(crate) enum IncompatibleUpdate {
 
 //Hint: Currently the API and internal definition match so we use the same type.
 #[derive(Debug, Clone, Default, Deref, IntoIterator, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct IndexedPropertiesSchemaUpdate {
     #[into_iterator(owned, ref)]
     properties: HashMap<DocumentPropertyId, IndexedPropertyDefinition>,
@@ -47,6 +48,7 @@ pub(crate) struct IndexedPropertiesSchemaUpdate {
 
 //Hint: Currently the API and internal definition match so we use the same type.
 #[derive(Debug, Clone, Default, Deref, IntoIterator, From, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct IndexedPropertiesSchema {
     #[into_iterator(owned, ref)]
     properties: HashMap<DocumentPropertyId, IndexedPropertyDefinition>,
@@ -166,6 +168,7 @@ impl IndexedPropertiesSchema {
 
 //Hint: Currently the API and internal definition match so we use the same type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct IndexedPropertyDefinition {
     pub(crate) r#type: IndexedPropertyType,
 }

--- a/web-api/src/tenants.rs
+++ b/web-api/src/tenants.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub(crate) enable_legacy_tenant: bool,
     pub(crate) enable_dev: bool,

--- a/web-api/tests/config.rs
+++ b/web-api/tests/config.rs
@@ -61,7 +61,6 @@ fn test_loading_config_with_env_overrides() {
     with_env_guard(
         [
             ("XAYN_WEB_API__STORAGE__POSTGRES__PORT", "3532"),
-            ("XAYN_INGESTION__NET__MAX_BODY_SIZE", "4422"),
             ("XAYN_WEB_API__LOGGING__LEVEL", "trace"),
             ("XAYN_WEB_API__TENANTS__ENABLE_LEGACY_TENANT", "false"),
         ],

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -225,7 +225,7 @@ fn test_semantic_search_with_dev_option_hybrid() {
                         "_dev": { "hybrid": { "customize": {
                             "normalize_knn": "identity",
                             "normalize_bm25": "identity",
-                            "merge_fn": { "rrf": { "k": 60. } }
+                            "merge_fn": { "rrf": { "rank_constant": 60. } }
                         } } }
                     }))
                     .build()?,


### PR DESCRIPTION
**Summary**

- add `#[serde(deny_unknown_fields)]` to user-facing deserialized inputs like configs and requests, this helps to detect for example outdated tests, request typos, etc
- fix two outdated integration tests
