### PR TITLE
Allow unknow field in config

### DIFF
--- a/coi/src/config.rs
+++ b/coi/src/config.rs
@@ -25,7 +25,8 @@ use crate::{
 
 /// Configurations of the coi system.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 #[must_use]
 pub struct Config {
     shift_factor: f32,

--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -50,7 +50,8 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     pub url: String,
     pub user: String,

--- a/web-api-shared/src/net.rs
+++ b/web-api-shared/src/net.rs
@@ -33,7 +33,7 @@ use tracing::warn;
 use crate::serde::serde_duration_in_config;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct ExponentialJitterRetryPolicyConfig {
     pub max_retries: u8,
     #[serde(with = "serde_duration_in_config")]

--- a/web-api-shared/src/postgres.rs
+++ b/web-api-shared/src/postgres.rs
@@ -26,7 +26,8 @@ use crate::{request::TenantId, serde::serialize_redacted};
 pub type Client = Pool<Postgres>;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     /// The default base url.
     ///

--- a/web-api/src/embedding.rs
+++ b/web-api/src/embedding.rs
@@ -34,7 +34,8 @@ impl Default for Config {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Pipeline {
     #[serde(deserialize_with = "RelativePathBuf::deserialize_string")]
     pub(crate) directory: RelativePathBuf,

--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -85,7 +85,8 @@ impl AppState {
 }
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     pub(crate) logging: logging::Config,
     pub(crate) net: net::Config,
@@ -98,7 +99,8 @@ pub struct Config {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct IngestionConfig {
     pub(crate) max_document_batch_size: usize,
     pub(crate) max_indexed_properties: usize,

--- a/web-api/src/logging.rs
+++ b/web-api/src/logging.rs
@@ -54,7 +54,8 @@ mod serde_level_filter {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     pub file: Option<RelativePathBuf>,
     #[serde(with = "serde_level_filter")]

--- a/web-api/src/net.rs
+++ b/web-api/src/net.rs
@@ -51,7 +51,8 @@ use crate::middleware::{
 /// Configuration for roughly network/connection layer specific configurations.
 // Hint: this value just happens to be copy, if needed the Copy trait can be removed
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     /// Address to which the server should bind.
     pub(crate) bind_to: SocketAddr,

--- a/web-api/src/personalization.rs
+++ b/web-api/src/personalization.rs
@@ -67,7 +67,8 @@ impl Application for Personalization {
 type AppState = app::AppState<Personalization>;
 
 #[derive(AsRef, Debug, Default, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     pub(crate) logging: logging::Config,
     pub(crate) net: net::Config,
@@ -81,7 +82,8 @@ pub struct Config {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub(crate) struct PersonalizationConfig {
     /// Max number of documents to return.
     pub(crate) max_number_documents: usize,
@@ -141,7 +143,8 @@ impl PersonalizationConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub(crate) struct SemanticSearchConfig {
     /// Max number of documents to return.
     pub(crate) max_number_documents: usize,

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -298,7 +298,8 @@ pub(crate) trait IndexedProperties {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     elastic: elastic::Config,
     postgres: postgres_shared::Config,

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -421,7 +421,8 @@ impl SerializeDocumentIds for HashSet<DocumentId> {}
 impl SerializeDocumentIds for HashSet<&'_ DocumentId> {}
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub(crate) struct IndexUpdateConfig {
     requests_per_second: usize,
     method: IndexUpdateMethod,

--- a/web-api/src/tenants.rs
+++ b/web-api/src/tenants.rs
@@ -15,7 +15,8 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
+#[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct Config {
     pub(crate) enable_legacy_tenant: bool,
     pub(crate) enable_dev: bool,


### PR DESCRIPTION
Having `deny_unknow_fields` makes it impossible to manage the infrastructure with different images. I left it for the test if it makes it easier to find obsolete options in those.