### PR TITLE
ET-5059 rename personalize to recommendations

### DIFF
--- a/docs/source/getting_started/getting_started.md
+++ b/docs/source/getting_started/getting_started.md
@@ -94,16 +94,16 @@ article, a title, a link to an image, and a text preview. Some of the examples b
 
 ## Recommendations
 
-After ingestion, we can use the front office to retrieve recommendations, which we call personalised documents, and implement a 'for you' section.
+After ingestion, we can use the front office to retrieve recommendations and implement a 'for you' section.
 
 From a system perspective, a user is represented by an ID that is needed to group their interactions. We don't need to know who this user is, so it is preferable to create this ID in a privacy-protecting way. For example, create a hash method that converts your user into an ID hash. Please ensure you don't use any sensitive or personally identifiable information (PII).
 
 Let's use `u1234` as the user ID for our example.
 
-We ask the system for [personalised documents](https://docs.xayn.com/front_office.html#tag/search/operation/getPersonalizedDocuments) for this user.
+We ask the system for [recommendations](https://docs.xayn.com/front_office.html#tag/search/operation/getRecommendations) for this user.
 
 ```bash
-curl -X POST "$URL/users/u1234/personalized_documents" \
+curl -X POST "$URL/users/u1234/recommendations" \
     --header "authorizationToken: $FRONTOFFICE_TOKEN" \
     --header "Content-Type: application/json"
 ```
@@ -139,7 +139,7 @@ Please note that if an interaction between a user and a document is added, the d
 Let's ask for recommendations again:
 
 ```bash
-curl -X POST "$URL/users/u1234/personalized_documents" \
+curl -X POST "$URL/users/u1234/recommendations" \
     --header "authorizationToken: $FRONTOFFICE_TOKEN" \
     --header "Content-Type: application/json" \
     --data '{
@@ -286,10 +286,10 @@ Similar to other APIs, using the [snippet id](#documents-with-multiple-snippets)
 
 Finding specific documents in large datasets based on a key-phrase or their relation to other documents can often be challenging. To address this issue, we can employ a structured filter on one or more of the `properties` fields to narrow down the search scope.
 
-The `filter` functionality is available in the [`/semantic_search`](https://docs.xayn.com/front_office.html#tag/search/operation/getSimilarDocuments) and [`/users/{user_id}/personalized_documents`](https://docs.xayn.com/front_office.html#tag/search/operation/getPersonalizedDocuments) endpoints, and it involves a two-step process:
+The `filter` functionality is available in the [`/semantic_search`](https://docs.xayn.com/front_office.html#tag/search/operation/getSimilarDocuments) and [`/users/{user_id}/recommendations`](https://docs.xayn.com/front_office.html#tag/search/operation/getPersonalizedDocuments) endpoints, and it involves a two-step process:
 
 1. Indexing the desired property field for the filter to operate on.
-2. Applying the `filter` in the request to `/semantic_search` or `/users/{user_id}/personalized_documents`.
+2. Applying the `filter` in the request to `/semantic_search` or `/users/{user_id}/recommendations`.
 
 ```{note}
 Please note that the __first step__ is necessary to leverage the filtering at all.
@@ -335,7 +335,7 @@ After a short indexing period, depending on the number of ingested documents, we
 
 #### Applying a Filter
 
-Applying a filter then just requires to use the `filter` property in the `/semantic_search` or `/users/{user_id}/personalized_documents` query parameter. In the following two examples we simply filter for the tag `conference`.
+Applying a filter then just requires to use the `filter` property in the `/semantic_search` or `/users/{user_id}/recommendations` query parameter. In the following two examples we simply filter for the tag `conference`.
 
 ```{code-block} bash
 :caption: /semantic_search
@@ -359,12 +359,12 @@ curl -X POST "$URL/semantic_search" \
     }'
 ```
 
-In `personalized_documents` the filter is applied in a similar way:
+In `recommendations` the filter is applied in a similar way:
 
 ```{code-block} bash
-:caption: /users/{user_id}/personalized_documents
+:caption: /users/{user_id}/recommendations
 
-curl -X POST "$URL/users/u1234/personalized_documents" \
+curl -X POST "$URL/users/u1234/recommendations" \
     --header "authorizationToken: $FRONTOFFICE_TOKEN" \
     --header "Content-Type: application/json" \
     --data '{
@@ -382,9 +382,9 @@ curl -X POST "$URL/users/u1234/personalized_documents" \
 Filter APIs can also work with rfc3339 formatted strings if the field is of type `date`:
 
 ```{code-block} bash
-:caption: /users/{user_id}/personalized_documents
+:caption: /users/{user_id}/recommendations
 
-curl -X POST "$URL/users/u1234/personalized_documents" \
+curl -X POST "$URL/users/u1234/recommendations" \
     --header "authorizationToken: $FRONTOFFICE_TOKEN" \
     --header "Content-Type: application/json" \
     --data '{

--- a/web-api/openapi/CHANGELOG.md
+++ b/web-api/openapi/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.7.0 - 2023-10-09
+
+- renamed `/users/{user_id}/personalized_documents` to `/users/{user_id}/recommendations`
+
+# 2.6.0 - 2023-09-06
+
+- added upload file API
 # 2.5.0 - 2023-07-31
 
 - Generalize scores in search results

--- a/web-api/openapi/back_office.yaml
+++ b/web-api/openapi/back_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Back Office API
-  version: 2.6.0
+  version: 2.7.0
   description: |-
     # Back Office
     This API acts as a create/read/update/delete interface for anything related to documents.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -58,7 +58,7 @@ security:
   - ApiKeyAuth: []
 
 paths:
-  /users/{user_id}/personalized_documents:
+  /users/{user_id}/recommendations:
     parameters:
       - $ref: './parameters/path/id.yml#/UserId'
 
@@ -68,6 +68,54 @@ paths:
         - search
       summary: Personalize documents for the user
       description: |-
+        Finds a number of recommendations for the given `user_id`.
+
+        Recommendations are based on snippets and each recommendation contains the snippet id it is based on as
+        well as a score. A higher score means that the document matches the preferences of the user better.
+        Scores can be compared only with other scores that belong to the same request; comparing scores of documents that have been obtained through different requests can lead to unexpected results.
+
+        Depending on the request parameters the recommendation can also include additional fields.
+
+        The recommendations also contain the properties of the snippets parent document if this is requested and the properties are not empty.
+
+        Documents that have been interacted with by the user are filtered out from the result.
+
+        Note that you can request personalized documents for a specific `user_id`, only after that same `user_id` has made enough interactions via our system.
+      operationId: getRecommendations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendationRequest'
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationResponse'
+        '400':
+          $ref: './responses/generic.yml#/BadRequest'
+        '409':
+          description: Impossible to create a personalized documents for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendationError'
+
+  /users/{user_id}/personalized_documents:
+    parameters:
+      - $ref: './parameters/path/id.yml#/UserId'
+
+    post:
+      tags:
+        - front office
+        - search
+      deprecated: true
+      summary: Personalize documents for the user
+      description: |-
+        Use `/users/{user_id}/recommendations` instead.
+
         Get a list of snippets personalized for the given `user_id`.
 
         Each snippet has an id and contains the id of the document it originates from as well as a score. A higher score means that the document matches the preferences of the user better.
@@ -81,14 +129,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PersonalizedDocumentsRequest'
+              $ref: '#/components/schemas/RecommendationRequest'
       responses:
         '200':
           description: Successful operation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonalizedDocumentsResponse'
+                $ref: '#/components/schemas/RecommendationResponse'
         '400':
           $ref: './responses/generic.yml#/BadRequest'
         '409':
@@ -96,7 +144,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonalizedDocumentsError'
+                $ref: '#/components/schemas/RecommendationError'
 
     get:
       tags:
@@ -148,7 +196,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonalizedDocumentsResponse'
+                $ref: '#/components/schemas/RecommendationResponse'
         '400':
           $ref: './responses/generic.yml#/BadRequest'
         '409':
@@ -156,7 +204,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonalizedDocumentsError'
+                $ref: '#/components/schemas/RecommendationError'
 
   /users/{user_id}/interactions:
     patch:
@@ -315,7 +363,7 @@ components:
       oneOf:
         - $ref: '#/components/schemas/FilterCompare'
         - $ref: '#/components/schemas/FilterCombine'
-    PersonalizedDocumentsRequest:
+    RecommendationRequest:
       type: object
       properties:
         count:
@@ -336,7 +384,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/FilterCompare'
             - $ref: '#/components/schemas/FilterCombine'
-    PersonalizedDocumentData:
+    SearchResultEntry:
       type: object
       required: [id, snippet_id, score]
       properties:
@@ -352,18 +400,18 @@ components:
           type: number
         properties:
           $ref: './schemas/document.yml#/DocumentProperties'
-    PersonalizedDocuments:
+    SearchResults:
       type: array
       minItems: 0
       maxItems: 100
       items:
-        $ref: '#/components/schemas/PersonalizedDocumentData'
-    PersonalizedDocumentsResponse:
+        $ref: '#/components/schemas/SearchResultEntry'
+    RecommendationResponse:
       type: object
       required: [documents]
       properties:
         documents:
-          $ref: '#/components/schemas/PersonalizedDocuments'
+          $ref: '#/components/schemas/SearchResults'
       example:
         documents:
           - id: 'document_id0'
@@ -422,7 +470,7 @@ components:
       required: [documents]
       properties:
         documents:
-          $ref: '#/components/schemas/PersonalizedDocuments'
+          $ref: '#/components/schemas/SearchResults'
       example:
         documents:
           - id: 'document_id0'
@@ -432,7 +480,7 @@ components:
             score: 0.87
             properties:
               title: "News title"
-    PersonalizedDocumentsError:
+    RecommendationError:
       allOf:
         - $ref: './schemas/error.yml#/GenericError'
         - type: object

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -42,15 +42,18 @@ tags:
   - name: front office
     description: Handles interactions between users and documents and allows to fetch personalized documents per user.
     x-traitTag: true
+  - name: recommendation
+    x-displayName: Recommendation
   - name: interaction
     x-displayName: Interaction
   - name: search
     x-displayName: Search
 x-tagGroups:
-  - name: Interaction
+  - name: Recommendation API
     tags:
+      - recommendation
       - interaction
-  - name: Search
+  - name: Search API
     tags:
       - search
 
@@ -65,8 +68,8 @@ paths:
     post:
       tags:
         - front office
-        - search
-      summary: Personalize documents for the user
+        - recommendation
+      summary: Provides recommendations for a given user
       description: |-
         Finds a number of recommendations for the given `user_id`.
 
@@ -110,7 +113,7 @@ paths:
     post:
       tags:
         - front office
-        - search
+        - recommendation
       deprecated: true
       summary: Personalize documents for the user
       description: |-
@@ -149,7 +152,7 @@ paths:
     get:
       tags:
         - front office
-        - search
+        - recommendation
       deprecated: true
       summary: Get personalized snippets for the user
       description: Deprecated. Use `POST /users/{user_id}/personalized_documents` instead.

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Front Office API
-  version: 2.6.0
+  version: 2.7.0
   description: |-
     # Front Office
     The front office is typically used within front-end apps, for example a website or a mobile application.

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -66,11 +66,14 @@ use crate::{
 pub(super) fn configure_service(config: &mut ServiceConfig) {
     let users = web::scope("/users/{user_id}")
         .service(web::resource("interactions").route(web::patch().to(interactions)))
+        .service(web::resource("recommendations").route(web::post().to(recommendations)))
         .service(
             web::resource("personalized_documents")
-                .route(web::post().to(personalized_documents))
+                .route(web::post().to(deprecate!(recommendations(
+                    state, user_id, body, params, storage,
+                ))))
                 // this route is deprecated and will be removed in the future
-                .route(web::get().to(deprecate!(personalized_documents(
+                .route(web::get().to(deprecate!(recommendations(
                     state, user_id, body, params, storage,
                 )))),
         );
@@ -226,7 +229,7 @@ impl UnvalidatedPersonalizedDocumentsRequest {
     }
 }
 
-async fn personalized_documents(
+async fn recommendations(
     state: Data<AppState>,
     user_id: Path<String>,
     body: Option<Json<UnvalidatedPersonalizedDocumentsRequest>>,

--- a/web-api/tests/et_4957_es_deletion.rs
+++ b/web-api/tests/et_4957_es_deletion.rs
@@ -190,15 +190,11 @@ async fn interact(
     Ok(())
 }
 
-async fn personalized_documents(
-    client: &Client,
-    url: &Url,
-    user: &str,
-) -> Result<Vec<String>, Error> {
+async fn recommendations(client: &Client, url: &Url, user: &str) -> Result<Vec<String>, Error> {
     let mut url = url.clone();
     url.path_segments_mut()
         .unwrap()
-        .extend(["users", user, "personalized_documents"]);
+        .extend(["users", user, "recommendations"]);
     let request = client.post(url).build()?;
     let response: Response = send_assert_json(client, request, StatusCode::OK, false).await;
     return Ok(response.documents.into_iter().map(|doc| doc.id).collect());
@@ -262,7 +258,7 @@ fn test_deletes_them_from_elastic_search() {
             interact(&client, &personalization_url, "u1", ["d3"]).await?;
             interact(&client, &personalization_url, "u1", ["d7"]).await?;
 
-            assert!(!personalized_documents(&client, &personalization_url, "u1")
+            assert!(!recommendations(&client, &personalization_url, "u1")
                 .await?
                 .is_empty());
 
@@ -318,7 +314,7 @@ fn test_deletes_them_from_elastic_search() {
             set_candidates(&client, &ingestion_url, ["d5"]).await?;
             assert_eq!(documents_from_es(&services).await?, string_set(["d5"]));
             assert_eq!(
-                personalized_documents(&client, &personalization_url, "u1").await?,
+                recommendations(&client, &personalization_url, "u1").await?,
                 vec!["d5".to_owned()]
             );
 

--- a/web-api/tests/split_documents.rs
+++ b/web-api/tests/split_documents.rs
@@ -454,7 +454,7 @@ fn test_endpoints_which_do_not_yet_fully_support_split_do_not_fall_over() {
             send_assert_json::<SearchResponse>(
                 &client,
                 client
-                    .post(personalization_url.join("/users/u1/personalized_documents")?)
+                    .post(personalization_url.join("/users/u1/recommendations")?)
                     .json(&json!({}))
                     .build()?,
                 StatusCode::OK,

--- a/web-api/tests/store_user_history.rs
+++ b/web-api/tests/store_user_history.rs
@@ -72,7 +72,7 @@ fn store_user_history(enabled: bool) {
             let documents = send_assert_json::<PersonalizedDocumentsResponse>(
                 &client,
                 client
-                    .post(personalization.join("/users/u0/personalized_documents")?)
+                    .post(personalization.join("/users/u0/recommendations")?)
                     .build()?,
                 StatusCode::OK,
                 false,


### PR DESCRIPTION
Fully rename personalized_documents to recommendations in documentation (rust code still uses `PersonalizedDocuments` ans similar  in some cases internally).

This now clearly separates the feature of finding recommendation and personalizing search. It also avoids issues like `PersonalizedDocument` not being a personalized document as we do not personalize the document. It's just part of a group of documents which order/choice of inclusion has been personalized. (It's also strictly speaking not a document but a snippet id and the scoring of the search for that snippet and optionally the properties of the document the snippet is from).

`/users/{user_id}/personalized_documents` => `/users/{user_id}/recommendations`

