### PR TITLE
parallel polling in hybrid search

### DIFF
--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -145,7 +145,6 @@ impl Client {
             }),
             generic_parameters,
         ]);
-        // FIXME parallelize polling
         let bm25_scores = self.search_request(bm25, SnippetId::try_from_es_id);
 
         let (knn_scores, bm25_scores) = join!(knn_scores, bm25_scores);


### PR DESCRIPTION
We just realized that we never fixed the "FIXME parallelize polling".

This will poll knn/bm25 in hybrid search.

Through this could affect load characteristics on ES in unexpected ways.