### PR TITLE
Fix example in doc

### DIFF
--- a/docs/source/getting_started/getting_started.md
+++ b/docs/source/getting_started/getting_started.md
@@ -60,7 +60,7 @@ curl -X POST "$URL/documents" \
             },
             {
                 "id": "xayn_ff5604c",
-                "snippet": "If you only ingested one short document you can't really try out any of the functional, so here is another document"
+                "snippet": "If you only ingested one short document you cannot really try out any of the functional, so here is another document"
             },
             {
                 "id": "00000",


### PR DESCRIPTION
We cannot use single quote in the text because we use it to delimit the json data.