### PR TITLE
fix typo and formatting

### DIFF
--- a/docs/source/getting_started/getting_started.md
+++ b/docs/source/getting_started/getting_started.md
@@ -135,7 +135,7 @@ curl -X PATCH "$URL/users/u1234/interactions" \
 ```
 
 ```{note}
-Please note that if an interaction between a user and a document is added, the document will **not** be part of the documents returned for future calls to the personalised endpoint. This includes all snippets associated to that document
+Please note that if an interaction between a user and a document is added, the document will **not** be part of the documents returned for future calls to the personalised endpoint. This includes all snippets associated to that document.
 ```
 
 Let's ask for personalised documents again now:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Xayn Api
 
 The API allows you to integrate Xayn's Personalised Semantic Search and Recommendations service into your systems. 
 
-The API is divided into two parts: the back office and the front office. The back office allows you to manage everything related to your content. In the Xayn service, every piece of content is managed as _document_'s. 
+The API is divided into two parts: the back office and the front office. The back office allows you to manage everything related to your content. In the Xayn service, every piece of content is managed as *document*'s. 
 The front office allows you to interact with the service to manage the users' interactions (clicks, reading, viewing) with your content, request recommendations, or perform searches.
 
 |Overview|


### PR DESCRIPTION
[RST uses asterisks to show text as italic](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/inline.html#italic-text)

<img width="848" alt="Screenshot 2023-09-19 at 15 16 23" src="https://github.com/xaynetwork/xayn_discovery_engine/assets/10488408/77be01fb-7ce4-403c-94a6-41937b9d48bc">
