### PR TITLE
Build service in the docker image, with caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/*
+!rust-toolchain.toml
+!Cargo.*
+!coi
+!bert
+!integration-tests
+!web-api
+!web-api-shared
+!web-api-db-ctrl
+!snippet-extractor
+!summarizer
+!test-utils
+!assets

--- a/justfile
+++ b/justfile
@@ -183,34 +183,18 @@ web-dev-down:
     #!/usr/bin/env -S bash -eu -o pipefail
     docker-compose -p web-dev -f "./web-api/compose.db.yml" down
 
-build-service-image crate_path bin asset_dir="":
+build-service-image crate_path bin model_dir="" ort_dir="":
     #!/usr/bin/env -S bash -eux -o pipefail
-    out="$(mktemp -d -t xayn.web-api.compose.XXXX)"
-    echo "Building in: $out"
-    cargo install \
-        --path "{{crate_path}}" \
-        --bin "{{bin}}" \
-        --debug \
-        --root "$out" \
-        --locked
-    # rename binary to the name the Dockerfile expects
-    mv "$out/bin/{{bin}}" "$out/server.bin"
-    rmdir "$out/bin"
-    if [ -n "{{asset_dir}}" ]; then
-        cp -R "{{asset_dir}}" "$out/assets"
-    fi
+    docker build -f "{{crate_path}}/Dockerfile" \
+      --target {{bin}} \
+      --build-arg MODEL_DIR="{{model_dir}}" \
+      --build-arg ORT_DIR="{{ort_dir}}" \
+      -t "xayn-{{crate_path}}-{{bin}}" {{justfile_directory()}}
 
-    cp "snippet-extractor/Pipfile" "$out/Pipfile"
-    cp "snippet-extractor/Pipfile.lock" "$out/Pipfile.lock"
-    cp -r "snippet-extractor/python_src/" "$out/python_src"
-
-    docker build -f "{{crate_path}}/Dockerfile" -t "xayn-{{crate_path}}-{{bin}}" "$out"
-    rm -rf "$out"
-
-compose-all-build model="xaynia_v0201":
+compose-all-build model="xaynia_v0201" ort="ort_v1.15.1":
     #!/usr/bin/env -S bash -eux -o pipefail
-    {{just_executable()}} build-service-image web-api personalization "assets/{{model}}"
-    {{just_executable()}} build-service-image web-api ingestion "assets/{{model}}"
+    {{just_executable()}} build-service-image web-api personalization "assets/{{model}}" "assets/{{ort}}"
+    {{just_executable()}} build-service-image web-api ingestion "assets/{{model}}" "assets/{{ort}}"
 
 compose-all-up *args:
     #!/usr/bin/env -S bash -eux -o pipefail

--- a/justfile
+++ b/justfile
@@ -186,15 +186,13 @@ web-dev-down:
 build-service-image crate_path bin model_dir="" ort_dir="":
     #!/usr/bin/env -S bash -eux -o pipefail
     docker build -f "{{crate_path}}/Dockerfile" \
-      --target {{bin}} \
       --build-arg MODEL_DIR="{{model_dir}}" \
       --build-arg ORT_DIR="{{ort_dir}}" \
       -t "xayn-{{crate_path}}-{{bin}}" {{justfile_directory()}}
 
 compose-all-build model="xaynia_v0201" ort="ort_v1.15.1":
     #!/usr/bin/env -S bash -eux -o pipefail
-    {{just_executable()}} build-service-image web-api personalization "assets/{{model}}" "assets/{{ort}}"
-    {{just_executable()}} build-service-image web-api ingestion "assets/{{model}}" "assets/{{ort}}"
+    {{just_executable()}} build-service-image web-api web-api "assets/{{model}}" "assets/{{ort}}"
 
 compose-all-up *args:
     #!/usr/bin/env -S bash -eux -o pipefail

--- a/web-api/Dockerfile
+++ b/web-api/Dockerfile
@@ -10,12 +10,10 @@ RUN --mount=type=bind,target=. cargo chef prepare --recipe-path ../recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --target-dir ../target --recipe-path recipe.json --bin ingestion && \
-    cargo chef cook --release --target-dir ../target --recipe-path recipe.json --bin personalization
+RUN cargo chef cook --release --target-dir ../target --recipe-path recipe.json --bin web-api
 # Build application
 COPY . .
-RUN cargo build --release --target-dir ../target --bin ingestion && \
-    cargo build --release --target-dir ../target --bin personalization
+RUN cargo build --release --target-dir ../target --bin web-api
 
 FROM debian:12.2-slim AS runtime
 WORKDIR /app
@@ -46,11 +44,7 @@ RUN --mount=type=bind,target=project set -eux; \
     esac; \
     cp -r project/assets/"$ORT_DIR"/linux_"$ORT_ARCH"/lib/* assets/lib
 
-FROM runtime AS ingestion
-COPY --from=builder /app/target/release/ingestion server.bin
-ENTRYPOINT ["/app/server.bin"]
-
-FROM runtime AS personalization
-COPY --from=builder /app/target/release/personalization server.bin
+FROM runtime AS service
+COPY --from=builder /app/target/release/web-api server.bin
 ENTRYPOINT ["/app/server.bin"]
 

--- a/web-api/Dockerfile
+++ b/web-api/Dockerfile
@@ -1,16 +1,56 @@
-FROM debian:bookworm-20230502-slim
+FROM lukemathwalker/cargo-chef:0.1.62-rust-1.74-slim-bookworm AS chef
+WORKDIR /app/project
+# install rust version we use
+COPY ./rust-toolchain.toml .
+RUN cargo --version
 
-# rustls in aws
+FROM chef AS planner
+RUN --mount=type=bind,target=. cargo chef prepare --recipe-path ../recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --target-dir ../target --recipe-path recipe.json --bin ingestion && \
+    cargo chef cook --release --target-dir ../target --recipe-path recipe.json --bin personalization
+# Build application
+COPY . .
+RUN cargo build --release --target-dir ../target --bin ingestion && \
+    cargo build --release --target-dir ../target --bin personalization
+
+FROM debian:12.2-slim AS runtime
+WORKDIR /app
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates python3.11 pipenv \
+        # rustls in aws
+        ca-certificates \
+	python3.11 pipenv \
         ; \
     update-ca-certificates
+COPY snippet-extractor/Pipfile snippet-extractor/Pipfile.lock .
+COPY snippet-extractor/python_src/ python_src
+RUN pipenv install --deploy &&\
+    pipenv run python -c 'import nltk; nltk.download("punkt")'
+ARG TARGETARCH
+ARG MODEL_DIR="model directory is required"
+ARG ORT_DIR="ort directory is required"
+RUN --mount=type=bind,target=project set -eux; \
+    # copy model \
+    mkdir assets; \
+    cp -r project/"$MODEL_DIR"/* assets/; \
+    # copy ort lib \
+    mkdir assets/lib; \
+    case "$TARGETARCH" in \
+        amd64) ORT_ARCH="x64" ;;\
+        arm64) ORT_ARCH="aarch64" ;;\
+    esac; \
+    cp -r project/assets/"$ORT_DIR"/linux_"$ORT_ARCH"/lib/* assets/lib
 
-WORKDIR /app
-COPY ./ ./
-
-RUN pipenv install --deploy && pipenv run python -c 'import nltk; nltk.download("punkt")'
-
+FROM runtime AS ingestion
+COPY --from=builder /app/target/release/ingestion server.bin
 ENTRYPOINT ["/app/server.bin"]
+
+FROM runtime AS personalization
+COPY --from=builder /app/target/release/personalization server.bin
+ENTRYPOINT ["/app/server.bin"]
+


### PR DESCRIPTION
Build the service in the docker image. This allows us to build the service on any machine.
We use cargo-chef to cache the build of the dependencies. 