### PR TITLE
Bubbling raw scores from elastic up to the response

### DIFF
--- a/web-api/src/models.rs
+++ b/web-api/src/models.rs
@@ -452,6 +452,23 @@ pub(crate) struct PersonalizedDocument {
 
     /// The tags associated to the document.
     pub(crate) tags: DocumentTags,
+
+    /// Additional data about the document that can be helpful while tuning or debugging the system.
+    pub(crate) dev: Option<DocumentDevData>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct DocumentDevData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) raw_scores: Option<RawScores>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct RawScores {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) knn: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bm25: Option<f32>,
 }
 
 impl AiDocument for PersonalizedDocument {

--- a/web-api/src/personalization/knn.rs
+++ b/web-api/src/personalization/knn.rs
@@ -85,6 +85,7 @@ where
                         include_properties: self.include_properties,
                         include_snippet: self.include_snippet,
                         filter: self.filter,
+                        with_raw_scores: false,
                     },
                 )
                 .await

--- a/web-api/src/personalization/rerank.rs
+++ b/web-api/src/personalization/rerank.rs
@@ -136,6 +136,7 @@ pub fn bench_rerank<S>(
                 .collect_vec()
                 .try_into()
                 .unwrap(),
+            dev: None,
         })
         .collect_vec();
     let tag_weights = tag_weights
@@ -190,6 +191,7 @@ mod tests {
                     properties: None,
                     snippet: None,
                     tags,
+                    dev: None,
                 }
             })
             .collect()

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -488,6 +488,7 @@ struct UnvalidatedSemanticSearchRequest {
 struct DevOption {
     hybrid: Option<DevHybrid>,
     max_number_candidates: Option<usize>,
+    show_raw_scores: Option<bool>,
 }
 
 impl DevOption {
@@ -580,6 +581,7 @@ impl UnvalidatedSemanticSearchRequest {
             .map(|personalize| personalize.validate(config.as_ref(), warnings))
             .transpose()?;
         let dev_hybrid_search = dev.hybrid;
+        let dev_show_raw_scores = dev.show_raw_scores;
         let filter = Filter::insert_published_after(filter, published_after);
         if let Some(filter) = &filter {
             filter.validate(&storage.load_schema().await?)?;
@@ -593,6 +595,7 @@ impl UnvalidatedSemanticSearchRequest {
             personalize,
             enable_hybrid_search,
             dev_hybrid_search,
+            dev_show_raw_scores,
             include_properties,
             include_snippet,
             filter,
@@ -694,6 +697,7 @@ struct SemanticSearchRequest {
     personalize: Option<Personalize>,
     enable_hybrid_search: bool,
     dev_hybrid_search: Option<DevHybrid>,
+    dev_show_raw_scores: Option<bool>,
     include_properties: bool,
     include_snippet: bool,
     filter: Option<Filter>,
@@ -741,6 +745,7 @@ async fn semantic_search(
         personalize,
         enable_hybrid_search,
         dev_hybrid_search,
+        dev_show_raw_scores,
         include_properties,
         include_snippet,
         filter,
@@ -789,7 +794,7 @@ async fn semantic_search(
             include_properties,
             include_snippet,
             filter: filter.as_ref(),
-            with_raw_scores: false,
+            with_raw_scores: dev_show_raw_scores.unwrap_or(false),
         },
     )
     .await?;

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -48,6 +48,7 @@ use crate::{
         warning::Warning,
     },
     models::{
+        DocumentDevData,
         DocumentId,
         DocumentProperties,
         DocumentQuery,
@@ -304,6 +305,8 @@ struct PersonalizedDocumentData {
     properties: Option<DocumentProperties>,
     #[serde(skip_serializing_if = "Option::is_none")]
     snippet: Option<DocumentSnippet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dev: Option<DocumentDevData>,
 }
 
 fn no_properties(properties: &Option<DocumentProperties>) -> bool {
@@ -320,6 +323,7 @@ impl From<PersonalizedDocument> for PersonalizedDocumentData {
             score: document.score,
             properties: document.properties,
             snippet: document.snippet,
+            dev: document.dev,
         }
     }
 }
@@ -785,6 +789,7 @@ async fn semantic_search(
             include_properties,
             include_snippet,
             filter: filter.as_ref(),
+            with_raw_scores: false,
         },
     )
     .await?;

--- a/web-api/src/storage.rs
+++ b/web-api/src/storage.rs
@@ -66,6 +66,7 @@ pub(crate) struct KnnSearchParams<'a> {
     pub(super) include_properties: bool,
     pub(super) include_snippet: bool,
     pub(super) filter: Option<&'a Filter>,
+    pub(super) with_raw_scores: bool,
 }
 
 #[derive(Default)]

--- a/web-api/src/storage/memory.rs
+++ b/web-api/src/storage/memory.rs
@@ -286,6 +286,7 @@ impl storage::Document for Storage {
                             properties: include_properties.then(|| document.properties.clone()),
                             snippet: include_snippet.then(|| document.snippet.clone()),
                             tags: document.tags.clone(),
+                            dev: None,
                         })
                 })
             })
@@ -358,6 +359,7 @@ impl storage::Document for Storage {
                             .then(|| document.properties.clone()),
                         snippet: params.include_snippet.then(|| document.snippet.clone()),
                         tags: document.tags.clone(),
+                        dev: None,
                     })
                 }
             })
@@ -784,6 +786,7 @@ mod tests {
                 include_properties: false,
                 include_snippet: false,
                 filter: None,
+                with_raw_scores: false,
             },
         )
         .await
@@ -807,6 +810,7 @@ mod tests {
                 include_properties: false,
                 include_snippet: false,
                 filter: None,
+                with_raw_scores: false,
             },
         )
         .await

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -69,6 +69,7 @@ use crate::{
         DocumentTags,
         ExcerptedDocument,
         PersonalizedDocument,
+        RawScores,
         Sha256Hash,
         SnippetForInteraction,
         SnippetId,
@@ -360,6 +361,7 @@ impl Database {
                             properties,
                             snippet,
                             tags,
+                            dev: None,
                         })
                     })
                     .fetch_all(&mut *tx)
@@ -922,11 +924,33 @@ impl storage::Document for Storage {
         let mut tx = self.postgres.begin().await?;
         let include_properties = params.include_properties;
         let include_snippet = params.include_snippet;
-        let scores = self.elastic.get_by_embedding(params).await?;
-        let documents =
+        let with_raw_scores = params.with_raw_scores;
+        let (scores, raw_scores) = self.elastic.get_by_embedding(params).await?;
+        let mut documents =
             Database::get_personalized(&mut tx, scores, include_properties, include_snippet)
                 .await?;
         tx.commit().await?;
+
+        if with_raw_scores {
+            for document in &mut documents {
+                let raw_scores = Some(RawScores {
+                    knn: raw_scores
+                        .knn
+                        .as_ref()
+                        .and_then(|knn_scores| knn_scores.get(&document.id))
+                        .copied(),
+                    bm25: raw_scores
+                        .bm25
+                        .as_ref()
+                        .and_then(|knn_scores| knn_scores.get(&document.id))
+                        .copied(),
+                });
+
+                if let Some(ref mut additional_data) = &mut document.dev {
+                    additional_data.raw_scores = raw_scores;
+                }
+            }
+        }
 
         Ok(documents)
     }

--- a/web-api/src/storage/postgres.rs
+++ b/web-api/src/storage/postgres.rs
@@ -59,6 +59,7 @@ use crate::{
     ingestion::IngestionConfig,
     models::{
         DocumentContent,
+        DocumentDevData,
         DocumentForIngestion,
         DocumentId,
         DocumentProperties,
@@ -948,6 +949,8 @@ impl storage::Document for Storage {
 
                 if let Some(ref mut additional_data) = &mut document.dev {
                     additional_data.raw_scores = raw_scores;
+                } else {
+                    document.dev = Some(DocumentDevData { raw_scores });
                 }
             }
         }

--- a/web-api/tests/semantic_search.rs
+++ b/web-api/tests/semantic_search.rs
@@ -377,10 +377,10 @@ fn test_semantic_search_with_dev_option_candidates() {
 }
 
 #[test]
-fn test_semantic_search_with_dev_option_snippet() {
+fn test_semantic_search_include_snippet() {
     test_two_apps::<Ingestion, Personalization, _>(
         UNCHANGED_CONFIG,
-        with_dev_options(),
+        UNCHANGED_CONFIG,
         |client, ingestion_url, personalization_url, _| async move {
             ingest(&client, &ingestion_url).await?;
 


### PR DESCRIPTION
Show raw scores from Elastic if a dev option is passed.

Passing the dev option is at the moment missing.