### PR TITLE
ET-4885 allow to prefix snippets

### DIFF
--- a/web-api/src/ingestion.rs
+++ b/web-api/src/ingestion.rs
@@ -29,7 +29,7 @@ use self::{
 };
 use crate::{
     app::{self, Application, SetupError},
-    embedding,
+    embedding::{self, EmbeddingKind},
     extractor,
     logging,
     models::{DocumentContent, PreprocessingStep},
@@ -70,6 +70,7 @@ type AppState = app::AppState<Ingestion>;
 impl AppState {
     pub(crate) async fn preprocess(
         &self,
+        kind: EmbeddingKind,
         original: InputData,
         preprocessing_step: &mut PreprocessingStep,
     ) -> Result<Vec<DocumentContent>, PreprocessError> {
@@ -77,6 +78,7 @@ impl AppState {
             &self.embedder,
             || self.snippet_extractor.get().map_err(Error::from),
             &self.extractor,
+            kind,
             original,
             preprocessing_step,
         )

--- a/web-api/src/ingestion/routes.rs
+++ b/web-api/src/ingestion/routes.rs
@@ -33,6 +33,7 @@ use xayn_web_api_db_ctrl::{Operation, Silo};
 use super::{preprocessor::PreprocessError, AppState};
 use crate::{
     app::TenantState,
+    embedding::EmbeddingKind,
     error::common::{
         BadRequest,
         DocumentInBatchError,
@@ -480,7 +481,7 @@ async fn upsert_documents(
             let original_sha256 = Sha256Hash::calculate(document.original.as_bytes());
 
             match state
-                .preprocess(document.original, &mut document.preprocessing_step)
+                .preprocess(EmbeddingKind::Content, document.original, &mut document.preprocessing_step)
                 .await
             {
                 Ok(snippets) => Ok(models::DocumentForIngestion {

--- a/web-api/src/mind/state.rs
+++ b/web-api/src/mind/state.rs
@@ -23,7 +23,7 @@ use xayn_test_utils::{
 };
 
 use crate::{
-    embedding::{self, Embedder, Pipeline},
+    embedding::{self, Embedder, EmbeddingKind, Pipeline},
     mind::{config::StateConfig, data::Document},
     models::{
         DocumentContent,
@@ -81,7 +81,10 @@ impl State {
         let documents = documents
             .into_iter()
             .map(|document| async move {
-                let embedding = self.embedder.run(&document.snippet).await?;
+                let embedding = self
+                    .embedder
+                    .run(EmbeddingKind::Content, &document.snippet)
+                    .await?;
                 Ok::<_, Panic>(DocumentForIngestion {
                     id: document.id,
                     original_sha256: Sha256Hash::calculate(document.snippet.as_bytes()),

--- a/web-api/src/personalization/routes.rs
+++ b/web-api/src/personalization/routes.rs
@@ -43,6 +43,7 @@ use super::{
 };
 use crate::{
     app::TenantState,
+    embedding::EmbeddingKind,
     error::{
         common::{BadRequest, DocumentNotFound, ForbiddenDevOption, InvalidDocumentCount},
         warning::Warning,
@@ -826,7 +827,7 @@ async fn semantic_search(
             (embedding, None)
         }
         InputDocument::Query(ref query) => {
-            let embedding = state.embedder.run(query).await?;
+            let embedding = state.embedder.run(EmbeddingKind::Query, query).await?;
             (embedding, Some(query))
         }
     };

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/cli_overrides.auto.toml
+++ b/web-api/tests/cmd/cli_overrides.auto.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets/model",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/default_ingestion_config.auto.toml
+++ b/web-api/tests/cmd/default_ingestion_config.auto.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -50,7 +50,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/default_personalization_config.auto.toml
+++ b/web-api/tests/cmd/default_personalization_config.auto.toml
@@ -52,8 +52,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/env_overrides.toml
+++ b/web-api/tests/cmd/env_overrides.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets/model",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/inline_config.auto.toml
+++ b/web-api/tests/cmd/inline_config.auto.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/load_config.auto.toml
+++ b/web-api/tests/cmd/load_config.auto.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets/model",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -57,8 +57,8 @@ stdout = """
     "runtime": "assets",
     "token_size": 250,
     "prefix": {
-      "query": null,
-      "snippet": null
+      "query": "",
+      "snippet": ""
     }
   },
   "text_extractor": {

--- a/web-api/tests/cmd/mixed_overrides.toml
+++ b/web-api/tests/cmd/mixed_overrides.toml
@@ -55,7 +55,11 @@ stdout = """
     "type": "pipeline",
     "directory": "assets/model",
     "runtime": "assets",
-    "token_size": 250
+    "token_size": 250,
+    "prefix": {
+      "query": null,
+      "snippet": null
+    }
   },
   "text_extractor": {
     "enabled": false,


### PR DESCRIPTION
Allows specifying two prefixes:

- `embedding.prefix.query` prefix all queries with this before computing their embedding
- `embedding.prefix.snippet` prefix all snippets with this before computing their embedding

works for both local and sagemaker setups

Env variables:

- `XAYN_WEB_API__EMBEDDING__PREFIX__QUERY`
- `XAYN_WEB_API__EMBEDDING__PREFIX__SNIPPET`