### PR TITLE
ET-5027 increase timeout to 20 min

### DIFF
--- a/.github/workflows/web-service.yml
+++ b/.github/workflows/web-service.yml
@@ -95,7 +95,7 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: services-build
     steps:
       - name: Checkout repository


### PR DESCRIPTION
the docker job often takes longer than 10 min. This pr increases the timeout to 20min 
- https://github.com/xaynetwork/xayn_discovery_engine/actions/runs/6239554682/job/16938040018
- https://github.com/xaynetwork/xayn_discovery_engine/actions/runs/6246363316/attempts/1
- https://github.com/xaynetwork/xayn_discovery_engine/actions/runs/6238156583/attempts/1
- https://github.com/xaynetwork/xayn_discovery_engine/actions/runs/6238156583/attempts/2