### PR TITLE
ET-4999 make search query size configurable

### DIFF
--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -15,12 +15,13 @@
 use std::{
     borrow::Cow,
     fmt::{Debug, Display},
+    ops::{Bound, RangeBounds},
 };
 
 use actix_web::http::StatusCode;
 use derive_more::From;
 use displaydoc::Display;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use serde_json::Value;
 use thiserror::Error;
 use tracing::Level;
@@ -53,10 +54,66 @@ impl_application_error!(DocumentPropertyNotFound => BAD_REQUEST, INFO);
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidString {
-    /// Invalid byte size. Got {got}, expected {min}..={max}.
-    Size { got: usize, min: usize, max: usize },
+    /// Invalid byte size. Got {got}, expected {bounds:?}.
+    Size {
+        got: usize,
+        bounds: RangeBoundsInError,
+    },
     /// Invalid syntax, expected: {expected}
     Syntax { expected: &'static str },
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+pub(crate) struct RangeBoundsInError {
+    start: Bound<usize>,
+    end: Bound<usize>,
+}
+
+impl RangeBoundsInError {
+    pub(crate) fn new(bound: impl RangeBounds<usize>) -> Self {
+        Self {
+            start: bound.start_bound().cloned(),
+            end: bound.end_bound().cloned(),
+        }
+    }
+}
+
+impl<T> From<T> for RangeBoundsInError
+where
+    T: RangeBounds<usize>,
+{
+    fn from(value: T) -> Self {
+        RangeBoundsInError::new(value)
+    }
+}
+
+impl Debug for RangeBoundsInError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.start {
+            Bound::Included(bound) => write!(f, "{bound}")?,
+            Bound::Excluded(bound) => write!(f, "{bound}<")?,
+            Bound::Unbounded => (),
+        }
+
+        f.write_str("..")?;
+
+        match self.end {
+            Bound::Included(bound) => write!(f, "={bound}")?,
+            Bound::Excluded(bound) => write!(f, "{bound}")?,
+            Bound::Unbounded => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl Serialize for RangeBoundsInError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        format!("{self:?}").serialize(serializer)
+    }
 }
 
 /// Malformed user id: {0}
@@ -150,7 +207,7 @@ impl_application_error!(InvalidDocumentTags => BAD_REQUEST, INFO);
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidDocumentSnippet {
     /// Malformed document snippet: {0}
-    InvalidString(InvalidString),
+    InvalidString(#[from] InvalidString),
     /// Input document didn't yield any snippets
     NoSnippets {},
     /// File is not base64 encoded
@@ -390,5 +447,20 @@ impl ApplicationError for PoolAcquisitionError {
 
     fn encode_details(&self) -> Value {
         Value::Null
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_range_bound_formatting() {
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(..)), "..");
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(1..)), "1..");
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(..1)), "..1");
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(1..2)), "1..2");
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(..=1)), "..=1");
+        assert_eq!(format!("{:?}", RangeBoundsInError::new(1..=2)), "1..=2");
     }
 }

--- a/web-api/src/error/common.rs
+++ b/web-api/src/error/common.rs
@@ -49,7 +49,7 @@ pub(crate) struct DocumentPropertyNotFound;
 
 impl_application_error!(DocumentPropertyNotFound => BAD_REQUEST, INFO);
 
-#[derive(Debug, Display, Serialize)]
+#[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InvalidString {
@@ -62,7 +62,7 @@ pub(crate) enum InvalidString {
 /// Malformed user id: {0}
 #[derive(Debug, Error, Display, Serialize)]
 #[serde(transparent)]
-pub(crate) struct InvalidUserId(pub(crate) InvalidString);
+pub(crate) struct InvalidUserId(#[from] InvalidString);
 
 impl_application_error!(InvalidUserId => BAD_REQUEST, INFO);
 
@@ -70,7 +70,7 @@ impl_application_error!(InvalidUserId => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(transparent)]
-pub(crate) struct InvalidDocumentId(pub(crate) InvalidString);
+pub(crate) struct InvalidDocumentId(#[from] InvalidString);
 
 impl_application_error!(InvalidDocumentId => BAD_REQUEST, INFO);
 
@@ -78,7 +78,7 @@ impl_application_error!(InvalidDocumentId => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(transparent)]
-pub(crate) struct InvalidDocumentPropertyId(pub(crate) InvalidString);
+pub(crate) struct InvalidDocumentPropertyId(#[from] InvalidString);
 
 impl_application_error!(InvalidDocumentPropertyId => BAD_REQUEST, INFO);
 
@@ -133,7 +133,7 @@ impl_application_error!(InvalidDocumentProperties => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(transparent)]
-pub(crate) struct InvalidDocumentTag(pub(crate) InvalidString);
+pub(crate) struct InvalidDocumentTag(#[from] InvalidString);
 
 impl_application_error!(InvalidDocumentTag => BAD_REQUEST, INFO);
 
@@ -182,7 +182,7 @@ impl_application_error!(InvalidBinary => BAD_REQUEST, INFO);
 #[derive(Debug, Error, Display, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(transparent)]
-pub(crate) struct InvalidDocumentQuery(pub(crate) InvalidString);
+pub(crate) struct InvalidDocumentQuery(#[from] InvalidString);
 
 impl_application_error!(InvalidDocumentQuery => BAD_REQUEST, INFO);
 

--- a/web-api/src/extractor.rs
+++ b/web-api/src/extractor.rs
@@ -218,7 +218,7 @@ impl ExtractorInner {
                 }
 
                 if let Some(content) = response.content {
-                    DocumentSnippet::new(content, usize::MAX)
+                    DocumentSnippet::new_with_length_constraint(content, 1..)
                         .map_err(|e| PreprocessError::Invalid(e.into()))
                 } else {
                     Err(PreprocessError::Invalid(

--- a/web-api/src/ingestion/preprocessor.rs
+++ b/web-api/src/ingestion/preprocessor.rs
@@ -110,7 +110,7 @@ where
     let snippets = snippets
         .into_iter()
         .map(|split| async move {
-            let snippet = DocumentSnippet::new(split, usize::MAX)?;
+            let snippet = DocumentSnippet::new_with_length_constraint(split, 1..)?;
             let embedding = embedder.run(&snippet).await?;
             Ok::<_, Error>(DocumentContent { snippet, embedding })
         })

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -125,9 +125,9 @@ impl InputDataRequest {
 
     fn validate(self, config: &IngestionConfig) -> Result<InputData, InvalidDocumentSnippet> {
         Ok(match self {
-            InputDataRequest::Snippet(snippet) => {
-                InputData::Snippet(DocumentSnippet::new(snippet, config.max_snippet_size)?)
-            }
+            InputDataRequest::Snippet(snippet) => InputData::Snippet(
+                DocumentSnippet::new_with_length_constraint(snippet, 1..=config.max_snippet_size)?,
+            ),
             InputDataRequest::File(encoded_bin) => InputData::Binary(
                 general_purpose::STANDARD
                     .decode(encoded_bin)

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -154,6 +154,9 @@ pub(crate) struct SemanticSearchConfig {
     /// Weights for reranking of the scores. Each weight is in `[0, 1]` and they add up to `1`. The
     /// order is `[interest_weight, tag_weight, elasticsearch_weight]`.
     pub(crate) score_weights: [f32; 3],
+
+    /// Max number of bytes a query can have
+    pub(crate) max_query_size: usize,
 }
 
 impl Default for SemanticSearchConfig {
@@ -163,6 +166,7 @@ impl Default for SemanticSearchConfig {
             max_number_candidates: 100,
             default_number_documents: 10,
             score_weights: [1., 1., 0.5],
+            max_query_size: 512,
         }
     }
 }
@@ -175,6 +179,9 @@ impl SemanticSearchConfig {
         }
         if self.default_number_documents > self.max_number_documents {
             bail!("invalid SemanticSearchConfig, default_number_documents must be <= max_number_documents");
+        }
+        if self.max_query_size < 1 {
+            bail!("max_query_size needs to be at least 1");
         }
 
         Ok(())

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -757,7 +757,8 @@ mod tests {
                 id: id.document_id().clone(),
                 original_sha256: Sha256Hash::calculate(b"snippet"),
                 snippets: vec![DocumentContent {
-                    snippet: DocumentSnippet::new("snippet", 100).unwrap(),
+                    snippet: DocumentSnippet::new_with_length_constraint("snippet", 1..=100)
+                        .unwrap(),
                     embedding,
                 }],
                 preprocessing_step: PreprocessingStep::None,
@@ -820,7 +821,7 @@ mod tests {
     async fn test_serde() {
         let storage = Storage::default();
         let doc_id = SnippetId::new(DocumentId::try_from("42").unwrap(), 0);
-        let snippet = DocumentSnippet::new("snippet", 100).unwrap();
+        let snippet = DocumentSnippet::new_with_length_constraint("snippet", 1..=100).unwrap();
         let tags = DocumentTags::try_from(vec!["tag".try_into().unwrap()]).unwrap();
         let embedding = NormalizedEmbedding::try_from([1., 2., 3.]).unwrap();
         storage::Document::insert(

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -80,7 +80,8 @@ stdout = """
       1.0,
       1.0,
       0.5
-    ]
+    ],
+    "max_query_size": 512
   },
   "tenants": {
     "enable_legacy_tenant": true,

--- a/web-api/tests/ingestion.rs
+++ b/web-api/tests/ingestion.rs
@@ -163,8 +163,7 @@ fn test_ingestion_bad_request() {
                     "invalid_string": {
                         "size": {
                             "got": 2049,
-                            "min": 1,
-                            "max": 2048,
+                            "bounds": "1..=2048",
                         }
                     }
                 }
@@ -636,8 +635,7 @@ fn test_ingestion_validation() {
                         "invalid_string": {
                             "size": {
                                 "got": 11,
-                                "min": 1,
-                                "max": 10
+                                "bounds": "1..=10",
                             }
                         }
                     }


### PR DESCRIPTION
- updated `string_wrapper!` to allow not having a hard coded len bound 
- now we can use it again for `DocumentSnippet`, so we do so
- then change `DocumentQuery` to not use a hard coded bound

**References:**

- issue: [ET-4999]

[ET-4999]: https://xainag.atlassian.net/browse/ET-4999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ