### PR TITLE
ET-5451 reduce probability of delete->insert race conditions

### DIFF
--- a/web-api-shared/src/elastic.rs
+++ b/web-api-shared/src/elastic.rs
@@ -263,7 +263,7 @@ pub struct BulkResponse<I> {
 }
 
 impl<I> BulkResponse<I> {
-    pub fn failed_documents(self, allow_not_found: bool, expected_result: &str) -> Vec<I>
+    pub fn failed_documents(self, allow_not_found: bool, expected_result: &'static str) -> Vec<I>
     where
         I: Display + Debug,
     {
@@ -281,7 +281,6 @@ impl<I> BulkResponse<I> {
                             //FIXME get id from zipping with query inputs, through also this should never happen so maybe don't bother
                             return None;
                         };
-                        let result = response.result.as_deref().unwrap_or("none");
                         if !response.is_success_status(allow_not_found) {
                             error!(
                                 document_id=%response.id,
@@ -290,11 +289,12 @@ impl<I> BulkResponse<I> {
                             );
                             return Some(response.id);
                         }
+                        let result = response.result.as_deref().unwrap_or("none");
                         if result != expected_result {
                             warn!(
                                 expected=%expected_result,
                                 got=%result,
-                                "Mismatch in expected kind of result for bulk operation"
+                                "Mismatch in expected kind of result for bulk operation",
                             );
                         }
                         None

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -221,7 +221,7 @@ impl Client {
         }
 
         let response = self.bulk_request(snippets).await?;
-        Ok(response.failed_documents("index", false, "created").into())
+        Ok(response.failed_documents(false, "created").into())
     }
 
     pub(super) async fn delete_by_parents(

--- a/web-api/src/storage/elastic.rs
+++ b/web-api/src/storage/elastic.rs
@@ -241,8 +241,9 @@ impl Client {
             }
         });
 
-        let result: Value = self.query_with_json(Method::POST, url, Some(body)).await?;
-
+        let result = self
+            .query_with_json::<_, Value>(Method::POST, url, Some(body))
+            .await?;
         if !result
             .get("failures")
             .and_then(Value::as_array)
@@ -250,6 +251,7 @@ impl Client {
         {
             warn!(response=%result, "ignored deletion failures when deleting by parent");
         }
+
         Ok(())
     }
 


### PR DESCRIPTION

- ignore version conflict of `delete_by_parent`
  - but still warn if it happens
- change `freshly_insert_document` to use `index` instead of `create`, so it will replace existing documents with the
  same ID,  while `freshly_insert_document` is supposed to only be called with snippet ids not in elastic search there seems to be a race condition where this isn't the case, maybe related to `delete_by_parent`
  - but still warn if it happens
