### PR TITLE
Upload file

### DIFF
--- a/.github/workflows/_reusable.rust.yml
+++ b/.github/workflows/_reusable.rust.yml
@@ -69,6 +69,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      tika:
+        image: apache/tika:2.8.0.0-full
+        options: >-
+          --memory 256m
+          --health-cmd "wget --no-verbose --tries=1 --spider 'http://localhost:9998/'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_serde_shim"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9c5b33b135e34aab675cef7f678c688b30740ba299d75e3a8c0af89b5d5cea"
+dependencies = [
+ "mime",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,6 +5116,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-sagemakerruntime",
+ "base64 0.21.2",
  "bincode",
  "chrono",
  "clap",
@@ -5121,6 +5132,7 @@ dependencies = [
  "instant-distance",
  "itertools 0.10.5",
  "mime",
+ "mime_serde_shim",
  "ndarray",
  "npyz",
  "once_cell",

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -611,12 +611,12 @@ pub fn with_dev_options() -> Option<Table> {
     })
 }
 
-pub fn with_text_extractor_options(allowed_content_type: Vec<String>) -> Option<Table> {
+pub fn with_text_extractor_options(allowed_media_type: Vec<String>) -> Option<Table> {
     Some(toml! {
         [text_extractor]
         enabled = true
         extractor = "tika"
-        allowed_content_type = allowed_content_type
+        allowed_media_type = allowed_media_type
     })
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -611,6 +611,15 @@ pub fn with_dev_options() -> Option<Table> {
     })
 }
 
+pub fn with_text_extractor_options(allowed_content_type: Vec<String>) -> Option<Table> {
+    Some(toml! {
+        [text_extractor]
+        enabled = true
+        extractor = "tika"
+        allowed_content_type = allowed_content_type
+    })
+}
+
 pub fn extend_config(current: &mut Table, extension: Table) {
     for (key, value) in extension {
         if let Some(current) = current.get_mut(&key) {
@@ -715,6 +724,16 @@ pub fn build_test_config_from_parts_and_names(
 
                 [snippet_extractor.tokenizers]
                 default = tokenizer
+            },
+        );
+    }
+
+    if *RUNS_IN_CONTAINER {
+        extend_config(
+            &mut config,
+            toml! {
+                [text_extractor]
+                url = "http://tika:9998/"
             },
         );
     }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -733,6 +733,7 @@ pub fn build_test_config_from_parts_and_names(
             &mut config,
             toml! {
                 [text_extractor]
+                extractor = "tika"
                 url = "http://tika:9998/"
             },
         );

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -14,6 +14,7 @@ async-stream = "0.3.5"
 async-trait = { workspace = true }
 aws-config = "0.56.0"
 aws-sdk-sagemakerruntime = "0.29.0"
+base64 = "0.21.2"
 chrono = { workspace = true }
 clap = { version = "4.3.4", features = ["derive"] }
 const_format = "0.2.31"
@@ -26,6 +27,7 @@ figment = { workspace = true, features = ["env"] }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 mime = "0.3.17"
+mime_serde_shim = "0.2.2"
 ndarray = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }

--- a/web-api/compose.db.yml
+++ b/web-api/compose.db.yml
@@ -34,14 +34,30 @@ services:
       timeout: 5s
       retries: 5
 
-  db_ready:
-    image: debian:bookworm-slim
+  tika:
+    image: apache/tika:2.8.0.0-full
+    mem_limit: 256m
+    restart: always
+    ports:
+      - "9998:9998"
+    networks:
+      - internal
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider 'http://localhost:9998/'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  services_ready:
+    image: debian:12-slim
     command: echo dummy
     restart: "no"
     depends_on:
       elasticsearch:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      tika:
         condition: service_healthy
 
   # adminer:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Back Office API
-  version: 2.5.1
+  version: 2.6.0
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.
@@ -14,9 +14,9 @@ info:
     The API requires to set the `authorizationToken` header when used with the provided token.
 
     ## Document
-    As a document we consider a cohesive text, for example a complete news article.
-    However, we only require a simple representation for our system to work. Consisting just of a unique id, a text snippet, optional properties and optional tags.
+    As a document we consider a cohesive text, for example a complete news article. It consists just of a unique id, a text snippet or a file, optional properties and optional tags.
     The text snippet is ideally a short, meaningful representation of the larger document, reduced to just one paragraph.
+    In place of the text snippet it is possible to upload a file. The system will extract the text in the file and use that as the content of the document.
 
     ### Id
     The document id is a unique identifier for a single document.
@@ -80,8 +80,8 @@ paths:
       description: |-
         Upsert documents to the system, which creates a representation of the document that will be used to match it against the preferences of a user.
 
-        **Important note:** If you need to add more documents than the maximum batch size, then
-        please split up the total amount of documents in separate calls.
+        **Important note:** The maximum size for a request is 10Mb. This means that if you have big documents you would not be able to fill the request
+        to the maximum batch size.
 
         **Important note:** If a document id appears multiple times, only the last document with that id is retained.
       operationId: createDocuments
@@ -405,7 +405,7 @@ components:
             type: date
     IngestedDocument:
       type: object
-      required: [id, snippet]
+      required: [id]
       properties:
         id:
           $ref: './schemas/document.yml#/DocumentId'
@@ -415,10 +415,26 @@ components:
             Enclosing whitespace will be trimmed.
             The length constraints are in bytes, not characters.
             If `summarize` is enabled, then the length applies to the summarized instead of the original snippet.
+
+            One between `snippet` and `file` is required, but they are mutally exclusive.
           type: string
           minLength: 1
           maxLength: 2048
           pattern: '^[^\x00]+$'
+        file:
+          description: |-
+            A base64 encoded file. It file must be in one of the supported format (pdf, doc, etc.).
+            The text content will be automatically extracted and many snippets will be created for the given document id depeding on the length.
+            The length constraints are in bytes, not characters.
+            This option can only be used with split set to true and it does not work with summarization.
+
+            One between `file` and `snippet` is required, but they are mutally exclusive.
+
+            **Important note:** Uploading a file is not enabled by default, please write us if you needed it. If you try to use this when disabled
+            a bed request error will be returned.
+          type: string
+          minLength: 1
+          maxLength: 10000000
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
         tags:

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -433,6 +433,7 @@ components:
             **Important note:** Uploading a file is not enabled by default, please write us if you needed it. If you try to use this when disabled
             a bed request error will be returned.
           type: string
+          format: byte
           minLength: 1
           maxLength: 10000000
         properties:

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Front Office API
-  version: 2.5.1
+  version: 2.6.0
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.

--- a/web-api/src/app.rs
+++ b/web-api/src/app.rs
@@ -25,6 +25,7 @@ use tracing::{info, instrument};
 pub(crate) use self::state::{AppState, TenantState};
 use crate::{
     embedding,
+    extractor,
     logging,
     net::{self, AppHandle},
     storage,
@@ -40,6 +41,7 @@ pub trait Application: 'static {
         + AsRef<storage::Config>
         + AsRef<tenants::Config>
         + AsRef<embedding::Config>
+        + AsRef<extractor::Config>
         + DeserializeOwned
         + Serialize
         + Send

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -153,9 +153,30 @@ pub(crate) enum InvalidDocumentSnippet {
     InvalidString(InvalidString),
     /// Input document didn't yield any snippets
     NoSnippets {},
+    /// File is not base64 encoded
+    FileNotBase64Encoded,
 }
 
 impl_application_error!(InvalidDocumentSnippet => BAD_REQUEST, INFO);
+
+/// Binary upload feature it is not available.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) struct FileUploadNotEnabled;
+
+impl_application_error!(FileUploadNotEnabled => BAD_REQUEST, INFO);
+
+/// Content-type of the uploaded file is not supported.
+#[derive(Debug, Error, Display, Serialize)]
+pub(crate) enum InvalidBinary {
+    /// Unrecognized content-type.
+    Unrecognized,
+    /// Unsupported content-type. Found {found}
+    ContentType { found: String },
+    /// Invalid content
+    InvalidContent,
+}
+
+impl_application_error!(InvalidBinary => BAD_REQUEST, INFO);
 
 /// Malformed document query: {0}
 #[derive(Debug, Error, Display, Serialize)]

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -170,8 +170,8 @@ impl_application_error!(FileUploadNotEnabled => BAD_REQUEST, INFO);
 pub(crate) enum InvalidBinary {
     /// Unrecognized content-type.
     Unrecognized,
-    /// Unsupported content-type. Found {found}
-    ContentType { found: String },
+    /// Unsupported media type. Found {found}
+    MediaType { found: String },
     /// Invalid content
     InvalidContent,
 }

--- a/web-api/src/extractor.rs
+++ b/web-api/src/extractor.rs
@@ -1,0 +1,239 @@
+// Copyright 2023 Xayn AG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    cmp::Ordering,
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
+
+use derive_more::Display;
+use mime::{Mime, Name};
+use mime_serde_shim::Wrapper as SerDeMime;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use url::Url;
+
+use crate::{
+    error::common::{FileUploadNotEnabled, InvalidBinary},
+    ingestion::preprocessor::PreprocessError,
+    models::DocumentSnippet,
+};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Config {
+    /// File text extraction is available.
+    #[serde(default)]
+    pub(crate) enabled: bool,
+    #[serde(flatten)]
+    config: ExtractorConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "extractor")]
+pub enum ExtractorConfig {
+    #[serde(rename = "tika")]
+    Tika {
+        /// Tika server to contact
+        #[serde(default = "default_text_extractor_url")]
+        url: String,
+        /// Allowed content-type. If empty everything is allowed.
+        #[serde(default)]
+        allowed_content_type: Vec<SerDeMime>,
+    },
+}
+
+fn default_text_extractor_url() -> String {
+    "http://localhost:9998".into()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            config: ExtractorConfig::Tika {
+                url: default_text_extractor_url(),
+                allowed_content_type: Vec::new(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TikaResponse {
+    #[serde(rename = "Content-Type")]
+    content_type: String,
+
+    #[serde(rename = "X-TIKA:content")]
+    content: Option<String>,
+}
+
+// We want to compare only the type and subtype
+#[derive(Debug, Display)]
+struct CmpMime(Mime);
+
+impl CmpMime {
+    fn project(&self) -> (Name<'_>, Name<'_>) {
+        (self.0.type_(), self.0.subtype())
+    }
+}
+
+impl PartialEq for CmpMime {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+impl Eq for CmpMime {}
+
+impl PartialOrd for CmpMime {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CmpMime {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.project().cmp(&other.project())
+    }
+}
+
+impl Hash for CmpMime {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.project().hash(state);
+    }
+}
+
+/// Extract text and other information from different format
+pub(crate) struct TextExtractor {
+    inner: ExtractorInner,
+}
+
+impl TextExtractor {
+    pub(crate) fn new(config: &Config) -> Result<Self, anyhow::Error> {
+        if !config.enabled {
+            return Ok(Self {
+                inner: ExtractorInner::Disabled,
+            });
+        }
+
+        let inner = match &config.config {
+            ExtractorConfig::Tika {
+                url,
+                allowed_content_type,
+            } => {
+                let url = Url::parse(url)?;
+                if url.cannot_be_a_base() {
+                    return Err::<_, anyhow::Error>(anyhow::anyhow!("invalid url"));
+                }
+
+                ExtractorInner::Tika {
+                    client: Client::new(),
+                    url,
+                    allowed_content_type: allowed_content_type
+                        .iter()
+                        .map(|m| CmpMime(m.0.clone()))
+                        .collect(),
+                }
+            }
+        };
+
+        Ok(Self { inner })
+    }
+
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn extract_text(
+        &self,
+        data: Vec<u8>,
+    ) -> Result<DocumentSnippet, PreprocessError> {
+        self.inner.extract_text(data).await
+    }
+}
+
+enum ExtractorInner {
+    Disabled,
+    Tika {
+        client: Client,
+        url: Url,
+        allowed_content_type: HashSet<CmpMime>,
+    },
+}
+
+impl ExtractorInner {
+    pub(crate) async fn extract_text(
+        &self,
+        data: Vec<u8>,
+    ) -> Result<DocumentSnippet, PreprocessError> {
+        if data.is_empty() {
+            return Err(PreprocessError::Invalid(
+                InvalidBinary::InvalidContent.into(),
+            ));
+        }
+
+        match self {
+            Self::Disabled => Err(PreprocessError::Invalid(FileUploadNotEnabled.into())),
+            Self::Tika {
+                client,
+                url,
+                allowed_content_type,
+            } => {
+                let url = url.join("/rmeta/text").unwrap(/* url is a valid base */);
+                let mut response: Vec<TikaResponse> = client
+                    .put(url)
+                    .body(data)
+                    .send()
+                    .await
+                    .map_err(|e| PreprocessError::Fatal(e.into()))?
+                    .json()
+                    // tika wasn´t able to extract the text
+                    .await
+                    .map_err(|e| PreprocessError::Invalid(e.into()))?;
+
+                if response.is_empty() {
+                    return Err(PreprocessError::Invalid(InvalidBinary::Unrecognized.into()));
+                }
+                let response = response.remove(0);
+
+                let content_type =
+                    response
+                        .content_type
+                        .parse()
+                        .map_err(|e: mime::FromStrError| {
+                            info!("Unrecognized content-type from document: {}", e.to_string());
+                            PreprocessError::Invalid(InvalidBinary::Unrecognized.into())
+                        })?;
+                let content_type = CmpMime(content_type);
+
+                if !allowed_content_type.is_empty() && !allowed_content_type.contains(&content_type)
+                {
+                    return Err(PreprocessError::Invalid(
+                        InvalidBinary::ContentType {
+                            found: content_type.to_string(),
+                        }
+                        .into(),
+                    ));
+                }
+
+                if let Some(content) = response.content {
+                    DocumentSnippet::new(content, usize::MAX)
+                        .map_err(|e| PreprocessError::Invalid(e.into()))
+                } else {
+                    Err(PreprocessError::Invalid(
+                        InvalidBinary::InvalidContent.into(),
+                    ))
+                }
+            }
+        }
+    }
+}

--- a/web-api/src/extractor.rs
+++ b/web-api/src/extractor.rs
@@ -199,18 +199,16 @@ impl ExtractorInner {
                 }
                 let response = response.remove(0);
 
-                let media_type =
-                    response
-                        .media_type
-                        .parse()
-                        .map_err(|e: mime::FromStrError| {
-                            info!("Unrecognized media type: {}", e.to_string());
-                            PreprocessError::Invalid(InvalidBinary::Unrecognized.into())
-                        })?;
+                let media_type = response
+                    .media_type
+                    .parse()
+                    .map_err(|e: mime::FromStrError| {
+                        info!("Unrecognized media type: {}", e.to_string());
+                        PreprocessError::Invalid(InvalidBinary::Unrecognized.into())
+                    })?;
                 let content_type = CmpMime(media_type);
 
-                if !allowed_media_type.is_empty() && !allowed_media_type.contains(&content_type)
-                {
+                if !allowed_media_type.is_empty() && !allowed_media_type.contains(&content_type) {
                     return Err(PreprocessError::Invalid(
                         InvalidBinary::MediaType {
                             found: content_type.to_string(),

--- a/web-api/src/extractor.rs
+++ b/web-api/src/extractor.rs
@@ -133,16 +133,14 @@ impl TextExtractor {
             ExtractorConfig::Tika {
                 url,
                 allowed_content_type,
-            } => {
-                ExtractorInner::Tika {
-                    client: Client::new(),
-                    url: url.parse()?,
-                    allowed_content_type: allowed_content_type
-                        .iter()
-                        .map(|m| CmpMime(m.0.clone()))
-                        .collect(),
-                }
-            }
+            } => ExtractorInner::Tika {
+                client: Client::new(),
+                url: url.parse()?,
+                allowed_content_type: allowed_content_type
+                    .iter()
+                    .map(|m| CmpMime(m.0.clone()))
+                    .collect(),
+            },
         };
 
         Ok(Self { inner })

--- a/web-api/src/extractor.rs
+++ b/web-api/src/extractor.rs
@@ -218,7 +218,7 @@ impl ExtractorInner {
                 if !allowed_content_type.is_empty() && !allowed_content_type.contains(&content_type)
                 {
                     return Err(PreprocessError::Invalid(
-                        InvalidBinary::ContentType {
+                        InvalidBinary::MediaType {
                             found: content_type.to_string(),
                         }
                         .into(),

--- a/web-api/src/lib.rs
+++ b/web-api/src/lib.rs
@@ -35,6 +35,7 @@ mod app;
 pub mod config;
 mod embedding;
 mod error;
+pub mod extractor;
 mod ingestion;
 pub mod logging;
 mod middleware;

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -29,6 +29,7 @@ pub use self::{rerank::bench_rerank, stateless::bench_derive_interests};
 use crate::{
     app::{self, Application, SetupError},
     embedding,
+    extractor,
     logging,
     net,
     storage,
@@ -71,6 +72,7 @@ pub struct Config {
     pub(crate) storage: storage::Config,
     pub(crate) coi: CoiConfig,
     pub(crate) embedding: embedding::Config,
+    pub(crate) text_extractor: extractor::Config,
     pub(crate) personalization: PersonalizationConfig,
     pub(crate) semantic_search: SemanticSearchConfig,
     pub(crate) tenants: tenants::Config,

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": true,
     "enable_dev": false

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": true,
     "enable_dev": false

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -52,6 +52,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "personalization": {
     "max_number_documents": 100,
     "max_number_candidates": 100,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -56,7 +56,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "personalization": {
     "max_number_documents": 100,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": false,
     "enable_dev": false

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": false,
     "enable_dev": false

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": true,
     "enable_dev": false

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -61,7 +61,7 @@ stdout = """
     "enabled": false,
     "extractor": "tika",
     "url": "http://localhost:9998",
-    "allowed_content_type": []
+    "allowed_media_type": []
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -57,6 +57,12 @@ stdout = """
     "runtime": "assets",
     "token_size": 250
   },
+  "text_extractor": {
+    "enabled": false,
+    "extractor": "tika",
+    "url": "http://localhost:9998",
+    "allowed_content_type": []
+  },
   "tenants": {
     "enable_legacy_tenant": true,
     "enable_dev": false


### PR DESCRIPTION
Allow to upload a binary. We pass the binary through tika to extract the text.
By default, this is disabled at the system level. If used when disabled, an error that says that it is disabled is returned.
The text extractor configuration already provides a way to specify which extractor we are using to make it future-proof. At the moment, we don´t plan to use something else but it will make it easier to switch to something else. 

Some changes involve allowing the preprocess to return a bad request kind of error.

Also with updated spec.
