### PR TITLE
ET-4678 allow returning snippet

### DIFF
--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -117,6 +117,13 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/IncludeProperties'
+        - name: include_snippet
+          in: query
+          description:
+            $ref: '#/components/schemas/IncludeSnippet/description'
+          required: false
+          schema:
+            $ref: '#/components/schemas/IncludeSnippet'
         - name: filter
           in: query
           description:
@@ -305,6 +312,8 @@ components:
           $ref: './schemas/time.yml#/PublishedAfter'
         include_properties:
           $ref: '#/components/schemas/IncludeProperties'
+        include_snippet:
+          $ref: '#/components/schemas/IncludeSnippet'
         filter:
           description:
             $ref: '#/components/schemas/Filter/description'

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -224,6 +224,10 @@ components:
       description: Include the properties of each document in the response.
       type: boolean
       default: true
+    IncludeSnippet:
+      description: Includes the snippets text for each search result.
+      type: boolean
+      default: true
     FilterCompare:
       type: object
       additionalProperties:
@@ -316,6 +320,8 @@ components:
           $ref: './schemas/document.yml#/DocumentId'
         snippet_id:
           $ref: './schemas/document.yml#/SnippetId'
+        snippet:
+          $ref: './schemas/document.yml#/Snippet'
         score:
           description: A number where higher means better.
           type: number
@@ -354,6 +360,8 @@ components:
           $ref: './schemas/time.yml#/PublishedAfter'
         include_properties:
           $ref: '#/components/schemas/IncludeProperties'
+        include_snippet:
+          $ref: '#/components/schemas/IncludeSnippet'
         personalize:
           description: Personalize the ranking of candidates based on a users preferences.
           type: object

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -61,6 +61,16 @@ DocumentProperty:
     - $ref: '#/DocumentPropertyArrayString'
     - $ref: './time.yml#/Timestamp'
 
+Snippet:
+  description: |-
+    The text of the found snippet.
+
+    This can be the whole ingested document or a part of it depending on how the
+    document from which it stems was ingested.
+
+    Be aware that whitespace can differ between the original and the returned snippet.
+  type: text
+
 DocumentProperties:
   description: |-
     Mostly arbitrary properties that can be attached to a document, up to 2.5KB in size.

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -69,7 +69,7 @@ Snippet:
     document from which it stems was ingested.
 
     Be aware that whitespace can differ between the original and the returned snippet.
-  type: text
+  type: string
 
 DocumentProperties:
   description: |-

--- a/web-api/openapi/schemas/document.yml
+++ b/web-api/openapi/schemas/document.yml
@@ -66,7 +66,7 @@ Snippet:
     The text of the found snippet.
 
     This can be the whole ingested document or a part of it depending on how the
-    document from which it stems was ingested.
+    document was ingested.
 
     Be aware that whitespace can differ between the original and the returned snippet.
   type: string

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -466,6 +466,8 @@ struct UnvalidatedSemanticSearchRequest {
     dev: DevOption,
     #[serde(default = "default_include_properties")]
     include_properties: bool,
+    #[serde(default)]
+    include_snippet: bool,
     filter: Option<Filter>,
 }
 
@@ -474,16 +476,11 @@ struct UnvalidatedSemanticSearchRequest {
 struct DevOption {
     hybrid: Option<DevHybrid>,
     max_number_candidates: Option<usize>,
-    include_snippet: Option<bool>,
 }
 
 impl DevOption {
     fn validate(&self, enable_dev: bool) -> Result<(), Error> {
-        if !enable_dev
-            && (self.hybrid.is_some()
-                || self.max_number_candidates.is_some()
-                || self.include_snippet.is_some())
-        {
+        if !enable_dev && (self.hybrid.is_some() || self.max_number_candidates.is_some()) {
             // notify the caller instead of silently discarding the dev option
             return Err(ForbiddenDevOption::DevDisabled.into());
         }
@@ -550,6 +547,7 @@ impl UnvalidatedSemanticSearchRequest {
             enable_hybrid_search,
             dev,
             include_properties,
+            include_snippet,
             filter,
         } = self;
         let semantic_search_config: &SemanticSearchConfig = config.as_ref();
@@ -584,7 +582,7 @@ impl UnvalidatedSemanticSearchRequest {
             enable_hybrid_search,
             dev_hybrid_search,
             include_properties,
-            include_snippet: dev.include_snippet.unwrap_or_default(),
+            include_snippet,
             filter,
             is_deprecated,
         })

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -164,6 +164,8 @@ struct UnvalidatedPersonalizedDocumentsRequest {
     filter: Option<Filter>,
     #[serde(default = "default_include_properties")]
     include_properties: bool,
+    #[serde(default)]
+    include_snippet: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -174,6 +176,8 @@ struct UnvalidatedPersonalizedDocumentsQuery {
     filter: Option<String>,
     #[serde(default = "default_include_properties")]
     include_properties: bool,
+    #[serde(default)]
+    include_snippet: bool,
 }
 
 #[derive(Debug)]
@@ -181,6 +185,7 @@ struct PersonalizedDocumentsRequest {
     count: usize,
     filter: Option<Filter>,
     include_properties: bool,
+    include_snippet: bool,
     is_deprecated: bool,
 }
 
@@ -195,6 +200,7 @@ impl UnvalidatedPersonalizedDocumentsRequest {
             published_after,
             filter,
             include_properties,
+            include_snippet,
         } = self;
         let config = config.as_ref();
 
@@ -214,6 +220,7 @@ impl UnvalidatedPersonalizedDocumentsRequest {
             count,
             filter,
             include_properties,
+            include_snippet,
             is_deprecated,
         })
     }
@@ -231,6 +238,7 @@ async fn personalized_documents(
         count,
         filter,
         include_properties,
+        include_snippet,
         is_deprecated,
     } = if let Some(Json(body)) = body {
         body.validate_and_resolve_defaults(&state.config, &storage)
@@ -244,6 +252,7 @@ async fn personalized_documents(
                 .map(|filter| serde_json::from_str(&filter))
                 .transpose()?,
             include_properties: params.include_properties,
+            include_snippet: params.include_snippet,
         }
         .validate_and_resolve_defaults(&state.config, &storage)
         .await?
@@ -267,7 +276,7 @@ async fn personalized_documents(
         },
         Utc::now(),
         include_properties,
-        false,
+        include_snippet,
     )
     .await?
     {

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -391,7 +391,7 @@ fn test_semantic_search_with_dev_option_snippet() {
                     .json(&json!({
                         "document": { "query": "this is one sentence" },
                         "count": 3,
-                        "_dev": { "include_snippet": true }
+                        "include_snippet": true,
                     }))
                     .build()?,
                 StatusCode::OK,

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -96,7 +96,7 @@ async fn query(
                 "document": { "query": text },
                 "count": count,
                 "filter": filter,
-                "_dev": { "include_snippet": true }
+                "include_snippet": true,
             }))
             .build()?,
         StatusCode::OK,


### PR DESCRIPTION
Turns the `_dev.include_snippet` option into a non-dev and documented option.

Also adds it to all endpoints which have `include_properties` and didn't yet had a `_dev.include_snippet` option.

**References:**

- issue: [ET-4678]

[ET-4678]: https://xainag.atlassian.net/browse/ET-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ