### PR TITLE
ET-4780 support document id filters

### DIFF
--- a/.spectral.js
+++ b/.spectral.js
@@ -70,6 +70,7 @@ module.exports = {
       files: [
         "web-api/openapi/front_office.yaml#/components/schemas/FilterCompare/additionalProperties/properties",
         "web-api/openapi/front_office.yaml#/components/schemas/FilterCombine/properties",
+        "web-api/openapi/front_office.yaml#/components/schemas/FilterIds/properties",
       ],
       rules: {
         "ibm-property-casing-convention": "off",

--- a/web-api/openapi/front_office.yaml
+++ b/web-api/openapi/front_office.yaml
@@ -221,7 +221,7 @@ paths:
         For web sites, consider triggering this method whenever a certain document url loads, preferably after the user spent some time on the page, in order to prevent false positives.
         For apps, consider implementing a "like" button, where the on-click triggers this method.
 
-        Please remember that it is recommended to register a reaction with the specific snippet the user 
+        Please remember that it is recommended to register a reaction with the specific snippet the user
         interacted with instead of the document as a whole. You can do so by providing snippet ids instead of document ids.
       operationId: updateUserInteractions
       parameters:
@@ -396,6 +396,18 @@ components:
               - $ref: '#/components/schemas/FilterCombine'
       minProperties: 1
       maxProperties: 1
+    FilterIds:
+      type: object
+      properties:
+        $ids:
+          type: array
+          minItems: 0
+          maxItems: 500
+          items:
+            $ref: './schemas/document.yml#/DocumentId'
+      minProperties: 1
+      maxProperties: 1
+
     Filter:
       description: |-
         Filter the documents wrt their properties.
@@ -406,9 +418,17 @@ components:
 
         *Combination:*
         Combinators may only be nested two times.
+
+        *Ids:*
+        Works like the `$in` comparison operator but requires the returned documents id to be in the provided array of document ids.
+
+        Be aware that `$ids` will only work properly if document splitting isn't used.
+
+
       oneOf:
         - $ref: '#/components/schemas/FilterCompare'
         - $ref: '#/components/schemas/FilterCombine'
+        - $ref: '#/components/schemas/FilterIds'
     RecommendationRequest:
       type: object
       properties:
@@ -430,6 +450,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/FilterCompare'
             - $ref: '#/components/schemas/FilterCombine'
+            - $ref: '#/components/schemas/FilterIds'
     SearchResultEntry:
       type: object
       required: [id, snippet_id, score]
@@ -511,6 +532,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/FilterCompare'
             - $ref: '#/components/schemas/FilterCombine'
+            - $ref: '#/components/schemas/FilterIds'
     SemanticSearchResponse:
       type: object
       required: [documents]
@@ -564,6 +586,7 @@ components:
               oneOf:
                 - $ref: '#/components/schemas/FilterCompare'
                 - $ref: '#/components/schemas/FilterCombine'
+                - $ref: '#/components/schemas/FilterIds'
     RecommendationError:
       allOf:
         - $ref: './schemas/error.yml#/GenericError'

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -370,10 +370,10 @@ impl<'de> Deserialize<'de> for Ids {
 
         let len = ids.len();
         let max = CompareOp::MAX_VALUES_PER_IN;
-        if !(1..=max).contains(&len) {
+        if len > max {
             return Err(D::Error::invalid_length(
                 len,
-                &format!("$ids must contain 1..={max} ids").as_str(),
+                &format!("$ids must contain 0..={max} ids").as_str(),
             ));
         }
 
@@ -1143,7 +1143,7 @@ mod tests {
         serde_json::from_value::<Filter>(json!({
             "$ids": []
         }))
-        .unwrap_err();
+        .unwrap();
 
         serde_json::from_value::<Filter>(json!({
             "$ids": vec!["foo"; CompareOp::MAX_VALUES_PER_IN]

--- a/web-api/src/personalization/filter.rs
+++ b/web-api/src/personalization/filter.rs
@@ -860,7 +860,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
                 format!(
-                    "invalid variant, expected one of: Compare(invalid length 2, expected {}); Combine(invalid length 2, expected {}) at line 1 column 40",
+                    "invalid variant, expected one of: Compare(invalid length 2, expected {}); Combine(invalid length 2, expected {}); Ids(missing field `$ids`) at line 1 column 40",
                     Compare::EXPECTING,
                     Combine::EXPECTING,
                 ),

--- a/web-api/src/storage/elastic/filter.rs
+++ b/web-api/src/storage/elastic/filter.rs
@@ -329,6 +329,7 @@ enum Clause<'a> {
     Range(Range<'a>),
     Filter(Filter<'a>),
     Should(Should<'a>),
+    Ids(Ids<'a, DocumentId>),
 }
 
 fn merge_range_and(mut clause: Vec<Clause<'_>>) -> Vec<Clause<'_>> {
@@ -504,6 +505,10 @@ impl<'a> Clause<'a> {
                     }),
                 }
             }
+
+            filter::Filter::Ids(ids) => Self::Ids(Ids {
+                values: Cow::Borrowed(&ids.ids),
+            }),
         }
     }
 }
@@ -540,7 +545,10 @@ impl<'a> Clauses<'a> {
         };
         if let Some(filter) = filter {
             match Clause::new(filter, true) {
-                clause @ (Clause::Term(_) | Clause::Terms(_) | Clause::Range(_)) => {
+                clause @ (Clause::Term(_)
+                | Clause::Terms(_)
+                | Clause::Range(_)
+                | Clause::Ids(_)) => {
                     clauses.filter.filter.push(clause);
                 }
                 Clause::Filter(clause) => clauses.filter = clause,


### PR DESCRIPTION
Support filtering by document ids.

For now limit proper support to use cases which do not use document splitting (we can add that later if it's needed).

**References:**

- [ET-4780]

[ET-4780]: https://xainag.atlassian.net/browse/ET-4780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ