### PR TITLE
ET-4949 dynamic token size

### DIFF
--- a/.github/scripts/download_assets.sh
+++ b/.github/scripts/download_assets.sh
@@ -50,9 +50,9 @@ if [ $# -gt 0 ]; then
     done
 else
     download smbert v0003
-    download smbert v0004
-    download smbert_mocked v0004
-    download e5_mocked v0000
-    download xaynia v0002
+    download smbert v0005
+    download smbert_mocked v0005
+    download e5_mocked v0001
+    download xaynia v0201
     download ort v1.15.1
 fi

--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -11,7 +11,7 @@ on:
       model_version:
         description: Version of the model
         type: string
-        default: v0002
+        default: v0201
         required: true
       platform:
         description: Platform to build the image for

--- a/bert/src/config.rs
+++ b/bert/src/config.rs
@@ -37,45 +37,16 @@ use crate::{
 ///
 /// ```toml
 /// # the config file is always named `config.toml`
+/// # the tokenizer file is always named `tokenizer.json`
+/// # the model file is always named `model.onnx`
+/// # the runtime file is always named `lib/libonnxruntime.<so/dylib>`
 ///
-/// # the path is always `tokenizer.json`
 /// [tokenizer]
 /// add-special-tokens = true
-///
-/// [tokenizer.tokens]
 /// # the `token size` must be in the inclusive range, but is passed as an argument
 /// size.min = 2
 /// size.max = 512
 /// padding = "[PAD]"
-///
-/// # the [model] path is always `model.onnx`
-///
-/// # string shapes are considered dynamic and depend on arguments
-/// [model.input.0]
-/// shape.0 = 1
-/// shape.1 = "token size"
-/// type = "i64"
-///
-/// [model.input.1]
-/// shape.0 = 1
-/// shape.1 = "token size"
-/// type = "i64"
-///
-/// [model.input.2]
-/// shape.0 = 1
-/// shape.1 = "token size"
-/// type = "i64"
-///
-/// [model.output.0]
-/// shape.0 = 1
-/// shape.1 = "token size"
-/// shape.2 = 128
-/// type = "f32"
-///
-/// [model.output.1]
-/// shape.0 = 1
-/// shape.1 = 128
-/// type = "f32"
 /// ```
 #[must_use]
 pub struct Config<P> {
@@ -127,8 +98,8 @@ impl Config<NonePooler> {
 }
 
 impl<P> Config<P> {
-    const MIN_TOKEN_SIZE: &str = "tokenizer.tokens.size.min";
-    const MAX_TOKEN_SIZE: &str = "tokenizer.tokens.size.max";
+    const MIN_TOKEN_SIZE: &str = "tokenizer.min_size";
+    const MAX_TOKEN_SIZE: &str = "tokenizer.max_size";
 
     pub(crate) fn extract<'b, V>(&self, key: &str) -> Result<V, Error>
     where
@@ -150,9 +121,10 @@ impl<P> Config<P> {
         Ok(())
     }
 
-    /// Sets the token size for the tokenizer and the model.
+    /// Sets the token size for the tokenizer.
     ///
-    /// Defaults to the midpoint of the token size range.
+    /// Too long tokenized sequences are truncated accordingly. Defaults to the midpoint of the
+    /// token size range.
     ///
     /// # Errors
     /// Fails if `size` is not within the token size range.

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -40,7 +40,6 @@ use crate::config::Config;
 pub(crate) struct Model {
     runtime: Session,
     use_type_ids: bool,
-    pub(crate) token_size: usize,
     pub(crate) embedding_size: usize,
 }
 
@@ -83,7 +82,6 @@ impl Model {
         Ok(Model {
             runtime: session,
             use_type_ids,
-            token_size: config.token_size,
             embedding_size: embedding_size as usize,
         })
     }
@@ -132,10 +130,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let config = Config::new(smbert_mocked().unwrap(), ort().unwrap())
-            .unwrap()
-            .with_token_size(64)
-            .unwrap();
+        let config = Config::new(smbert_mocked().unwrap(), ort().unwrap()).unwrap();
         let model = Model::new(&config).unwrap();
 
         assert_eq!(model.runtime.inputs.len(), 3);
@@ -179,7 +174,6 @@ mod tests {
             HashMap::new(),
         );
         let embedding = model.embed(&encoding).unwrap();
-        assert_eq!(model.token_size, token_size);
         assert_eq!(
             embedding.extract().unwrap().view().shape(),
             [1, token_size, model.embedding_size],

--- a/bert/src/pipeline.rs
+++ b/bert/src/pipeline.rs
@@ -81,11 +81,6 @@ impl Pipeline<AveragePooler> {
 }
 
 impl<P> Pipeline<P> {
-    /// Gets the token size.
-    pub fn token_size(&self) -> usize {
-        self.model.token_size
-    }
-
     /// Gets the embedding size.
     pub fn embedding_size(&self) -> usize {
         self.model.embedding_size
@@ -115,48 +110,44 @@ mod tests {
     #[test]
     fn test_pipeline_none() {
         let pipeline = pipeline::<NonePooler>(smbert_mocked().unwrap());
-        let shape = [pipeline.token_size(), pipeline.embedding_size()];
 
         let embeddings = pipeline.run("This is a sequence.").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [7, pipeline.embedding_size()]);
 
         let embeddings = pipeline.run("").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [2, pipeline.embedding_size()]);
     }
 
     #[test]
     fn test_pipeline_first() {
         let pipeline = pipeline::<FirstPooler>(smbert_mocked().unwrap());
-        let shape = [pipeline.embedding_size()];
 
         let embeddings = pipeline.run("This is a sequence.").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
 
         let embeddings = pipeline.run("").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
     }
 
     #[test]
     fn test_pipeline_average() {
         let pipeline = pipeline::<AveragePooler>(smbert_mocked().unwrap());
-        let shape = [pipeline.embedding_size()];
 
         let embeddings = pipeline.run("This is a sequence.").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
 
         let embeddings = pipeline.run("").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
     }
 
     #[test]
     fn test_e5_pipeline() {
         let pipeline = pipeline::<AveragePooler>(e5_mocked().unwrap());
-        let shape = [pipeline.embedding_size()];
 
         let embeddings = pipeline.run("This is a sequence.").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
 
         let embeddings = pipeline.run("").unwrap();
-        assert_eq!(embeddings.shape(), shape);
+        assert_eq!(embeddings.shape(), [pipeline.embedding_size()]);
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -724,7 +724,7 @@ pub fn build_test_config_from_parts(
         pg_config,
         es_config,
         configure,
-        "xaynia_v0002",
+        "xaynia_v0201",
         &format!("ort_v1.15.1/{}", ort_target().unwrap()),
     )
 }

--- a/onnx-tool/README.md
+++ b/onnx-tool/README.md
@@ -7,7 +7,7 @@ You need to have [Python](https://www.python.org/) installed.
 
 # 🏗 Usage
 
-First install needed dependencies and then run the script specifying the type of the model (`smbert`) and output path. By default the output path is `"."` (the current directory).
+First install needed dependencies and then run the script specifying the type of the model (`bert`) and output path. By default the output path is `"."` (the current directory).
 
 ```sh
 # create virtual env
@@ -19,8 +19,9 @@ $ source .venv/bin/activate
 # install dependencies
 $ pip install -r requirements.txt
 
-# generate smbert model, put it in the assets dir and upload a new version
+# generate bert model, put it in the assets dir and upload a new version
 $ python src/mock_onnx_tool.py \
-  --type smbert \
-  --output ../assets/smbert_mocked_v0004
+  --type bert \
+  --embedding 128 \
+  --output ../assets/mocked_model
 ```

--- a/onnx-tool/requirements.txt
+++ b/onnx-tool/requirements.txt
@@ -1,3 +1,3 @@
 argparse==1.4.0
-onnx==1.11.0
-onnxruntime==1.10.0
+onnx==1.14.0
+onnxruntime==1.15.1

--- a/test-utils/src/asset.rs
+++ b/test-utils/src/asset.rs
@@ -40,22 +40,22 @@ fn resolve_path(path: &[impl AsRef<Path>]) -> Result<PathBuf> {
 
 /// Resolves the path to the smbert model.
 pub fn smbert() -> Result<PathBuf> {
-    resolve_path(&[ASSETS_DIR, "smbert_v0004"])
+    resolve_path(&[ASSETS_DIR, "smbert_v0005"])
 }
 
 /// Resolves the path to the mocked smbert model.
 pub fn smbert_mocked() -> Result<PathBuf> {
-    resolve_path(&[ASSETS_DIR, "smbert_mocked_v0004"])
+    resolve_path(&[ASSETS_DIR, "smbert_mocked_v0005"])
 }
 
 /// Resolves the path to the mocked e5 model.
 pub fn e5_mocked() -> Result<PathBuf> {
-    resolve_path(&[ASSETS_DIR, "e5_mocked_v0000"])
+    resolve_path(&[ASSETS_DIR, "e5_mocked_v0001"])
 }
 
 /// Resolves the path to the xaynia model.
 pub fn xaynia() -> Result<PathBuf> {
-    resolve_path(&[ASSETS_DIR, "xaynia_v0002"])
+    resolve_path(&[ASSETS_DIR, "xaynia_v0201"])
 }
 
 /// Resolves the target of the onnxruntime library.

--- a/web-api/tests/legacy_tenant_migration.rs
+++ b/web-api/tests/legacy_tenant_migration.rs
@@ -289,7 +289,7 @@ fn test_full_migration() {
             &pg_config,
             &es_config,
             Table::new(),
-            "smbert_v0004",
+            "smbert_v0005",
             &format!("ort_v1.15.1/{}", ort_target().unwrap()),
         );
         let args = &[


### PR DESCRIPTION
**Reference**

- [ET-4949]
- requires #1066

**Summary**

- remove fixed token size:
  - padding is set to longest of the batch, currently that means no padding at all, if we chose to go with batch sizes > 1 then this will actually take effect
  - truncation is still applied, the token size keeps its meaning in that regard that it acts as a max token size, this also means that the embedding computation is not breaking for existing tenants (removed padding is also not breaking because we average-pool the embeddings only over the active tokens which doesn't apply to padding tokens)
- removed unused model config values & simplify/consistify remaining config values, all used models have been updated accordingly:
  - `smbert`: `v0004` -> `v0005`
  - `smbert_mocked`: `v0004` -> `v0005`
  - `e5_mocked`: `v0000` -> `v0001` (this wasn't a mocked model but a small-ish e5 model before, now it's really mocked)
  - `xaynia`: `v0002` -> `v0201`
  - `e5_small_v2`: `v0000` -> `v0001`
  - `multilingual_e5_small`: `v0000` -> `v0001`
- update the python model mock tool


[ET-4949]: https://xainag.atlassian.net/browse/ET-4949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ