### PR TITLE
Add support for openai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5142,6 +5142,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2",

--- a/web-api/Cargo.toml
+++ b/web-api/Cargo.toml
@@ -33,6 +33,7 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { version = "0.10.7", features = ["asm"] }


### PR DESCRIPTION
Add support to use OpenAi embedding models. This allows us to use openai and azure services.

This also fixes the prefix for sagemaker.