### PR TITLE
Fix stuck tests

### DIFF
--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::env;
+use std::{env, sync::Arc};
 
 use anyhow::{bail, Error};
 use ndarray::{Array, CowArray, IxDyn};
@@ -41,6 +41,8 @@ pub(crate) struct Model {
     runtime: Session,
     use_type_ids: bool,
     pub(crate) embedding_size: usize,
+    // we drop env last. This as been fixed upstream but not yet released.
+    _env: Arc<Environment>,
 }
 
 pub(crate) struct Embedding(Value<'static>);

--- a/bert/src/model.rs
+++ b/bert/src/model.rs
@@ -83,6 +83,7 @@ impl Model {
             runtime: session,
             use_type_ids,
             embedding_size: embedding_size as usize,
+            _env: environment,
         })
     }
 


### PR DESCRIPTION
During the drop of `Session` the `Environment` is dropped before the session, this causes the random block of the test.

This has been fixed upstream https://github.com/pykeio/ort/pull/105 but it has not been ported to the `1.16` branch nor it has been released yet.