### PR TITLE
ET-4943 remove tract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,32 +4214,8 @@ dependencies = [
  "num-traits",
  "rustfft",
  "smallvec",
- "tract-data 0.19.16",
- "tract-linalg 0.19.16",
-]
-
-[[package]]
-name = "tract-core"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1518c2b81258326ade7659d9c71d3747fee884cb792afdd09977fd4693cf1d"
-dependencies = [
- "anyhow",
- "bit-set",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "lazy_static",
- "log",
- "maplit",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "rustfft",
- "smallvec",
- "tract-data 0.20.7",
- "tract-linalg 0.20.7",
+ "tract-data",
+ "tract-linalg",
 ]
 
 [[package]]
@@ -4265,26 +4241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tract-data"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68315af15998e0cf06c29f017905c083d4f964b3114d8436ef6887b11fa39f56"
-dependencies = [
- "anyhow",
- "half 2.2.1",
- "itertools 0.10.5",
- "lazy_static",
- "maplit",
- "ndarray",
- "nom",
- "num-integer",
- "num-traits",
- "scan_fmt",
- "smallvec",
- "string-interner",
-]
-
-[[package]]
 name = "tract-hir"
 version = "0.19.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,18 +4249,7 @@ dependencies = [
  "derive-new",
  "educe",
  "log",
- "tract-core 0.19.16",
-]
-
-[[package]]
-name = "tract-hir"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be070982d0310dc8f9164251cef6e67514bd64c844066d853adfe45d65f2622a"
-dependencies = [
- "derive-new",
- "log",
- "tract-core 0.20.7",
+ "tract-core",
 ]
 
 [[package]]
@@ -4326,31 +4271,7 @@ dependencies = [
  "paste",
  "scan_fmt",
  "smallvec",
- "tract-data 0.19.16",
- "unicode-normalization",
- "walkdir",
-]
-
-[[package]]
-name = "tract-linalg"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4332a4be4cb2c12c317d0e092dcf5b09479314be18b906333113429ec258d36"
-dependencies = [
- "cc",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "half 2.2.1",
- "lazy_static",
- "liquid",
- "liquid-core",
- "log",
- "num-traits",
- "paste",
- "scan_fmt",
- "smallvec",
- "tract-data 0.20.7",
+ "tract-data",
  "unicode-normalization",
  "walkdir",
 ]
@@ -4366,22 +4287,7 @@ dependencies = [
  "log",
  "nom",
  "tar",
- "tract-core 0.19.16",
- "walkdir",
-]
-
-[[package]]
-name = "tract-nnef"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb872e9c8c156a8b5194f27ebaff5867f2b2edbc22a6f47dc7fcf2bb8b52473"
-dependencies = [
- "byteorder",
- "flate2",
- "log",
- "nom",
- "tar",
- "tract-core 0.20.7",
+ "tract-core",
  "walkdir",
 ]
 
@@ -4399,27 +4305,9 @@ dependencies = [
  "num-integer",
  "prost",
  "smallvec",
- "tract-hir 0.19.16",
- "tract-nnef 0.19.16",
- "tract-onnx-opl 0.19.16",
-]
-
-[[package]]
-name = "tract-onnx"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4ba4a71a7eb6ab440bd0e525ea582fc339d938ff1cee91dbf38e0a59af277e"
-dependencies = [
- "bytes",
- "derive-new",
- "log",
- "memmap2",
- "num-integer",
- "prost",
- "smallvec",
- "tract-hir 0.20.7",
- "tract-nnef 0.20.7",
- "tract-onnx-opl 0.20.7",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
 ]
 
 [[package]]
@@ -4434,21 +4322,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rustfft",
- "tract-nnef 0.19.16",
-]
-
-[[package]]
-name = "tract-onnx-opl"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5efd9ae10b507905ae6d1df7ec48f4dab77ab9605b1bd86275bb19997882267"
-dependencies = [
- "getrandom",
- "log",
- "rand",
- "rand_distr",
- "rustfft",
- "tract-nnef 0.20.7",
+ "tract-nnef",
 ]
 
 [[package]]
@@ -4996,7 +4870,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokenizers",
- "tract-onnx 0.19.16",
+ "tract-onnx",
  "xayn-test-utils 0.1.1",
 ]
 
@@ -5018,7 +4892,6 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokenizers",
- "tract-onnx 0.20.7",
  "xayn-test-utils 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,3 @@ toml = "0.7.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 uuid = { version = "1.3.4", features = ["serde", "v4"] }
-
-[profile.dev.package.tract-core]
-opt-level = 3
-# extremely slows down tract ^0.19 if enabled for non-trivial onnx models
-debug-assertions = false

--- a/bert/Cargo.toml
+++ b/bert/Cargo.toml
@@ -17,7 +17,6 @@ serde = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokenizers = { version = "0.13.3", default-features = false, features = ["onig"] }
-tract-onnx = "0.20.7"
 xayn-test-utils = { path = "../test-utils" }
 
 [dev-dependencies]

--- a/bert/benches/bert.rs
+++ b/bert/benches/bert.rs
@@ -15,7 +15,7 @@
 use std::{hint::black_box, path::Path};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use xayn_ai_bert::{AveragePooler, Config, Runtime};
+use xayn_ai_bert::{AveragePooler, Config};
 use xayn_test_utils::asset::{ort, xaynia};
 
 const TOKEN_SIZE: usize = 250;
@@ -36,12 +36,11 @@ tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim v
 exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel
 eum iriure dolor in hendrerit in vulputate velit esse";
 
-fn bench_bert(manager: &mut Criterion, name: &str, dir: &Path, rt: Runtime) {
-    let pipeline = Config::new(dir)
+fn bench_bert(manager: &mut Criterion, name: &str, dir: &Path) {
+    let pipeline = Config::new(dir, ort().unwrap())
         .unwrap()
         .with_token_size(TOKEN_SIZE)
         .unwrap()
-        .with_runtime(rt)
         .with_pooler::<AveragePooler>()
         .build()
         .unwrap();
@@ -50,25 +49,15 @@ fn bench_bert(manager: &mut Criterion, name: &str, dir: &Path, rt: Runtime) {
     });
 }
 
-fn bench_bert_tract(manager: &mut Criterion) {
-    bench_bert(manager, "Bert Tract", &xaynia().unwrap(), Runtime::Tract);
-}
-
-fn bench_bert_ort(manager: &mut Criterion) {
-    bench_bert(
-        manager,
-        "Bert Ort",
-        &xaynia().unwrap(),
-        Runtime::Ort(ort().unwrap()),
-    );
+fn bench_xaynia(manager: &mut Criterion) {
+    bench_bert(manager, "Bert Xaynia", &xaynia().unwrap());
 }
 
 criterion_group! {
     name = bench;
     config = Criterion::default();
     targets =
-        bench_bert_tract,
-        bench_bert_ort,
+        bench_xaynia,
 }
 
 criterion_main! {

--- a/bert/examples/bert.rs
+++ b/bert/examples/bert.rs
@@ -14,13 +14,13 @@
 
 //! Run as `cargo run --example bert
 
-use xayn_ai_bert::{Config, FirstPooler};
-use xayn_test_utils::asset::smbert;
+use xayn_ai_bert::{AveragePooler, Config};
+use xayn_test_utils::asset::{ort, xaynia};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pipeline = Config::new(smbert()?)?
-        .with_token_size(64)?
-        .with_pooler::<FirstPooler>()
+    let pipeline = Config::new(xaynia()?, ort()?)?
+        .with_token_size(250)?
+        .with_pooler::<AveragePooler>()
         .build()?;
     let embedding = pipeline.run("This is a sequence.")?;
     println!("{}", *embedding);

--- a/bert/src/lib.rs
+++ b/bert/src/lib.rs
@@ -43,7 +43,7 @@ mod pooler;
 mod tokenizer;
 
 pub use crate::{
-    config::{Config, Runtime},
+    config::Config,
     pipeline::{Pipeline, PipelineError},
     pooler::{
         AveragePooler,

--- a/bert/src/tokenizer.rs
+++ b/bert/src/tokenizer.rs
@@ -13,71 +13,22 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use anyhow::anyhow;
-use derive_more::{Deref, From};
-use figment::value::Dict;
-use ndarray::Array2;
 use tokenizers::{
     tokenizer::Tokenizer as HfTokenizer,
     utils::{
         padding::{PaddingDirection, PaddingParams, PaddingStrategy},
         truncation::{TruncationDirection, TruncationParams, TruncationStrategy},
     },
+    Encoding,
     Error,
 };
-use tract_onnx::prelude::{tvec, IntoArcTensor, TValue, TVec};
 
 use crate::config::Config;
-
-/// The attention mask of the encoded sequence.
-///
-/// The attention mask is of shape `(1, token_size)`.
-#[derive(Clone, Deref, From)]
-pub(crate) struct AttentionMask(pub(crate) Array2<i64>);
-
-/// The encoded sequence.
-#[derive(Clone)]
-pub(crate) struct Encoding {
-    pub(crate) token_ids: Array2<i64>,
-    pub(crate) attention_mask: Array2<i64>,
-    pub(crate) type_ids: Option<Array2<i64>>,
-}
-
-impl Encoding {
-    pub(crate) fn to_attention_mask(&self) -> AttentionMask {
-        self.attention_mask.clone().into()
-    }
-}
-
-impl From<Encoding> for TVec<TValue> {
-    fn from(encoding: Encoding) -> Self {
-        let token_ids = TValue::Const(encoding.token_ids.into_arc_tensor());
-        let attention_mask = TValue::Const(encoding.attention_mask.into_arc_tensor());
-        if let Some(type_ids) = encoding
-            .type_ids
-            .map(|type_ids| TValue::Const(type_ids.into_arc_tensor()))
-        {
-            tvec![token_ids, attention_mask, type_ids]
-        } else {
-            tvec![token_ids, attention_mask]
-        }
-    }
-}
-
-impl From<Encoding> for Vec<Array2<i64>> {
-    fn from(encoding: Encoding) -> Self {
-        if let Some(type_ids) = encoding.type_ids {
-            vec![encoding.token_ids, encoding.attention_mask, type_ids]
-        } else {
-            vec![encoding.token_ids, encoding.attention_mask]
-        }
-    }
-}
 
 /// A pre-configured huggingface tokenizer.
 pub(crate) struct Tokenizer {
     tokenizer: HfTokenizer,
     add_special_tokens: bool,
-    use_type_ids: bool,
 }
 
 impl Tokenizer {
@@ -109,99 +60,88 @@ impl Tokenizer {
         tokenizer.with_padding(Some(padding));
         tokenizer.with_truncation(Some(truncation));
         let add_special_tokens = config.extract::<bool>("tokenizer.add-special-tokens")?;
-        let use_type_ids = config.extract::<Dict>("model.input")?.len() > 2;
 
         Ok(Tokenizer {
             tokenizer,
             add_special_tokens,
-            use_type_ids,
         })
     }
 
     pub(crate) fn encode(&self, sequence: impl AsRef<str>) -> Result<Encoding, Error> {
-        let encoding = self
-            .tokenizer
-            .encode(sequence.as_ref(), self.add_special_tokens)?;
-        let array_from =
-            |slice: &[u32]| Array2::from_shape_fn((1, slice.len()), |(_, i)| i64::from(slice[i]));
-
-        Ok(Encoding {
-            token_ids: array_from(encoding.get_ids()),
-            attention_mask: array_from(encoding.get_attention_mask()),
-            type_ids: self
-                .use_type_ids
-                .then(|| array_from(encoding.get_type_ids())),
-        })
+        self.tokenizer
+            .encode(sequence.as_ref(), self.add_special_tokens)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ndarray::{arr1, s};
-    use xayn_test_utils::asset::{e5_mocked, smbert_mocked};
+    use xayn_test_utils::asset::{e5_mocked, ort, smbert_mocked};
 
     use super::*;
 
     #[test]
     fn test_smbert() {
-        let config = Config::new(smbert_mocked().unwrap()).unwrap();
+        let config = Config::new(smbert_mocked().unwrap(), ort().unwrap()).unwrap();
         let tokenizer = Tokenizer::new(&config).unwrap();
         let encoding = tokenizer
             .encode("These are normal, common EMBEDDINGS.")
             .unwrap();
-        assert_eq!(encoding.token_ids.shape(), [1, 257]);
+        assert_eq!(encoding.get_ids().len(), 257);
         assert_eq!(
-            encoding.token_ids.slice(s![0, ..20]),
-            arr1(&[2, 4538, 2128, 8561, 1, 6541, 69469, 2762, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            encoding.get_ids()[..20],
+            [2, 4538, 2128, 8561, 1, 6541, 69469, 2762, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         );
         assert_eq!(
-            encoding.attention_mask.slice(s![0, ..20]),
-            arr1(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            encoding.get_attention_mask()[..20],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         );
         assert_eq!(
-            encoding.type_ids.unwrap().slice(s![0, ..20]),
-            arr1(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            encoding.get_type_ids()[..20],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         );
     }
 
     #[test]
     fn test_smbert_troublemakers() {
-        let config = Config::new(smbert_mocked().unwrap()).unwrap();
+        let config = Config::new(smbert_mocked().unwrap(), ort().unwrap()).unwrap();
         let tokenizer = Tokenizer::new(&config).unwrap();
         let encoding = tokenizer
             .encode("for “life-threatening storm surge” according")
             .unwrap();
-        assert_eq!(encoding.token_ids.shape(), [1, 257]);
+        assert_eq!(encoding.get_ids().len(), 257);
         assert_eq!(
-            encoding.token_ids.slice(s![0, ..15]),
-            arr1(&[2, 1665, 1, 3902, 1, 83775, 11123, 41373, 1, 7469, 3, 0, 0, 0, 0]),
+            encoding.get_ids()[..15],
+            [2, 1665, 1, 3902, 1, 83775, 11123, 41373, 1, 7469, 3, 0, 0, 0, 0],
         );
         assert_eq!(
-            encoding.attention_mask.slice(s![0, ..15]),
-            arr1(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]),
+            encoding.get_attention_mask()[..15],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
         );
         assert_eq!(
-            encoding.type_ids.unwrap().slice(s![0, ..15]),
-            arr1(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            encoding.get_type_ids()[..15],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         );
     }
 
     #[test]
     fn test_e5() {
-        let config = Config::new(e5_mocked().unwrap()).unwrap();
+        let config = Config::new(e5_mocked().unwrap(), ort().unwrap()).unwrap();
         let tokenizer = Tokenizer::new(&config).unwrap();
         let encoding = tokenizer
             .encode("These are normal, common EMBEDDINGS.")
             .unwrap();
-        assert_eq!(encoding.token_ids.shape(), [1, 258]);
+        assert_eq!(encoding.get_ids().len(), 258);
         assert_eq!(
-            encoding.token_ids.slice(s![0, ..15]),
-            arr1(&[0, 32255, 621, 3638, 4, 39210, 19515, 20090, 24057, 142_766, 5, 2, 1, 1, 1]),
+            encoding.get_ids()[..15],
+            [0, 32255, 621, 3638, 4, 39210, 19515, 20090, 24057, 142_766, 5, 2, 1, 1, 1],
         );
         assert_eq!(
-            encoding.attention_mask.slice(s![0, ..15]),
-            arr1(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]),
+            encoding.get_attention_mask()[..15],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
         );
-        assert!(encoding.type_ids.is_none());
+        assert_eq!(
+            encoding.get_type_ids()[..15],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        );
     }
 }

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -17,7 +17,10 @@ use derive_more::{Deref, DerefMut};
 use futures_util::{stream::FuturesOrdered, TryStreamExt};
 use serde::Serialize;
 use xayn_ai_coi::{CoiConfig, CoiSystem};
-use xayn_test_utils::error::Panic;
+use xayn_test_utils::{
+    asset::{ort, xaynia},
+    error::Panic,
+};
 
 use crate::{
     embedding::{self, Embedder, Pipeline},
@@ -50,7 +53,8 @@ pub(super) struct State {
 impl State {
     pub(super) async fn new(storage: Storage, config: StateConfig) -> Result<Self, Panic> {
         let embedder = Embedder::load(&embedding::Config::Pipeline(Pipeline {
-            directory: "../assets/xaynia_v0002".into(),
+            directory: xaynia()?.into(),
+            runtime: ort()?.into(),
             ..Pipeline::default()
         }))
         .await

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets/model",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -49,8 +49,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "personalization": {
     "max_number_documents": 100,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets/model",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets/model",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -54,8 +54,8 @@ stdout = """
   "embedding": {
     "type": "pipeline",
     "directory": "assets/model",
-    "token_size": 250,
-    "runtime": "assets"
+    "runtime": "assets",
+    "token_size": 250
   },
   "tenants": {
     "enable_legacy_tenant": true,


### PR DESCRIPTION
**Reference**

- [ET-4943]
- requires #1054
- followed by #1067

**Summary**

- remove `tract` dependency
- use `ort` native types for model inputs and outputs


[ET-4943]: https://xainag.atlassian.net/browse/ET-4943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ