### PR TITLE
change migration to not calculate hash

### DIFF
--- a/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
+++ b/web-api-db-ctrl/postgres/tenant/20230713173212_document.sql
@@ -25,7 +25,9 @@ CREATE TABLE snippet (
 INSERT INTO snippet(document_id, sub_id, snippet, embedding)
     SELECT document_id, 0, snippet, embedding FROM document;
 
-ALTER TABLE document ALTER COLUMN snippet TYPE BYTEA USING sha256(snippet::bytea);
-ALTER TABLE document RENAME COLUMN snippet TO original_sha256;
-
-ALTER TABLE document DROP COLUMN embedding;
+ALTER TABLE document
+    -- 32 byte sha256 hash used to determine if the original changed since last ingestion
+    ADD COLUMN original_sha256 BYTEA NOT NULL
+        DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea,
+    DROP COLUMN snippet,
+    DROP COLUMN embedding;


### PR DESCRIPTION
This only works if the migration (and any follow up migrations) haven't been applied already due to it changing an existing migration. Outside of one demo tenant that seems to be the case.

Run `cargo clean -p xayn-web-api-db-ctrl` can be a good idea to preclude any cargo cache related issues.